### PR TITLE
백로그 확인 API 작성 (/api/backlogs/{projectId})

### DIFF
--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Delete, Patch, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Put,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { BacklogsService } from './backlogs.service';
 import {
   CreateBacklogsEpicRequestDto,
@@ -23,6 +35,11 @@ import {
 @UsePipes(ValidationPipe)
 export class BacklogsController {
   constructor(private readonly backlogsService: BacklogsService) {}
+
+  @Get(':id')
+  readBacklog(@Param('id', ParseIntPipe) id) {
+    return this.backlogsService.readBacklog(id);
+  }
 
   @Post('epic')
   async createEpic(@Body() body: CreateBacklogsEpicRequestDto): Promise<CreateBacklogsEpicResponseDto> {

--- a/BE/src/backlogs/dto/backlog.dto.ts
+++ b/BE/src/backlogs/dto/backlog.dto.ts
@@ -1,0 +1,18 @@
+import { OmitType, PickType } from '@nestjs/swagger';
+import { baseEpicDto, baseStoryDto, baseTaskDto } from './baseType.dto';
+
+export class MTask extends OmitType(baseTaskDto, ['storyId', 'userId']) {
+  userName: string;
+}
+
+export class MStory extends PickType(baseStoryDto, ['id', 'title']) {
+  taskList: MTask[];
+}
+
+export class MEpic extends PickType(baseEpicDto, ['id', 'title']) {
+  storyList: MStory[];
+}
+
+export class ReadBacklogResponseDto {
+  epicList: MEpic[];
+}

--- a/BE/test/backlogs.e2e-spec.ts
+++ b/BE/test/backlogs.e2e-spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../src/app.module';
+import { take } from 'rxjs';
 
 describe('e2e 테스트 시작', () => {
   let app: INestApplication;
@@ -22,12 +23,14 @@ describe('e2e 테스트 시작', () => {
     app.close();
   });
   describe('backlogs Test', () => {
-    const epicURI = '/api/backlogs/Epic';
-    const storyURI = '/api/backlogs/Story';
-    const taskURI = '/api/backlogs/Task';
+    const EPIC_URI = '/api/backlogs/Epic';
+    const STORY_URI = '/api/backlogs/Story';
+    const TASK_URI = '/api/backlogs/Task';
+    const BACKLOG_URI = '/api/backlogs';
     let postEpicResponse;
     let postStoryResponse;
     let postTaskResponse;
+    const PROJECT_URI = '/api/projects';
     const postEpicPayload = { projectId: null, title: '이거슨타이틀' };
     const postStoryPayload = {
       epicId: null,
@@ -40,23 +43,23 @@ describe('e2e 테스트 시작', () => {
       point: 0,
       condition: '인수조건은 다음과같다~~',
     };
-    const PROJECT_URI = '/api/projects';
+    let projectResponse;
     describe('POST /api/epic 에픽생성', () => {
       it('성공', async () => {
-        const projectResponse = await request(httpServer)
+        projectResponse = await request(httpServer)
           .post(PROJECT_URI)
           .send({ name: 'Lesser' })
           .expect(HttpStatus.CREATED);
         expect(typeof projectResponse.body.id).toBe('number');
         postEpicPayload.projectId = projectResponse.body.id;
-        postEpicResponse = await request(httpServer).post(epicURI).send(postEpicPayload).expect(HttpStatus.CREATED);
+        postEpicResponse = await request(httpServer).post(EPIC_URI).send(postEpicPayload).expect(HttpStatus.CREATED);
         expect(postEpicResponse.body).toHaveProperty('id');
         expect(typeof postEpicResponse.body.id).toBe('number');
       });
 
       it('잘못된 데이터 형식', () =>
         request(httpServer)
-          .post(epicURI)
+          .post(EPIC_URI)
           .send({
             projectId: postEpicPayload.projectId,
             title: 3,
@@ -65,7 +68,7 @@ describe('e2e 테스트 시작', () => {
 
       it('데이터 필드 누락', () =>
         request(httpServer)
-          .post(epicURI)
+          .post(EPIC_URI)
           .send({
             id: postEpicPayload.projectId,
           })
@@ -74,7 +77,7 @@ describe('e2e 테스트 시작', () => {
     describe('PUT /api/epic 에픽수정', () => {
       it('성공', async () => {
         await request(httpServer)
-          .put(epicURI)
+          .put(EPIC_URI)
           .send({
             id: postEpicResponse.body.id,
             title: '수정된 제목',
@@ -83,7 +86,7 @@ describe('e2e 테스트 시작', () => {
       });
       it('잘못된 데이터 형식', async () => {
         await request(httpServer)
-          .put(epicURI)
+          .put(EPIC_URI)
           .send({
             id: postEpicResponse.body.id,
             title: 3,
@@ -92,7 +95,7 @@ describe('e2e 테스트 시작', () => {
       });
       it('데이터 필드 누락', async () => {
         await request(httpServer)
-          .put(epicURI)
+          .put(EPIC_URI)
           .send({
             id: postEpicResponse.body.id,
           })
@@ -102,7 +105,7 @@ describe('e2e 테스트 시작', () => {
     describe('DELETE /api/epic 에픽삭제', () => {
       it('성공', async () => {
         await request(httpServer)
-          .delete(epicURI)
+          .delete(EPIC_URI)
           .send({
             id: postEpicResponse.body.id,
           })
@@ -110,7 +113,7 @@ describe('e2e 테스트 시작', () => {
       });
       it('이미 삭제된 데이터', async () => {
         await request(httpServer)
-          .delete(epicURI)
+          .delete(EPIC_URI)
           .send({
             id: postEpicResponse.body.id,
           })
@@ -118,28 +121,28 @@ describe('e2e 테스트 시작', () => {
       });
       it('잘못된 데이터 형식', async () => {
         await request(httpServer)
-          .delete(epicURI)
+          .delete(EPIC_URI)
           .send({
             id: 'postEpicResponse.body.epicId,',
           })
           .expect(HttpStatus.BAD_REQUEST);
       });
       it('데이터 필드 누락', async () => {
-        await request(httpServer).delete(epicURI).send({}).expect(HttpStatus.BAD_REQUEST);
+        await request(httpServer).delete(EPIC_URI).send({}).expect(HttpStatus.BAD_REQUEST);
       });
     });
     describe('POST /api/story 스토리생성', () => {
       it('성공', async () => {
-        postEpicResponse = await request(httpServer).post(epicURI).send(postEpicPayload).expect(HttpStatus.CREATED);
+        postEpicResponse = await request(httpServer).post(EPIC_URI).send(postEpicPayload).expect(HttpStatus.CREATED);
         postStoryPayload.epicId = postEpicResponse.body.id;
-        postStoryResponse = await request(httpServer).post(storyURI).send(postStoryPayload).expect(HttpStatus.CREATED);
+        postStoryResponse = await request(httpServer).post(STORY_URI).send(postStoryPayload).expect(HttpStatus.CREATED);
         expect(postStoryResponse.body).toHaveProperty('id');
         expect(typeof postStoryResponse.body.id).toBe('number');
       });
 
       it('잘못된 데이터 형식', () =>
         request(httpServer)
-          .post(storyURI)
+          .post(STORY_URI)
           .send({
             epicId: postEpicResponse.body.id,
             title: 3,
@@ -148,7 +151,7 @@ describe('e2e 테스트 시작', () => {
 
       it('필요한 데이터 누락', () =>
         request(httpServer)
-          .post(epicURI)
+          .post(EPIC_URI)
           .send({
             epicId: postEpicResponse.body.id,
           })
@@ -157,7 +160,7 @@ describe('e2e 테스트 시작', () => {
     describe('PUT /api/story 스토리생성', () => {
       it('성공', async () => {
         await request(httpServer)
-          .put(storyURI)
+          .put(STORY_URI)
           .send({
             id: postStoryResponse.body.id,
             title: '수정된 스토리',
@@ -167,7 +170,7 @@ describe('e2e 테스트 시작', () => {
 
       it('잘못된 데이터 형식', async () =>
         await request(httpServer)
-          .put(storyURI)
+          .put(STORY_URI)
           .send({
             id: postStoryResponse.body.id,
             title: 3,
@@ -176,7 +179,7 @@ describe('e2e 테스트 시작', () => {
 
       it('데이터 필드 누락', async () =>
         await request(httpServer)
-          .put(storyURI)
+          .put(STORY_URI)
           .send({
             id: postStoryResponse.body.id,
           })
@@ -184,28 +187,28 @@ describe('e2e 테스트 시작', () => {
     });
     describe('DELETE /api/story 스토리삭제', () => {
       it('성공', async () => {
-        await request(httpServer).delete(storyURI).send({ id: postStoryResponse.body.id }).expect(HttpStatus.OK);
+        await request(httpServer).delete(STORY_URI).send({ id: postStoryResponse.body.id }).expect(HttpStatus.OK);
       });
 
       it('잘못된 데이터 형식', async () =>
-        await request(httpServer).delete(storyURI).send({ id: '1' }).expect(HttpStatus.BAD_REQUEST));
+        await request(httpServer).delete(STORY_URI).send({ id: '1' }).expect(HttpStatus.BAD_REQUEST));
 
       it('데이터 필드 누락', async () =>
-        await request(httpServer).delete(storyURI).send({}).expect(HttpStatus.BAD_REQUEST));
+        await request(httpServer).delete(STORY_URI).send({}).expect(HttpStatus.BAD_REQUEST));
     });
     describe('POST /api/task 태스크 생성', () => {
       it('성공', async () => {
-        postEpicResponse = await request(httpServer).post(epicURI).send(postEpicPayload).expect(HttpStatus.CREATED);
+        postEpicResponse = await request(httpServer).post(EPIC_URI).send(postEpicPayload).expect(HttpStatus.CREATED);
         postStoryPayload.epicId = postEpicResponse.body.id;
-        postStoryResponse = await request(httpServer).post(storyURI).send(postStoryPayload).expect(HttpStatus.CREATED);
+        postStoryResponse = await request(httpServer).post(STORY_URI).send(postStoryPayload).expect(HttpStatus.CREATED);
         postTaskPayload.storyId = postStoryResponse.body.id;
-        postTaskResponse = await request(httpServer).post(taskURI).send(postTaskPayload).expect(HttpStatus.CREATED);
+        postTaskResponse = await request(httpServer).post(TASK_URI).send(postTaskPayload).expect(HttpStatus.CREATED);
         expect(postTaskResponse.body).toHaveProperty('id');
         expect(typeof postTaskResponse.body.id).toBe('number');
       });
       it('잘못된 데이터 형식', () =>
         request(httpServer)
-          .post(taskURI)
+          .post(TASK_URI)
           .send({
             storyId: postStoryResponse.body.id,
             title: 'ERD작성하기',
@@ -217,7 +220,7 @@ describe('e2e 테스트 시작', () => {
 
       it('필요한 데이터 누락', () =>
         request(httpServer)
-          .post(taskURI)
+          .post(TASK_URI)
           .send({
             storyId: postStoryResponse.body.id,
             title: 'ERD작성하기',
@@ -229,7 +232,7 @@ describe('e2e 테스트 시작', () => {
     describe('PATCH /api/backlogs/task 태스크 수정', () => {
       it('성공', async () =>
         await request(httpServer)
-          .patch(taskURI)
+          .patch(TASK_URI)
           .send({
             id: postTaskResponse.body.id,
             title: '수정된 제목',
@@ -241,7 +244,7 @@ describe('e2e 테스트 시작', () => {
 
       it('잘못된 데이터 형식', async () =>
         await request(httpServer)
-          .patch(taskURI)
+          .patch(TASK_URI)
           .send({
             id: postTaskResponse.body.id,
             title: '수정된 제목',
@@ -253,7 +256,7 @@ describe('e2e 테스트 시작', () => {
 
       it('필요한 데이터 누락', async () =>
         await request(httpServer)
-          .patch(taskURI)
+          .patch(TASK_URI)
           .send({
             title: '수정된 제목',
             point: 0,
@@ -265,7 +268,7 @@ describe('e2e 테스트 시작', () => {
     describe('DELETE /api/backlogs/task 태스크 삭제', () => {
       it('성공', async () =>
         await request(httpServer)
-          .delete(taskURI)
+          .delete(TASK_URI)
           .send({
             id: postTaskResponse.body.id,
           })
@@ -273,7 +276,7 @@ describe('e2e 테스트 시작', () => {
 
       it('잘못된 데이터 형식', async () =>
         await request(httpServer)
-          .delete(taskURI)
+          .delete(TASK_URI)
           .send({
             id: 'postTaskResponse.body.id',
           })
@@ -281,11 +284,39 @@ describe('e2e 테스트 시작', () => {
 
       it('필요한 데이터 누락', async () =>
         await request(httpServer)
-          .delete(taskURI)
+          .delete(TASK_URI)
           .send({
             id: 'postTaskResponse.body.id',
           })
           .expect(HttpStatus.BAD_REQUEST));
+    });
+    describe('GET /api/backlog/{id}', () => {
+      let projectId;
+      it('성공', async () => {
+        projectId = (await request(httpServer).post(PROJECT_URI).send({ name: '프로젝트' })).body.id;
+        const epicId = (await request(httpServer).post(EPIC_URI).send({ projectId: projectId, title: '타이틀2' })).body
+          .id;
+        const storyId = (await request(httpServer).post(STORY_URI).send({ epicId: epicId, title: 'title' })).body.id;
+        postTaskPayload.storyId = storyId;
+        const taskId = (await request(httpServer).post(TASK_URI).send(postTaskPayload)).body.id;
+        const getBacklogResponse = await request(httpServer)
+          .get(`${BACKLOG_URI}/${projectId}`)
+          .send()
+          .expect(HttpStatus.OK);
+
+        expect(getBacklogResponse.body.epicList[0].id).toBe(epicId);
+        expect(getBacklogResponse.body.epicList[0].storyList[0].id).toBe(storyId);
+        expect(getBacklogResponse.body.epicList[0].storyList[0].taskList[0].id).toBe(taskId);
+      });
+      it('존재하지 않는 프로젝트', async () => {
+        await request(httpServer)
+          .get(`${BACKLOG_URI}/${projectId + 1}`)
+          .send()
+          .expect(HttpStatus.NOT_FOUND);
+      });
+      it('잘못된 데이터 형식', async () => {
+        await request(httpServer).get(`${BACKLOG_URI}/aa`).send().expect(HttpStatus.BAD_REQUEST);
+      });
     });
   });
 });


### PR DESCRIPTION
## task 
LES-163 [BE] 프로젝트의 백로그데이터를 전달한다.

## 설명
### feat: [backlog-read] 백로그 읽기 API작성
    
    task: [BE] 프로젝트의 백로그데이터를 전달한다.
    1. RESPONSE DTO정의
    2. /backlogs/[id]경로에 서비스, 컨트롤러 매핑
    3. 프로젝트 없을경우 404처리
    4. 있을경우 데이터 만들어서 반환

### test: [backlog-read] /api/backlogs/[projectId] 테스트 작성
    
    1. 프로젝트로 백로그 찾는 테스트 작성

* 백로그를 찾는 API를 작성했습니다. id에 대한 유효성검사는 parseIntPipe로 했습니다.
* 백로그 데이터를 만들기위해 DB에 select를 많이 해야해서 이 부분을 조금 신경써서 Promise.all로 처리했습니다. 비효율적인 부분이나, 더 괜찮은 방법이 있으면 말씀해주시면 좋을것같아요 !