### PR TITLE
백로그 API 수정, 백로그 테스트코드 작성

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+	"test:e2e:watch": "jest --watch --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Delete, Patch, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
 import { CreateBacklogsEpicResponseDto } from 'src/dto/create-backlogs-epic-response.dto';
 import { CreateBacklogsEpicDto } from 'src/dto/create-backlogs-epic.dto';
 import { CreateBacklogsStoryResponseDto } from 'src/dto/create-backlogs-story-response.dto';
@@ -57,7 +57,7 @@ export class BacklogsController {
     return this.backlogsService.createTask(body);
   }
 
-  @Put('Task')
+  @Patch('Task')
   async updateTask(@Body() body: UpdateBacklogsTaskDto): Promise<Record<string, never>> {
     await this.backlogsService.updateTask(body);
     return {};

--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -1,6 +1,9 @@
 import { Body, Controller, Delete, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { CreateBacklogsEpicResponseDto } from 'src/dto/create-backlogs-epic-response.dto';
 import { CreateBacklogsEpicDto } from 'src/dto/create-backlogs-epic.dto';
+import { CreateBacklogsStoryResponseDto } from 'src/dto/create-backlogs-story-response.dto';
 import { CreateBacklogsStoryDto } from 'src/dto/create-backlogs-story.dto';
+import { CreateBacklogsTaskResponseDto } from 'src/dto/create-backlogs-task-response.dto';
 import { CreateBacklogsTaskDto } from 'src/dto/create-backlogs-task.dto';
 import { DeleteBacklogsEpicDto } from 'src/dto/delete-backlogs-epic.dto';
 import { DeleteBacklogsStoryDto } from 'src/dto/delete-backlogs-story.dto';
@@ -16,9 +19,8 @@ export class BacklogsController {
   constructor(private readonly backlogsService: BacklogsService) {}
 
   @Post('Epic')
-  async createEpic(@Body() body: CreateBacklogsEpicDto): Promise<Record<string, never>> {
-    await this.backlogsService.createEpic(body);
-    return {};
+  async createEpic(@Body() body: CreateBacklogsEpicDto): Promise<CreateBacklogsEpicResponseDto> {
+    return this.backlogsService.createEpic(body);
   }
 
   @Put('Epic')
@@ -34,9 +36,8 @@ export class BacklogsController {
   }
 
   @Post('Story')
-  async createStory(@Body() body: CreateBacklogsStoryDto): Promise<Record<string, never>> {
-    await this.backlogsService.createStory(body);
-    return {};
+  async createStory(@Body() body: CreateBacklogsStoryDto): Promise<CreateBacklogsStoryResponseDto> {
+    return this.backlogsService.createStory(body);
   }
 
   @Put('Story')
@@ -52,9 +53,8 @@ export class BacklogsController {
   }
 
   @Post('Task')
-  async createTask(@Body() body: CreateBacklogsTaskDto) {
-    await this.backlogsService.createTask(body);
-    return {};
+  async createTask(@Body() body: CreateBacklogsTaskDto): Promise<CreateBacklogsTaskResponseDto> {
+    return this.backlogsService.createTask(body);
   }
 
   @Put('Task')

--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CreateBacklogsEpicResponseDto } from 'src/dto/create-backlogs-epic-response.dto';
 import { CreateBacklogsEpicDto } from 'src/dto/create-backlogs-epic.dto';
+import { CreateBacklogsStoryResponseDto } from 'src/dto/create-backlogs-story-response.dto';
 import { CreateBacklogsStoryDto } from 'src/dto/create-backlogs-story.dto';
+import { CreateBacklogsTaskResponseDto } from 'src/dto/create-backlogs-task-response.dto';
 import { CreateBacklogsTaskDto } from 'src/dto/create-backlogs-task.dto';
 import { DeleteBacklogsEpicDto } from 'src/dto/delete-backlogs-epic.dto';
 import { DeleteBacklogsStoryDto } from 'src/dto/delete-backlogs-story.dto';
@@ -22,18 +25,18 @@ export class BacklogsService {
     @InjectRepository(Task) private taskRepository: Repository<Task>,
   ) {}
 
-  async createEpic(dto: CreateBacklogsEpicDto): Promise<void> {
+  async createEpic(dto: CreateBacklogsEpicDto): Promise<CreateBacklogsEpicResponseDto> {
     const newEpic = this.epicRepository.create({ title: dto.epicTitle });
-    await this.epicRepository.save(newEpic);
+    return { epicId: (await this.epicRepository.save(newEpic)).id };
   }
 
-  async createStory(dto: CreateBacklogsStoryDto): Promise<void> {
+  async createStory(dto: CreateBacklogsStoryDto): Promise<CreateBacklogsStoryResponseDto> {
     const epic = await this.epicRepository.findOne({ where: { id: dto.story.epicId } });
     const newStory = this.storyRepository.create({ title: dto.story.title, epic });
-    await this.storyRepository.save(newStory);
+    return { storyId: (await this.storyRepository.save(newStory)).id };
   }
 
-  async createTask(dto: CreateBacklogsTaskDto): Promise<void> {
+  async createTask(dto: CreateBacklogsTaskDto): Promise<CreateBacklogsTaskResponseDto> {
     const epic = await this.epicRepository.findOne({ where: { id: dto.task.epicId } });
     const story = await this.storyRepository.findOne({ where: { id: dto.task.storyId } });
     const newTask = this.taskRepository.create({
@@ -45,7 +48,7 @@ export class BacklogsService {
       epic,
       story,
     });
-    await this.taskRepository.save(newTask);
+    return { taskId: (await this.taskRepository.save(newTask)).id };
   }
 
   async updateEpic(dto: UpdateBacklogsEpicDto): Promise<void> {

--- a/BE/src/dto/create-backlogs-epic-response.dto.ts
+++ b/BE/src/dto/create-backlogs-epic-response.dto.ts
@@ -1,0 +1,3 @@
+export class CreateBacklogsEpicResponseDto {
+  epicId: number;
+}

--- a/BE/src/dto/create-backlogs-story-response.dto.ts
+++ b/BE/src/dto/create-backlogs-story-response.dto.ts
@@ -1,0 +1,3 @@
+export class CreateBacklogsStoryResponseDto {
+  storyId: number;
+}

--- a/BE/src/dto/create-backlogs-task-response.dto.ts
+++ b/BE/src/dto/create-backlogs-task-response.dto.ts
@@ -1,0 +1,3 @@
+export class CreateBacklogsTaskResponseDto {
+  taskId: number;
+}

--- a/BE/test/app.e2e-spec.ts
+++ b/BE/test/app.e2e-spec.ts
@@ -1,24 +1,353 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { HttpStatus, INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 
-describe('AppController (e2e)', () => {
+describe('e2e 테스트 시작', () => {
   let app: INestApplication;
+  let httpServer;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
     await app.init();
+    httpServer = app.getHttpServer();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  afterAll(async () => {
+    app.close();
+  });
+  describe('backlogs Test', () => {
+    const epicURI = '/api/backlogs/Epic';
+    const storyURI = '/api/backlogs/Story';
+    const taskURI = '/api/backlogs/Task';
+    let postEpicResponse;
+    let postStoryResponse;
+    let postTaskResponse;
+    const postEpicPayload = { projectId: 3, epicTitle: '이거슨타이틀' };
+    const postStoryPayload = {
+      projectId: 3,
+      story: {
+        epicId: null,
+        title: '회원은 로그인을 할 수 없다.',
+      },
+    };
+    const postTaskPayload = {
+      projectId: 1,
+      task: {
+        epicId: null,
+        storyId: null,
+        userId: 1,
+        title: 'ERD작성하기',
+        state: 'ToDo',
+        point: 0,
+        condition: '인수조건은 다음과같다~~',
+      },
+    };
+    describe('POST /api/epic 에픽생성', () => {
+      it('성공', async () => {
+        postEpicResponse = await request(httpServer).post(epicURI).send(postEpicPayload).expect(HttpStatus.CREATED);
+        expect(postEpicResponse.body).toHaveProperty('epicId');
+        expect(typeof postEpicResponse.body.epicId).toBe('number');
+      });
+
+      it('잘못된 데이터 형식', () =>
+        request(httpServer)
+          .post(epicURI)
+          .send({
+            projectId: '3',
+            epicTitle: '이거슨타이틀',
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+
+      it('데이터 필드 누락', () =>
+        request(httpServer)
+          .post(epicURI)
+          .send({
+            projectId: 3,
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+    });
+    describe('PUT /api/epic 에픽수정', () => {
+      it('성공', async () => {
+        await request(httpServer)
+          .put(epicURI)
+          .send({
+            projectId: 3,
+            epic: {
+              id: postEpicResponse.body.epicId,
+              title: '수정된 제목',
+            },
+          })
+          .expect(HttpStatus.OK);
+      });
+      it('잘못된 데이터 형식', async () => {
+        await request(httpServer)
+          .put(epicURI)
+          .send({
+            projectId: '1',
+            epic: {
+              id: postEpicResponse.body.epicId,
+              title: '수정된 제목',
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST);
+      });
+      it('데이터 필드 누락', async () => {
+        await request(httpServer)
+          .put(epicURI)
+          .send({
+            projectId: '1',
+            epic: {
+              id: postEpicResponse.body.epicId,
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST);
+      });
+    });
+    describe('DELETE /api/epic 에픽삭제', () => {
+      it('성공', async () => {
+        await request(httpServer)
+          .delete(epicURI)
+          .send({
+            projectId: 1,
+            epicId: postEpicResponse.body.epicId,
+          })
+          .expect(HttpStatus.OK);
+      });
+      it('이미 삭제된 데이터', async () => {
+        await request(httpServer)
+          .delete(epicURI)
+          .send({
+            projectId: 1,
+            epicId: postEpicResponse.body.epicId,
+          })
+          .expect(HttpStatus.INTERNAL_SERVER_ERROR);
+      });
+      it('잘못된 데이터 형식', async () => {
+        await request(httpServer)
+          .delete(epicURI)
+          .send({
+            projectId: '1',
+            epicId: postEpicResponse.body.epicId,
+          })
+          .expect(HttpStatus.BAD_REQUEST);
+      });
+      it('데이터 필드 누락', async () => {
+        await request(httpServer)
+          .delete(epicURI)
+          .send({
+            epicId: postEpicResponse.body.epicId,
+          })
+          .expect(HttpStatus.BAD_REQUEST);
+      });
+    });
+    describe('POST /api/story 스토리생성', () => {
+      it('성공', async () => {
+        postEpicResponse = await request(httpServer).post(epicURI).send(postEpicPayload).expect(HttpStatus.CREATED);
+        postStoryPayload.story.epicId = postEpicResponse.body.epicId;
+        postStoryResponse = await request(httpServer).post(storyURI).send(postStoryPayload).expect(HttpStatus.CREATED);
+        expect(postStoryResponse.body).toHaveProperty('storyId');
+        expect(typeof postStoryResponse.body.storyId).toBe('number');
+      });
+
+      it('잘못된 데이터 형식', () =>
+        request(httpServer)
+          .post(storyURI)
+          .send({
+            projectId: 3,
+            story: {
+              epicId: postEpicResponse.body.epicId,
+              title: 3,
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+
+      it('필요한 데이터 누락', () =>
+        request(httpServer)
+          .post(epicURI)
+          .send({
+            projectId: 3,
+            story: {
+              epicId: postEpicResponse.body.epicId,
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+    });
+    describe('PUT /api/story 스토리생성', () => {
+      it('성공', async () => {
+        await request(httpServer)
+          .put(storyURI)
+          .send({
+            projectId: 1,
+            story: {
+              id: postStoryResponse.body.storyId,
+              title: '수정된 스토리',
+            },
+          })
+          .expect(HttpStatus.OK);
+      });
+
+      it('잘못된 데이터 형식', async () =>
+        await request(httpServer)
+          .put(storyURI)
+          .send({
+            projectId: 1,
+            story: {
+              id: postStoryResponse.body.storyId,
+              title: 1,
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+
+      it('데이터 필드 누락', async () =>
+        await request(httpServer)
+          .put(storyURI)
+          .send({
+            projectId: 1,
+            story: {
+              id: postStoryResponse.body.storyId,
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+    });
+    describe('DELETE /api/story 스토리삭제', () => {
+      it('성공', async () => {
+        await request(httpServer)
+          .delete(storyURI)
+          .send({ projectId: 1, storyId: postStoryResponse.body.storyId })
+          .expect(HttpStatus.OK);
+      });
+
+      it('잘못된 데이터 형식', async () =>
+        await request(httpServer)
+          .delete(storyURI)
+          .send({ projectId: '1', storyId: postStoryResponse.body.storyId })
+          .expect(HttpStatus.BAD_REQUEST));
+
+      it('데이터 필드 누락', async () =>
+        await request(httpServer).delete(storyURI).send({ projectId: 1 }).expect(HttpStatus.BAD_REQUEST));
+    });
+    describe('POST /api/task 태스크 생성', () => {
+      it('성공', async () => {
+        postEpicResponse = await request(httpServer).post(epicURI).send(postEpicPayload).expect(HttpStatus.CREATED);
+        postStoryPayload.story.epicId = postEpicResponse.body.epicId;
+        postStoryResponse = await request(httpServer).post(storyURI).send(postStoryPayload).expect(HttpStatus.CREATED);
+        postTaskPayload.task.epicId = postEpicResponse.body.epicId;
+        postTaskPayload.task.storyId = postStoryResponse.body.storyId;
+        postTaskResponse = await request(httpServer).post(taskURI).send(postTaskPayload).expect(HttpStatus.CREATED);
+        expect(postTaskResponse.body).toHaveProperty('taskId');
+        expect(typeof postTaskResponse.body.taskId).toBe('number');
+      });
+      it('잘못된 데이터 형식', () =>
+        request(httpServer)
+          .post(taskURI)
+          .send({
+            projectId: 1,
+            task: {
+              epicId: null,
+              storyId: null,
+              userId: 1,
+              title: 'ERD작성하기',
+              state: 'ToDo',
+              point: '0',
+              condition: '인수조건은 다음과같다~~',
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+
+      it('필요한 데이터 누락', () =>
+        request(httpServer)
+          .post(taskURI)
+          .send({
+            projectId: 1,
+            task: {
+              epicId: null,
+              storyId: null,
+              userId: 1,
+              title: 'ERD작성하기',
+              point: 0,
+              condition: '인수조건은 다음과같다~~',
+            },
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+    });
+    describe('PATCH /api/backlogs/task 태스크 수정', () => {
+      it('성공', async () =>
+        await request(httpServer)
+          .patch(taskURI)
+          .send({
+            projectId: 1,
+            task: {
+              id: postTaskResponse.body.taskId,
+              userId: 3,
+              state: 'ToDo2',
+              point: 10,
+              condition: '인수조건은 다음과같다~~',
+            },
+          })
+          .expect(HttpStatus.OK));
+
+      it('잘못된 데이터 형식', async () =>
+        await request(httpServer)
+          .patch(taskURI)
+          .send({
+            projectId: 1,
+            task: {
+              id: postTaskResponse.body.taskId,
+              userId: '3',
+              state: 'ToDo2',
+              point: 10,
+              condition: '인수조건은 다음과같다~~',
+            },
+          })
+          .expect(400));
+
+      it('필요한 데이터 누락', async () =>
+        await request(httpServer)
+          .patch(taskURI)
+          .send({
+            projectId: 1,
+            task: {
+              userId: '3',
+              state: 'ToDo2',
+              point: 10,
+              condition: '인수조건은 다음과같다~~',
+            },
+          })
+          .expect(400));
+    });
+
+    describe('DELETE /api/backlogs/task 태스크 삭제', () => {
+      it('성공', async () =>
+        await request(httpServer)
+          .delete(taskURI)
+          .send({
+            projectId: 1,
+            taskId: postTaskResponse.body.taskId,
+          })
+          .expect(200));
+
+      it('잘못된 데이터 형식', async () =>
+        await request(httpServer)
+          .delete(taskURI)
+          .send({
+            projectId: '1',
+            taskId: postTaskResponse.body.taskId,
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+
+      it('필요한 데이터 누락', async () =>
+        await request(httpServer)
+          .delete(taskURI)
+          .send({
+            projectId: 1,
+          })
+          .expect(HttpStatus.BAD_REQUEST));
+    });
   });
 });

--- a/BE/test/jest-e2e.json
+++ b/BE/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "moduleDirectories": ["<rootDir>/../", "node_modules"]
 }


### PR DESCRIPTION
## task
태스크 없음

## 설명

### feat: [update-backlog] 백로그 생성 API변경
    
    1. 에픽, 스토리, 태스크 생성의 리턴을 빈 객체에서 식별자로 변경
    2. RESPONSE DTO정의
    
### fix: [update-backlog] 태스크 수정 버그픽스
    
    1. API/backlogs/task의 수정메서드가 PATCH로 되어있어야 하는데 PUT으로 되어있어 수정

###  test: [backlogs-test] 테스트 초기설정
    
    1. e2e테스트 경로설정
    2. e2e --watch 명령어 추가

### test: [backlogs-test] 백로그 테스트코드 추가
    
    1. epic, story, task의 CREATE, PUT/PATCH, DELETE에 대해 테스트코드를 추가하였다.
