### PR TITLE
백로그 페이지 코드 작성

### DIFF
--- a/FE/src/components/backlog/EpicBlock.tsx
+++ b/FE/src/components/backlog/EpicBlock.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import useBlock from '../../hooks/useBlock';
+import StoryBlock from './StoryBlock';
+
+interface EpicBlockProps {
+  epicTitle: string;
+}
+
+const EpicBlock = ({ epicTitle }: EpicBlockProps) => {
+  const { items, newItemTitle, showForm, formRef, handleAddButton, handleFormSubmit, setNewItemTitle } = useBlock();
+  const [showEpic, setShowEpic] = useState<boolean>(true);
+  const handleToggleEpic = () => {
+    setShowEpic(!showEpic);
+  };
+
+  return (
+    <div className="my-5 border-2 border-red-600">
+      <div className="flex gap-2">
+        <h2>{epicTitle}</h2>
+        <button className="border" onClick={handleToggleEpic}>
+          Toggle Epic
+        </button>
+      </div>
+      {showEpic && items.map((item) => <StoryBlock key={item} storyTitle={item} />)}
+      {showForm ? (
+        <form ref={formRef} onSubmit={handleFormSubmit}>
+          <input
+            type="text"
+            placeholder={`Enter Story Title`}
+            value={newItemTitle}
+            onChange={(e) => setNewItemTitle(e.target.value)}
+          />
+          <button className="border px-8" type="submit">
+            + Story 생성하기
+          </button>
+        </form>
+      ) : (
+        <button className="border px-8" onClick={handleAddButton}>
+          + Story 생성하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default EpicBlock;

--- a/FE/src/components/backlog/StoryBlock.tsx
+++ b/FE/src/components/backlog/StoryBlock.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import TaskBlock from './TaskBlock';
+import TaskModal, { TaskData } from './TaskModal';
+
+interface StoryBlockProps {
+  storyTitle: string;
+}
+
+const StoryBlock = ({ storyTitle }: StoryBlockProps) => {
+  const [tasks, setTasks] = useState<TaskData[]>([]);
+  const [showStory, setShowStory] = useState<boolean>(true);
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const handleToggleStory = () => {
+    setShowStory(!showStory);
+  };
+
+  const handleToggleModal = () => {
+    setShowModal(!showModal);
+  };
+
+  const handleTaskCreate = (taskData: TaskData) => {
+    setTasks((prevTasks) => [...prevTasks, taskData]);
+  };
+
+  return (
+    <div className="border-2 border-blue-600">
+      <div className="flex gap-2">
+        <h3>{storyTitle}</h3>
+        <button className="border" onClick={handleToggleStory}>
+          Toggle Story
+        </button>
+      </div>
+      {showStory && tasks.map((task, index) => <TaskBlock key={index} taskData={task} />)}
+      {showModal && <TaskModal onClose={handleToggleModal} onTaskCreate={handleTaskCreate} />}
+      <button className="border px-8" onClick={handleToggleModal}>
+        + Task 생성하기
+      </button>
+    </div>
+  );
+};
+
+export default StoryBlock;

--- a/FE/src/components/backlog/TaskBlock.tsx
+++ b/FE/src/components/backlog/TaskBlock.tsx
@@ -1,0 +1,16 @@
+import { TaskData } from './TaskModal';
+
+interface TaskBlockProps {
+  taskData: TaskData;
+}
+
+const TaskBlock = ({ taskData }: TaskBlockProps) => (
+  <div className="border-2 border-green-600">
+    <h4>Title: {taskData.title}</h4>
+    <p>Point: {taskData.point}</p>
+    <p>Member: {taskData.member}</p>
+    <p>Completion Condition: {taskData.completionCondition}</p>
+  </div>
+);
+
+export default TaskBlock;

--- a/FE/src/components/backlog/TaskModal.tsx
+++ b/FE/src/components/backlog/TaskModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+
+export interface TaskData {
+  title: string;
+  member: string;
+  point: number;
+  completionCondition: string;
+}
+
+interface TaskModalProps {
+  onClose: () => void;
+  onTaskCreate: (taskData: TaskData) => void;
+}
+
+const TaskModal = ({ onClose, onTaskCreate }: TaskModalProps) => {
+  const [taskData, setTaskData] = useState<TaskData>({
+    title: '',
+    member: '',
+    point: 0,
+    completionCondition: '',
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setTaskData((prevData) => ({ ...prevData, [name]: value }));
+  };
+
+  const handleNumberInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    const parsedValue = parseInt(value, 10);
+    setTaskData((prevData) => ({ ...prevData, [name]: isNaN(parsedValue) ? 0 : parsedValue }));
+  };
+
+  const handleCreateTask = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    onTaskCreate(taskData);
+    setTaskData({
+      title: '',
+      point: 0,
+      member: '',
+      completionCondition: '',
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal">
+      <form className="modal-content">
+        <h2 className="text-lg font-semibold">TASK MODAL</h2>
+        <label htmlFor="title">제목:</label>
+        <input type="text" id="title" name="title" value={taskData.title} onChange={handleInputChange} />
+        <label htmlFor="point">포인트:</label>
+        <input type="number" id="point" name="point" value={taskData.point} onChange={handleNumberInputChange} />
+        <label htmlFor="member">멤버:</label>
+        <input type="text" id="member" name="member" value={taskData.member} onChange={handleInputChange} />
+        <label htmlFor="completionCondition">완료 조건:</label>
+        <input
+          type="text"
+          id="completionCondition"
+          name="completionCondition"
+          value={taskData.completionCondition}
+          onChange={handleInputChange}
+        />
+        <button className="border px-8" onClick={handleCreateTask}>
+          생성
+        </button>
+        <button
+          className="border px-8"
+          onClick={(e) => {
+            e.preventDefault();
+            onClose();
+          }}
+        >
+          취소
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default TaskModal;

--- a/FE/src/hooks/useBlock.tsx
+++ b/FE/src/hooks/useBlock.tsx
@@ -1,0 +1,48 @@
+import { useState, useRef, useEffect } from 'react';
+
+const useBlock = () => {
+  const [items, setItems] = useState<string[]>([]);
+  const [newItemTitle, setNewItemTitle] = useState<string>('');
+  const [showForm, setShowForm] = useState<boolean>(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleAddButton = () => {
+    setShowForm(!showForm);
+  };
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (formRef.current && !formRef.current.contains(e.target as Node)) {
+      setShowForm(false);
+      setNewItemTitle('');
+    }
+  };
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newItemTitle.trim() !== '') {
+      setItems([...items, newItemTitle]);
+      setNewItemTitle('');
+      setShowForm(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return {
+    items,
+    newItemTitle,
+    showForm,
+    formRef,
+    handleAddButton,
+    handleFormSubmit,
+    setNewItemTitle,
+  };
+};
+
+export default useBlock;

--- a/FE/src/pages/backlog/BacklogPage.tsx
+++ b/FE/src/pages/backlog/BacklogPage.tsx
@@ -1,0 +1,34 @@
+import EpicBlock from '../../components/backlog/EpicBlock';
+import useBlock from '../../hooks/useBlock';
+
+const BacklogPage = () => {
+  const { items, newItemTitle, showForm, formRef, handleAddButton, handleFormSubmit, setNewItemTitle } = useBlock();
+
+  return (
+    <div className="border-2 border-black">
+      <h1>Backlog Page</h1>
+      {items.map((item) => (
+        <EpicBlock key={item} epicTitle={item} />
+      ))}
+      {showForm ? (
+        <form ref={formRef} onSubmit={handleFormSubmit}>
+          <input
+            type="text"
+            placeholder={`Enter Epic Title`}
+            value={newItemTitle}
+            onChange={(e) => setNewItemTitle(e.target.value)}
+          />
+          <button className="border px-8" type="submit">
+            + Epic 생성하기
+          </button>
+        </form>
+      ) : (
+        <button className="border px-8" onClick={handleAddButton}>
+          + Epic 생성하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default BacklogPage;


### PR DESCRIPTION
## task
LES-132 [FE] 유저는 백로그 전체를 확인할 수 있다.
LES-63 [FE] 에픽 목록을 화면에 렌더링 하는 코드를 작성
LES-64 [FE] 에픽 목록을 추가하는 버튼을 만든다.
LES-75 [FE] 스토리 목록을 화면에 렌더링 하는 코드를 작성
LES-76 [FE] 스토리 목록을 추가하는 버튼을 만든다.
LES-83 [FE] 태스크 목록을 추가하는 버튼을 만든다.
LES-84 [FE] 태스크 목록을 화면에 렌더링 하는 코드를 작성

## 설명
칸반보드를 볼 수 있는 페이지를 생성하고 에픽, 스토리, 태스크를 추가할 수 있는 코드를 작성하였습니다.

## 고민거리 (Optional)
### 전역 상태 관리
- 태스크 목록을 추가하는 기능까지 구현했고, 에픽 Toggle 버튼을 눌렀을 때 태스크 목록이 사라지는 경험을 했습니다. 이로 인해 useState를 사용하지 않고 전역으로 상태를 관리해야 한다는 것을 깨달았습니다.