### PR TITLE
태스크 생성

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -28,9 +28,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
         username: ConfigService.get('DATABASE_USER'),
         password: ConfigService.get('DATABASE_PASSWORD'),
         database: ConfigService.get('DATABASE_NAME'),
-        entities: [__dirname + '/**/*.entity{.ts,.js}'],
-        synchronize:
-          ConfigService.get('LESSER_ENVIRONMENT') == 'deploy' ? false : true,
+        entities: [`${__dirname}/**/*.entity{.ts,.js}`],
+        synchronize: ConfigService.get('LESSER_ENVIRONMENT') === 'deploy' ? false : true,
       }),
     }),
     BacklogsModule,
@@ -39,13 +38,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
     ReviewsModule,
     SprintsModule,
   ],
-  controllers: [
-    AppController,
-    SprintsController,
-    MembersController,
-    ProjectsController,
-    ReviewsController,
-  ],
+  controllers: [AppController, SprintsController, MembersController, ProjectsController, ReviewsController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Post, ValidationPipe } from '@nestjs/common';
 import { createBacklogsEpicDto } from 'src/dto/create-backlogs-epic.dto';
 import { createBacklogsStoryDto } from 'src/dto/create-backlogs-story.dto';
+import { createBacklogsTaskDto } from 'src/dto/create-backlogs-task.dto';
 import { BacklogsService } from './backlogs.service';
 
 @Controller('backlogs')
@@ -15,6 +16,12 @@ export class BacklogsController {
   @Post('Story')
   async createStory(@Body(new ValidationPipe()) body: createBacklogsStoryDto): Promise<Record<string, never>> {
     await this.backlogsService.createStory(body);
+    return {};
+  }
+
+  @Post('Task')
+  async createTask(@Body(new ValidationPipe()) body: createBacklogsTaskDto) {
+    await this.backlogsService.createTask(body);
     return {};
   }
 }

--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -1,26 +1,27 @@
-import { Body, Controller, Post, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Post, UsePipes, ValidationPipe } from '@nestjs/common';
 import { createBacklogsEpicDto } from 'src/dto/create-backlogs-epic.dto';
 import { createBacklogsStoryDto } from 'src/dto/create-backlogs-story.dto';
 import { createBacklogsTaskDto } from 'src/dto/create-backlogs-task.dto';
 import { BacklogsService } from './backlogs.service';
 
 @Controller('backlogs')
+@UsePipes(ValidationPipe)
 export class BacklogsController {
   constructor(private readonly backlogsService: BacklogsService) {}
 
   @Post('Epic')
-  async createEpic(@Body(new ValidationPipe()) body: createBacklogsEpicDto): Promise<Record<string, never>> {
+  async createEpic(@Body() body: createBacklogsEpicDto): Promise<Record<string, never>> {
     await this.backlogsService.createEpic(body);
     return {};
   }
   @Post('Story')
-  async createStory(@Body(new ValidationPipe()) body: createBacklogsStoryDto): Promise<Record<string, never>> {
+  async createStory(@Body() body: createBacklogsStoryDto): Promise<Record<string, never>> {
     await this.backlogsService.createStory(body);
     return {};
   }
 
   @Post('Task')
-  async createTask(@Body(new ValidationPipe()) body: createBacklogsTaskDto) {
+  async createTask(@Body() body: createBacklogsTaskDto) {
     await this.backlogsService.createTask(body);
     return {};
   }

--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -14,7 +14,6 @@ export class BacklogsController {
   }
   @Post('Story')
   async createStory(@Body(new ValidationPipe()) body: createBacklogsStoryDto): Promise<Record<string, never>> {
-    console.log('here');
     await this.backlogsService.createStory(body);
     return {};
   }

--- a/BE/src/backlogs/backlogs.module.ts
+++ b/BE/src/backlogs/backlogs.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Epic } from 'src/entities/epic.entity';
 import { Story } from 'src/entities/story.entity';
+import { Task } from 'src/entities/task.entity';
 import { BacklogsController } from './backlogs.controller';
 import { BacklogsService } from './backlogs.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Epic, Story])],
+  imports: [TypeOrmModule.forFeature([Epic, Story, Task])],
   controllers: [BacklogsController],
   providers: [BacklogsService],
 })

--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { createBacklogsEpicDto } from 'src/dto/create-backlogs-epic.dto';
 import { createBacklogsStoryDto } from 'src/dto/create-backlogs-story.dto';
+import { createBacklogsTaskDto } from 'src/dto/create-backlogs-task.dto';
 import { Epic } from 'src/entities/epic.entity';
 import { Story } from 'src/entities/story.entity';
+import { Task } from 'src/entities/task.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
@@ -11,6 +13,7 @@ export class BacklogsService {
   constructor(
     @InjectRepository(Epic) private epicRepository: Repository<Epic>,
     @InjectRepository(Story) private storyRepository: Repository<Story>,
+    @InjectRepository(Task) private taskRepository: Repository<Task>,
   ) {}
 
   async createEpic(dto: createBacklogsEpicDto): Promise<void> {
@@ -19,8 +22,23 @@ export class BacklogsService {
   }
 
   async createStory(dto: createBacklogsStoryDto): Promise<void> {
-    const epic = await this.epicRepository.findOne({ where: { id: dto.projectId } });
+    const epic = await this.epicRepository.findOne({ where: { id: dto.story.epicId } });
     const newStory = this.storyRepository.create({ title: dto.story.title, epic });
     await this.storyRepository.save(newStory);
+  }
+
+  async createTask(dto: createBacklogsTaskDto): Promise<void> {
+    const epic = await this.epicRepository.findOne({ where: { id: dto.task.epicId } });
+    const story = await this.storyRepository.findOne({ where: { id: dto.task.storyId } });
+    const newTask = this.taskRepository.create({
+      title: dto.task.title,
+      state: dto.task.state,
+      point: dto.task.point,
+      condition: dto.task.condition,
+      userId: dto.task.userId,
+      epic,
+      story,
+    });
+    await this.taskRepository.save(newTask);
   }
 }

--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -9,18 +9,18 @@ import { Repository } from 'typeorm';
 @Injectable()
 export class BacklogsService {
   constructor(
-    @InjectRepository(Epic) private EpicRepository: Repository<Epic>,
-    @InjectRepository(Story) private StoryRepository: Repository<Story>,
+    @InjectRepository(Epic) private epicRepository: Repository<Epic>,
+    @InjectRepository(Story) private storyRepository: Repository<Story>,
   ) {}
 
   async createEpic(dto: createBacklogsEpicDto): Promise<void> {
-    const newEpic = this.EpicRepository.create({ title: dto.epicTitle });
-    await this.EpicRepository.save(newEpic);
+    const newEpic = this.epicRepository.create({ title: dto.epicTitle });
+    await this.storyRepository.save(newEpic);
   }
 
   async createStory(dto: createBacklogsStoryDto): Promise<void> {
-    const epic = await this.EpicRepository.findOne({ where: { id: dto.projectId } });
-    const newStory = this.StoryRepository.create({ title: dto.story.title, epic });
-    await this.StoryRepository.save(newStory);
+    const epic = await this.epicRepository.findOne({ where: { id: dto.projectId } });
+    const newStory = this.storyRepository.create({ title: dto.story.title, epic });
+    await this.storyRepository.save(newStory);
   }
 }

--- a/BE/src/dto/create-backlogs-epic.dto.ts
+++ b/BE/src/dto/create-backlogs-epic.dto.ts
@@ -1,9 +1,11 @@
-import { IsString, IsInt } from 'class-validator';
+import { IsString, IsInt, IsNotEmpty } from 'class-validator';
 
 export class createBacklogsEpicDto {
   @IsInt()
+  @IsNotEmpty()
   projectId: number;
 
   @IsString()
+  @IsNotEmpty()
   epicTitle: string;
 }

--- a/BE/src/dto/create-backlogs-story.dto.ts
+++ b/BE/src/dto/create-backlogs-story.dto.ts
@@ -1,7 +1,9 @@
-import { ValidateNested, IsInt } from 'class-validator';
+import { ValidateNested, IsInt, IsString } from 'class-validator';
 
 class storyDto {
+  @IsInt()
   epicId: number;
+  @IsString()
   title: string;
 }
 

--- a/BE/src/dto/create-backlogs-story.dto.ts
+++ b/BE/src/dto/create-backlogs-story.dto.ts
@@ -1,16 +1,23 @@
-import { ValidateNested, IsInt, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ValidateNested, IsInt, IsString, IsNotEmpty } from 'class-validator';
 
 class storyDto {
   @IsInt()
+  @IsNotEmpty()
   epicId: number;
+
   @IsString()
+  @IsNotEmpty()
   title: string;
 }
 
 export class createBacklogsStoryDto {
   @IsInt()
+  @IsNotEmpty()
   projectId: number;
 
+  @Type(() => storyDto)
   @ValidateNested()
+  @IsNotEmpty()
   story: storyDto;
 }

--- a/BE/src/dto/create-backlogs-task.dto.ts
+++ b/BE/src/dto/create-backlogs-task.dto.ts
@@ -2,42 +2,42 @@ import { Type } from 'class-transformer';
 import { ValidateNested, IsInt, IsString, IsNotEmpty, IsOptional } from 'class-validator';
 
 class taskDto {
-  @IsNotEmpty()
   @IsInt()
+  @IsNotEmpty()
   epicId: number;
 
-  @IsNotEmpty()
   @IsInt()
+  @IsNotEmpty()
   storyId: number;
 
-  @IsOptional()
   @IsInt()
+  @IsOptional()
   userId: number;
 
-  @IsNotEmpty()
   @IsString()
+  @IsNotEmpty()
   title: string;
 
-  @IsNotEmpty()
   @IsString()
+  @IsNotEmpty()
   state: string;
 
-  @IsNotEmpty()
   @IsInt()
+  @IsNotEmpty()
   point: number;
 
-  @IsNotEmpty()
   @IsString()
+  @IsNotEmpty()
   condition: string;
 }
 
 export class createBacklogsTaskDto {
-  @IsNotEmpty()
   @IsInt()
+  @IsNotEmpty()
   projectId: number;
 
-  @IsNotEmpty()
-  @ValidateNested()
   @Type(() => taskDto)
+  @ValidateNested()
+  @IsNotEmpty()
   task: taskDto;
 }

--- a/BE/src/dto/create-backlogs-task.dto.ts
+++ b/BE/src/dto/create-backlogs-task.dto.ts
@@ -1,0 +1,43 @@
+import { Type } from 'class-transformer';
+import { ValidateNested, IsInt, IsString, IsNotEmpty, IsOptional } from 'class-validator';
+
+class taskDto {
+  @IsNotEmpty()
+  @IsInt()
+  epicId: number;
+
+  @IsNotEmpty()
+  @IsInt()
+  storyId: number;
+
+  @IsOptional()
+  @IsInt()
+  userId: number;
+
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  state: string;
+
+  @IsNotEmpty()
+  @IsInt()
+  point: number;
+
+  @IsNotEmpty()
+  @IsString()
+  condition: string;
+}
+
+export class createBacklogsTaskDto {
+  @IsNotEmpty()
+  @IsInt()
+  projectId: number;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => taskDto)
+  task: taskDto;
+}

--- a/BE/src/entities/story.entity.ts
+++ b/BE/src/entities/story.entity.ts
@@ -9,6 +9,6 @@ export class Story extends BaseEntity {
   @Column()
   title: string;
 
-  @ManyToOne(() => Epic, (Epic) => Epic.id, { cascade: true, nullable: false })
+  @ManyToOne(() => Epic, (Epic) => Epic.id, { nullable: false })
   epic: Epic;
 }

--- a/BE/src/entities/task.entity.ts
+++ b/BE/src/entities/task.entity.ts
@@ -1,4 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne } from 'typeorm';
+import { Epic } from './epic.entity';
+import { Story } from './story.entity';
 
 @Entity()
 export class Task extends BaseEntity {
@@ -16,4 +18,13 @@ export class Task extends BaseEntity {
 
   @Column()
   condition: string;
+
+  @Column({ nullable: true })
+  userId: number;
+
+  @ManyToOne(() => Epic, (Epic) => Epic.id, { nullable: false })
+  epic: Epic;
+
+  @ManyToOne(() => Story, (Story) => Story.id, { nullable: false })
+  story: Story;
 }


### PR DESCRIPTION
## task
LES-72 태스크 데이터를 받아 데이터베이스에 저장한다.
LES-73 태스크가 생성되었을때 성공여부를 알려준다.

## 설명

### [fix] [task-create] 변수명 수정
    
    1. 변수명 수정(인스턴스 이름 소문자 시작)
    2. controller console.log 삭제
    
### [feat] [task-create] 태스크 생성
    
    task: 태스크 데이터를 받아 데이터베이스에 저장한다.
    task: 태스크가 생성되었을때 성공여부를 알려준다.
    1. task 스키마와 epic, story를 조인
    2. dto정의 후 유효성검사 로직작성
    3. 삼항연산자 삭제, string 백틱으로 작성

### [fix] [task-create] Dto Nest Object 유효성검사추가
    
    1. 기존에는 NestObject의 경우 유효성 검사가 정상적으로 이루어 지지 않았음
    2. StoryDTO에 Type추가, IsNotEmpty추가, NestObject내부에 유효성검사 데코레이터 추가
    3. 데코레이터 실행순서를 고려하여 IsNotEmpty를 데코레이터 아래로 배치


### [refactor] [task-create] 파이프처리 성능개선
    
    1. 파이프 관리를 메서드별 인스턴스 생성에서 컨트롤러단위로 클래스이름을 전달해 의존성을 통해 관리하도록 변경

이전에 언급했던 nest-object유효성검사, 메서드별 파이프 new 문제, 삼중등호를 변경했습니다.
추가적으로 console.log가 발견되 삭제하였습니다.
나머지는 task로직이고 이전에 언급한 일대다 조인으로 작성했습니다.
감사합니다 ~