### PR TITLE
칸반보드 렌더링 코드 작성

### DIFF
--- a/FE/src/components/backlog/EpicBlock.tsx
+++ b/FE/src/components/backlog/EpicBlock.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import useBlock from '../../hooks/useBlock';
+import StoryBlock from './StoryBlock';
+
+interface EpicBlockProps {
+  epicTitle: string;
+}
+
+const EpicBlock = ({ epicTitle }: EpicBlockProps) => {
+  const { items, newItemTitle, showForm, formRef, handleAddButton, handleFormSubmit, setNewItemTitle } = useBlock();
+  const [showEpic, setShowEpic] = useState<boolean>(true);
+  const handleToggleEpic = () => {
+    setShowEpic(!showEpic);
+  };
+
+  return (
+    <div className="my-5 border-2 border-red-600">
+      <div className="flex gap-2">
+        <h2>{epicTitle}</h2>
+        <button className="border" onClick={handleToggleEpic}>
+          Toggle Epic
+        </button>
+      </div>
+      {showEpic && items.map((item) => <StoryBlock key={item} storyTitle={item} />)}
+      {showForm ? (
+        <form ref={formRef} onSubmit={handleFormSubmit}>
+          <input
+            type="text"
+            placeholder={`Enter Story Title`}
+            value={newItemTitle}
+            onChange={(e) => setNewItemTitle(e.target.value)}
+          />
+          <button className="border px-8" type="submit">
+            + Story 생성하기
+          </button>
+        </form>
+      ) : (
+        <button className="border px-8" onClick={handleAddButton}>
+          + Story 생성하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default EpicBlock;

--- a/FE/src/components/backlog/StoryBlock.tsx
+++ b/FE/src/components/backlog/StoryBlock.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import TaskBlock from './TaskBlock';
+import TaskModal, { TaskData } from './TaskModal';
+
+interface StoryBlockProps {
+  storyTitle: string;
+}
+
+const StoryBlock = ({ storyTitle }: StoryBlockProps) => {
+  const [tasks, setTasks] = useState<TaskData[]>([]);
+  const [showStory, setShowStory] = useState<boolean>(true);
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const handleToggleStory = () => {
+    setShowStory(!showStory);
+  };
+
+  const handleToggleModal = () => {
+    setShowModal(!showModal);
+  };
+
+  const handleTaskCreate = (taskData: TaskData) => {
+    setTasks((prevTasks) => [...prevTasks, taskData]);
+  };
+
+  return (
+    <div className="border-2 border-blue-600">
+      <div className="flex gap-2">
+        <h3>{storyTitle}</h3>
+        <button className="border" onClick={handleToggleStory}>
+          Toggle Story
+        </button>
+      </div>
+      {showStory && tasks.map((task, index) => <TaskBlock key={index} taskData={task} />)}
+      {showModal && <TaskModal onClose={handleToggleModal} onTaskCreate={handleTaskCreate} />}
+      <button className="border px-8" onClick={handleToggleModal}>
+        + Task 생성하기
+      </button>
+    </div>
+  );
+};
+
+export default StoryBlock;

--- a/FE/src/components/backlog/TaskBlock.tsx
+++ b/FE/src/components/backlog/TaskBlock.tsx
@@ -1,0 +1,16 @@
+import { TaskData } from './TaskModal';
+
+interface TaskBlockProps {
+  taskData: TaskData;
+}
+
+const TaskBlock = ({ taskData }: TaskBlockProps) => (
+  <div className="border-2 border-green-600">
+    <h4>Title: {taskData.title}</h4>
+    <p>Point: {taskData.point}</p>
+    <p>Member: {taskData.member}</p>
+    <p>Completion Condition: {taskData.completionCondition}</p>
+  </div>
+);
+
+export default TaskBlock;

--- a/FE/src/components/backlog/TaskModal.tsx
+++ b/FE/src/components/backlog/TaskModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+
+export interface TaskData {
+  title: string;
+  member: string;
+  point: number;
+  completionCondition: string;
+}
+
+interface TaskModalProps {
+  onClose: () => void;
+  onTaskCreate: (taskData: TaskData) => void;
+}
+
+const TaskModal = ({ onClose, onTaskCreate }: TaskModalProps) => {
+  const [taskData, setTaskData] = useState<TaskData>({
+    title: '',
+    member: '',
+    point: 0,
+    completionCondition: '',
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setTaskData((prevData) => ({ ...prevData, [name]: value }));
+  };
+
+  const handleNumberInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    const parsedValue = parseInt(value, 10);
+    setTaskData((prevData) => ({ ...prevData, [name]: isNaN(parsedValue) ? 0 : parsedValue }));
+  };
+
+  const handleCreateTask = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    onTaskCreate(taskData);
+    setTaskData({
+      title: '',
+      point: 0,
+      member: '',
+      completionCondition: '',
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal">
+      <form className="modal-content">
+        <h2 className="text-lg font-semibold">TASK MODAL</h2>
+        <label htmlFor="title">제목:</label>
+        <input type="text" id="title" name="title" value={taskData.title} onChange={handleInputChange} />
+        <label htmlFor="point">포인트:</label>
+        <input type="number" id="point" name="point" value={taskData.point} onChange={handleNumberInputChange} />
+        <label htmlFor="member">멤버:</label>
+        <input type="text" id="member" name="member" value={taskData.member} onChange={handleInputChange} />
+        <label htmlFor="completionCondition">완료 조건:</label>
+        <input
+          type="text"
+          id="completionCondition"
+          name="completionCondition"
+          value={taskData.completionCondition}
+          onChange={handleInputChange}
+        />
+        <button className="border px-8" onClick={handleCreateTask}>
+          생성
+        </button>
+        <button
+          className="border px-8"
+          onClick={(e) => {
+            e.preventDefault();
+            onClose();
+          }}
+        >
+          취소
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default TaskModal;

--- a/FE/src/components/common/ProgressBar/ProgressBar.tsx
+++ b/FE/src/components/common/ProgressBar/ProgressBar.tsx
@@ -10,13 +10,13 @@ const PrograssBar = (props: PrograssBarProps) => {
   const percentage = Number(currentAmount / totalAmount) * 100;
 
   return (
-    <div>
-      <span>{startText}</span>
-      <div>
-        <div>배경바</div>
-        <div>{percentage}</div>
+    <div className="flex items-center gap-3">
+      <span className="text-xs font-bold">{startText}</span>
+      <div className="relative">
+        <div className="h-2 rounded-lg w-44 bg-green-stroke"></div>
+        <div className="absolute top-0 w-12 h-2 rounded-lg bg-starbucks-green"></div>
       </div>
-      <span>{endText}</span>
+      <span className="text-xs font-bold">{endText}</span>
     </div>
   );
 };

--- a/FE/src/components/sprint/BoardHeader.tsx
+++ b/FE/src/components/sprint/BoardHeader.tsx
@@ -1,0 +1,16 @@
+interface BaordHeaderProps {
+  boardName: string;
+  taskNumber: number;
+  boardDescription: string;
+}
+const BoardHeader = ({ boardName, taskNumber, boardDescription }: BaordHeaderProps) => (
+  <div className="w-72 px-2.5 mb-2.5">
+    <p className="flex justify-between text-2xl font-bold text-house-green">
+      <span>{boardName}</span>
+      <span>{taskNumber}</span>
+    </p>
+    <p className="text-xs font-medium">{boardDescription}</p>
+  </div>
+);
+
+export default BoardHeader;

--- a/FE/src/components/sprint/ColumnBoard.tsx
+++ b/FE/src/components/sprint/ColumnBoard.tsx
@@ -7,9 +7,9 @@ interface ColumnBoardProps {
 
 const ColumnBoard = ({ taskList }: ColumnBoardProps) => (
   <ul className="flex flex-col gap-3 p-5 border rounded-lg w-72 border-green-stroke">
-    {taskList.map(({ id, title, user, point }) => (
+    {taskList.map(({ id, title, userName, point }) => (
       <li>
-        <TaskCard key={id} id={id} title={title} assignee={user} point={point} />
+        <TaskCard key={id} id={id} title={title} assignee={userName} point={point} />
       </li>
     ))}
   </ul>

--- a/FE/src/components/sprint/ColumnBoard.tsx
+++ b/FE/src/components/sprint/ColumnBoard.tsx
@@ -2,17 +2,17 @@ import TaskCard from './TaskCard';
 import { Task } from '../../pages/sprint/SprintPage';
 
 interface ColumnBoardProps {
-  boardName: string;
   taskList: Task[];
 }
 
-const ColumnBoard = ({ boardName, taskList }: ColumnBoardProps) => (
-  <div>
-    <span>{boardName}</span>
+const ColumnBoard = ({ taskList }: ColumnBoardProps) => (
+  <ul className="flex flex-col gap-3 p-5 border rounded-lg w-72 border-green-stroke">
     {taskList.map(({ id, title, user, point }) => (
-      <TaskCard key={id} taskName={title} assignee={user} taskPoint={point} />
+      <li>
+        <TaskCard key={id} id={id} title={title} assignee={user} point={point} />
+      </li>
     ))}
-  </div>
+  </ul>
 );
 
 export default ColumnBoard;

--- a/FE/src/components/sprint/FilterDropdown.tsx
+++ b/FE/src/components/sprint/FilterDropdown.tsx
@@ -1,0 +1,58 @@
+import { UserFilter, TaskGroup } from '../../types/sprint';
+
+interface User {
+  id?: number;
+  name: string;
+}
+
+interface FilterDropdownProps {
+  userList: User[];
+  userToFilter: UserFilter;
+  taskGroup: TaskGroup;
+  onClickUserFilterButton: (user: UserFilter) => void;
+  onClickGroupFilterButton: (group: TaskGroup) => void;
+}
+
+const FilterDropdown = (props: FilterDropdownProps) => {
+  const { userToFilter, taskGroup, userList, onClickGroupFilterButton, onClickUserFilterButton } = props;
+
+  const activeMenuClass = 'text-starbucks-green font-medium';
+  const inactiveMenuClass = 'text-green-stroke';
+
+  return (
+    <ul className="flex flex-col gap-1.5 absolute w-32 p-3 border rounded top-8 border-green-stroke bg-true-white">
+      <p className="font-bold text-center ">멤버별 필터</p>
+      {userList.map(({ id, name }) => (
+        <p
+          key={id}
+          className={`text-center text-xs hover:cursor-pointer ${
+            name === userToFilter ? activeMenuClass : inactiveMenuClass
+          }`}
+          onClick={() => onClickUserFilterButton(name)}
+        >
+          {name}
+        </p>
+      ))}
+      <hr className="bg-green-stroke" />
+      <p className="font-bold text-center ">그룹화</p>
+      <p
+        className={`text-center text-xs hover:cursor-pointer ${
+          taskGroup === 'all' ? activeMenuClass : inactiveMenuClass
+        }`}
+        onClick={() => onClickGroupFilterButton('all')}
+      >
+        전체 태스크
+      </p>
+      <p
+        className={`text-center text-xs hover:cursor-pointer ${
+          taskGroup === 'story' ? activeMenuClass : inactiveMenuClass
+        }`}
+        onClick={() => onClickGroupFilterButton('story')}
+      >
+        스토리 그룹
+      </p>
+    </ul>
+  );
+};
+
+export default FilterDropdown;

--- a/FE/src/components/sprint/KanbanBoard.tsx
+++ b/FE/src/components/sprint/KanbanBoard.tsx
@@ -2,25 +2,27 @@ import { Task } from '../../pages/sprint/SprintPage';
 import ColumnBoard from './ColumnBoard';
 
 interface KanbanBoardProps {
-  storyName?: string;
-  taskList: Task[];
+  storyTitle?: string;
+  storyId?: string;
+  todoList: Task[];
+  inProgressList: Task[];
+  doneList: Task[];
 }
 
-const KanbanBoard = ({ storyName, taskList }: KanbanBoardProps) => {
-  const todoList = taskList.filter(({ state }) => state === 'ToDo');
-  const inProgressList = taskList.filter(({ state }) => state === 'InProgress');
-  const doneList = taskList.filter(({ state }) => state === 'Done');
-
-  return (
-    <div>
-      {storyName && <span>{storyName}</span>}
-      <div>
-        <ColumnBoard boardName="Todo" taskList={todoList} />
-        <ColumnBoard boardName="In Progress" taskList={inProgressList} />
-        <ColumnBoard boardName="Done" taskList={doneList} />
-      </div>
+const KanbanBoard = ({ storyId, storyTitle, todoList, inProgressList, doneList }: KanbanBoardProps) => (
+  <div>
+    {storyTitle && (
+      <p className="flex items-center gap-2 mb-2.5">
+        <span className="text-sm font-bold text-starbucks-green">{storyId}</span>
+        <span className="text-xs font-medium ">{storyTitle}</span>
+      </p>
+    )}
+    <div className="flex justify-between">
+      <ColumnBoard taskList={todoList} />
+      <ColumnBoard taskList={inProgressList} />
+      <ColumnBoard taskList={doneList} />
     </div>
-  );
-};
+  </div>
+);
 
 export default KanbanBoard;

--- a/FE/src/components/sprint/TaskCard.tsx
+++ b/FE/src/components/sprint/TaskCard.tsx
@@ -1,16 +1,18 @@
 interface TaskCardProps {
-  taskName: string;
+  id: number;
+  title: string;
   assignee?: string;
-  taskPoint: number;
+  point: number;
 }
 
-const TaskCard = ({ taskName, assignee, taskPoint }: TaskCardProps) => (
-  <div>
-    <span>{taskName}</span>
-    <div>
+const TaskCard = ({ id, title, assignee, point }: TaskCardProps) => (
+  <div className="flex flex-col gap-5 p-3 text-sm border rounded-lg border-green-stroke bg-cool-neutral">
+    <p className="font-medium">{title}</p>
+    <p className="flex justify-between text-starbucks-green">
+      <span className="font-bold">{id}</span>
       <span>{assignee}</span>
-      <span>{taskPoint}시간</span>
-    </div>
+      <span>{point} point</span>
+    </p>
   </div>
 );
 

--- a/FE/src/hooks/useBlock.tsx
+++ b/FE/src/hooks/useBlock.tsx
@@ -1,0 +1,48 @@
+import { useState, useRef, useEffect } from 'react';
+
+const useBlock = () => {
+  const [items, setItems] = useState<string[]>([]);
+  const [newItemTitle, setNewItemTitle] = useState<string>('');
+  const [showForm, setShowForm] = useState<boolean>(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleAddButton = () => {
+    setShowForm(!showForm);
+  };
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (formRef.current && !formRef.current.contains(e.target as Node)) {
+      setShowForm(false);
+      setNewItemTitle('');
+    }
+  };
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newItemTitle.trim() !== '') {
+      setItems([...items, newItemTitle]);
+      setNewItemTitle('');
+      setShowForm(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return {
+    items,
+    newItemTitle,
+    showForm,
+    formRef,
+    handleAddButton,
+    handleFormSubmit,
+    setNewItemTitle,
+  };
+};
+
+export default useBlock;

--- a/FE/src/pages/backlog/BacklogPage.tsx
+++ b/FE/src/pages/backlog/BacklogPage.tsx
@@ -1,0 +1,34 @@
+import EpicBlock from '../../components/backlog/EpicBlock';
+import useBlock from '../../hooks/useBlock';
+
+const BacklogPage = () => {
+  const { items, newItemTitle, showForm, formRef, handleAddButton, handleFormSubmit, setNewItemTitle } = useBlock();
+
+  return (
+    <div className="border-2 border-black">
+      <h1>Backlog Page</h1>
+      {items.map((item) => (
+        <EpicBlock key={item} epicTitle={item} />
+      ))}
+      {showForm ? (
+        <form ref={formRef} onSubmit={handleFormSubmit}>
+          <input
+            type="text"
+            placeholder={`Enter Epic Title`}
+            value={newItemTitle}
+            onChange={(e) => setNewItemTitle(e.target.value)}
+          />
+          <button className="border px-8" type="submit">
+            + Epic 생성하기
+          </button>
+        </form>
+      ) : (
+        <button className="border px-8" onClick={handleAddButton}>
+          + Epic 생성하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default BacklogPage;

--- a/FE/src/pages/sprint/SprintPage.tsx
+++ b/FE/src/pages/sprint/SprintPage.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import PrograssBar from '../../components/common/ProgressBar/ProgressBar';
 import KanbanBoard from '../../components/sprint/KanbanBoard';
 import BoardHeader from '../../components/sprint/BoardHeader';
+import FilterDropdown from '../../components/sprint/FilterDropdown';
+import { UserFilter, TaskGroup } from '../../types/sprint';
 
 export interface Task {
   id: number;
   title: string;
-  user: string;
+  userName: string;
   point: number;
   state: 'ToDo' | 'InProgress' | 'Done';
   storyTitle: string;
@@ -18,52 +20,55 @@ interface Data {
 
 type TaskGroupedByStory = Record<string, Task[]>;
 
+const data: Data = {
+  taskList: [
+    {
+      storyTitle: '유저는 로그인할 수 있다.',
+      id: 2,
+      title: '로그인 DB저장',
+      userName: '승민',
+      point: 3,
+      state: 'ToDo',
+    },
+    {
+      storyTitle: '유저는 에픽을 생성할 수 있다.',
+      id: 3,
+      title: 'API작성하기',
+      userName: '수린',
+      point: 5,
+      state: 'ToDo',
+    },
+    {
+      storyTitle: '유저는 로그인할 수 있다.',
+      id: 4,
+      title: '회원가입 기능 구현',
+      userName: '승민',
+      point: 4,
+      state: 'InProgress',
+    },
+    {
+      storyTitle: '유저는 칸반보드를 조회할 수 있다.',
+      id: 5,
+      title: 'UI 디자인',
+      userName: '용현',
+      point: 2,
+      state: 'Done',
+    },
+  ],
+};
+
 const SprintPage = () => {
-  const [taskGroup, setTaskGroup] = useState<'all' | 'group'>('all');
+  const [taskGroup, setTaskGroup] = useState<TaskGroup>('all');
+  const [userToFilter, setUserToFilter] = useState<UserFilter>('전체');
+  const [dropdownOpend, setDropdownOpend] = useState<boolean>(false);
+  const [taskList, setTaskList] = useState<Task[]>(data.taskList);
 
-  const data: Data = {
-    taskList: [
-      {
-        storyTitle: '유저는 로그인할 수 있다.',
-        id: 2,
-        title: '로그인 DB저장',
-        user: '1',
-        point: 3,
-        state: 'ToDo',
-      },
-      {
-        storyTitle: '유저는 에픽을 생성할 수 있다.',
-        id: 3,
-        title: 'API작성하기',
-        user: '4',
-        point: 5,
-        state: 'ToDo',
-      },
-      {
-        storyTitle: '유저는 로그인할 수 있다.',
-        id: 4,
-        title: '회원가입 기능 구현',
-        user: '3',
-        point: 4,
-        state: 'InProgress',
-      },
-      {
-        storyTitle: '유저는 칸반보드를 조회할 수 있다.',
-        id: 5,
-        title: 'UI 디자인',
-        user: '4',
-        point: 2,
-        state: 'Done',
-      },
-    ],
-  };
-
-  const todoList = data.taskList.filter(({ state }) => state === 'ToDo');
-  const inProgressList = data.taskList.filter(({ state }) => state === 'InProgress');
-  const doneList = data.taskList.filter(({ state }) => state === 'Done');
+  const todoList = taskList.filter(({ state }) => state === 'ToDo');
+  const inProgressList = taskList.filter(({ state }) => state === 'InProgress');
+  const doneList = taskList.filter(({ state }) => state === 'Done');
 
   // storyTitle을 기준으로 데이터를 나누기
-  const tasksByStory: TaskGroupedByStory = data.taskList.reduce((result: TaskGroupedByStory, current: Task) => {
+  const tasksByStory: TaskGroupedByStory = taskList.reduce((result: TaskGroupedByStory, current: Task) => {
     const storyTitle = current.storyTitle;
     result[storyTitle] = result[storyTitle] ?? [];
     result[storyTitle].push(current);
@@ -88,8 +93,21 @@ const SprintPage = () => {
     );
   });
 
-  const handleGroupButtonClick = () => {
-    setTaskGroup((taskGroup) => (taskGroup === 'all' ? 'group' : 'all'));
+  const handleGroupButtonClick = (taskGroup: TaskGroup): void => {
+    setTaskGroup(taskGroup);
+    setDropdownOpend(false);
+  };
+
+  const handleUserFilterButtonClick = (user: UserFilter): void => {
+    user === '전체'
+      ? setTaskList([...data.taskList])
+      : setTaskList([...data.taskList.filter(({ userName }) => user === userName)]);
+    setUserToFilter(user);
+    setDropdownOpend(false);
+  };
+
+  const handleFilterButtonClick = (): void => {
+    setDropdownOpend((prevValue) => !prevValue);
   };
 
   return (
@@ -104,16 +122,24 @@ const SprintPage = () => {
           <PrograssBar startText="태스크 60건" endText="완료 9건" totalAmount={60} currentAmount={9} />
         </div>
         <div className="flex gap-2">
-          <button
-            className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs"
-            onClick={handleGroupButtonClick}
-          >
-            필터
-          </button>
-          <button
-            className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs"
-            onClick={handleGroupButtonClick}
-          >
+          <div className="relative">
+            <button
+              onClick={handleFilterButtonClick}
+              className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs"
+            >
+              필터
+            </button>
+            {dropdownOpend && (
+              <FilterDropdown
+                userList={[{ name: '전체' }, { id: 4, name: '수린' }, { id: 2, name: '용현' }, { id: 1, name: '승민' }]}
+                userToFilter={userToFilter}
+                taskGroup={taskGroup}
+                onClickGroupFilterButton={handleGroupButtonClick}
+                onClickUserFilterButton={handleUserFilterButtonClick}
+              />
+            )}
+          </div>
+          <button className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs">
             스프린트 완료
           </button>
         </div>

--- a/FE/src/pages/sprint/SprintPage.tsx
+++ b/FE/src/pages/sprint/SprintPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import PrograssBar from '../../components/common/ProgressBar/ProgressBar';
 import KanbanBoard from '../../components/sprint/KanbanBoard';
+import BoardHeader from '../../components/sprint/BoardHeader';
 
 export interface Task {
   id: number;
@@ -8,7 +9,7 @@ export interface Task {
   user: string;
   point: number;
   state: 'ToDo' | 'InProgress' | 'Done';
-  storyName: string;
+  storyTitle: string;
 }
 
 interface Data {
@@ -23,7 +24,7 @@ const SprintPage = () => {
   const data: Data = {
     taskList: [
       {
-        storyName: '스토리1',
+        storyTitle: '유저는 로그인할 수 있다.',
         id: 2,
         title: '로그인 DB저장',
         user: '1',
@@ -31,7 +32,7 @@ const SprintPage = () => {
         state: 'ToDo',
       },
       {
-        storyName: '스토리2',
+        storyTitle: '유저는 에픽을 생성할 수 있다.',
         id: 3,
         title: 'API작성하기',
         user: '4',
@@ -39,7 +40,7 @@ const SprintPage = () => {
         state: 'ToDo',
       },
       {
-        storyName: '스토리1',
+        storyTitle: '유저는 로그인할 수 있다.',
         id: 4,
         title: '회원가입 기능 구현',
         user: '3',
@@ -47,7 +48,7 @@ const SprintPage = () => {
         state: 'InProgress',
       },
       {
-        storyName: '스토리3',
+        storyTitle: '유저는 칸반보드를 조회할 수 있다.',
         id: 5,
         title: 'UI 디자인',
         user: '4',
@@ -57,40 +58,88 @@ const SprintPage = () => {
     ],
   };
 
-  // storyName을 기준으로 데이터를 나누기
+  const todoList = data.taskList.filter(({ state }) => state === 'ToDo');
+  const inProgressList = data.taskList.filter(({ state }) => state === 'InProgress');
+  const doneList = data.taskList.filter(({ state }) => state === 'Done');
+
+  // storyTitle을 기준으로 데이터를 나누기
   const tasksByStory: TaskGroupedByStory = data.taskList.reduce((result: TaskGroupedByStory, current: Task) => {
-    const storyName = current.storyName;
-    result[storyName] = result[storyName] ?? [];
-    result[storyName].push(current);
+    const storyTitle = current.storyTitle;
+    result[storyTitle] = result[storyTitle] ?? [];
+    result[storyTitle].push(current);
     return result;
   }, {});
 
-  const storyKanbanBoards = Object.entries(tasksByStory).map(([storyName, taskList]) => (
-    <KanbanBoard key={storyName} storyName={storyName} taskList={taskList} />
-  ));
+  const storyKanbanBoards = Object.entries(tasksByStory).map(([storyTitle, taskList]) => {
+    const todoList = taskList.filter(({ state }) => state === 'ToDo');
+    const inProgressList = taskList.filter(({ state }) => state === 'InProgress');
+    const doneList = taskList.filter(({ state }) => state === 'Done');
+    return (
+      <li>
+        <KanbanBoard
+          key={storyTitle}
+          storyTitle={storyTitle}
+          storyId="LES-12"
+          todoList={todoList}
+          inProgressList={inProgressList}
+          doneList={doneList}
+        />
+      </li>
+    );
+  });
 
   const handleGroupButtonClick = () => {
     setTaskGroup((taskGroup) => (taskGroup === 'all' ? 'group' : 'all'));
   };
 
   return (
-    <>
-      <header>
-        <h1>스프린트 1</h1>
-        <span>백로그와 칸반보드가 보이는 이슈관리 프로토 타입을 만들자</span>
-      </header>
-      <div>
-        <div>
+    <section className="p-4">
+      <div className="flex mb-2.5">
+        <h1 className="mr-2 text-2xl font-bold text-starbucks-green">스프린트 1</h1>
+        <span className="self-end text-xs h-fit">백로그와 칸반보드가 보이는 이슈관리 프로토 타입을 만들자</span>
+      </div>
+      <div className="flex justify-between mb-4">
+        <div className="flex gap-x-8">
           <PrograssBar startText="23.11.14" endText="23.11.17" totalAmount={5} currentAmount={3} />
           <PrograssBar startText="태스크 60건" endText="완료 9건" totalAmount={60} currentAmount={9} />
         </div>
-        <div>
-          <button onClick={handleGroupButtonClick}>전체 태스크</button>
-          <button onClick={handleGroupButtonClick}>스토리 그룹화</button>
+        <div className="flex gap-2">
+          <button
+            className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs"
+            onClick={handleGroupButtonClick}
+          >
+            필터
+          </button>
+          <button
+            className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs"
+            onClick={handleGroupButtonClick}
+          >
+            스프린트 완료
+          </button>
         </div>
       </div>
-      <div>{taskGroup === 'all' ? <KanbanBoard taskList={data.taskList} /> : storyKanbanBoards}</div>
-    </>
+      <hr className="mb-2.5 bg-green-stroke border" />
+      <div>
+        <div className="flex justify-between">
+          <BoardHeader
+            boardName="할 일"
+            boardDescription="스프린트 내 아직 진행되지 않은 업무"
+            taskNumber={todoList.length}
+          />
+          <BoardHeader boardName="진행 중" boardDescription="현재 진행 중인 업무" taskNumber={inProgressList.length} />
+          <BoardHeader boardName="완료" boardDescription="스프린트 중 완료된 모든 업무" taskNumber={doneList.length} />
+        </div>
+        <ul className="flex flex-col gap-y-1.5">
+          {taskGroup === 'all' ? (
+            <li>
+              <KanbanBoard todoList={todoList} inProgressList={inProgressList} doneList={doneList} />
+            </li>
+          ) : (
+            storyKanbanBoards
+          )}
+        </ul>
+      </div>
+    </section>
   );
 };
 

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -1,0 +1,3 @@
+export type TaskGroup = 'all' | 'story';
+
+export type UserFilter = '전체' | string;

--- a/FE/tailwind.config.js
+++ b/FE/tailwind.config.js
@@ -2,7 +2,20 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'true-white': '#FFFFFF',
+        'cool-neutral': '#F9F9F9',
+        'warm-neutral': 'F2F0EB',
+        ceramic: '#EDEBE9',
+        'true-black': '#000000',
+        'house-green': '#1E3932',
+        'accent-green': '#00754A',
+        'starbucks-green': '#006241',
+        'green-stroke': '#8E9C99',
+        'rewards-gold': '#CBA258',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## task

- LES-112 [FE] 칸반보드를 렌더링하는 코드를 작성한다.

## 설명

- 지정된 디자인에 맞게 className 추가
- 필터링하는 드롭다운 메뉴 컴포넌트 생성 및 필터 기능 추가

### 동작 화면
![녹화_2023_11_16_20_48_20_708](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/11af2155-fbd4-4fab-ade2-383382bf49f4)
- 보드 크기를 고정해놔서 사이 간격이 넓습니다. 나중에 사이드 바를 추가하면서 스타일을 수정하려 합니다.

## 고민거리 (Optional)
- twin.macro를 사용하려고 했는데 어떤 이유에서인지 동작을 하지 않아서 어떤 점이 문제가 되는 것인지 더 알아봐야 할 것 같습니다. 스타일 코드보다는 기능이 더 중요하다고 생각해 일단 스타일은 모두 className에 tailwind를 사용해 정의했습니다.
  - 빨리 문제를 찾고 적용해 중복되는 부분을 줄여야 할 것 같습니다.
  - 어떤 컴포넌트를 styled component로 만들 것인지도 더 고민해봐야 할 것 같습니다.
- 생각보다 같은 타입을 지정해줘야 하는 부분이 많아서 잘 사용하고 있는지 의문이 들었습니다.다.
    ``` typescript
    // state 정의할 때 타입 지정
    const [taskGroup, setTaskGroup] = useState<TaskGroup>('all');

    // 해당 state를 변경하는 함수의 매개변수 타입 지정
    const handleGroupButtonClick = (taskGroup: TaskGroup): void => {
        setTaskGroup(taskGroup);
        setDropdownOpend(false);
      };
    
    // 해당 state를 props로 받는 곳에서 타입 지정, 해당 state를 변경하는 함수를 props로 전달할 때 그 함수의 매개변수 타입 지정
    interface FilterDropdownProps {
      taskGroup: TaskGroup;
      onClickGroupFilterButton: (group: TaskGroup) => void;
    }
    ```
    