### PR TITLE
칸반보드 및 네비게이션 바 디자인 수정

### DIFF
--- a/FE/src/components/backlog/NavigationButton.tsx
+++ b/FE/src/components/backlog/NavigationButton.tsx
@@ -11,9 +11,7 @@ const NavigationButton = ({ pageName, description, pageURI, currentURI }: Naviga
   return (
     <Link
       to={pageURI}
-      className={`flex flex-col items-center gap-2.5 w-full ${
-        sameURL ? 'bg-true-white py-3 px-5 rounded-lg h-40' : 'py-3'
-      }`}
+      className={`flex flex-col items-center gap-2.5 ${sameURL ? 'bg-true-white py-3 px-5 rounded-lg h-40' : 'py-3'}`}
     >
       <p className={`text-lg font-bold ${sameURL ? 'text-house-green' : 'text-true-white'}`}>{pageName}</p>
       {sameURL && <p className="text-xs font-medium text-house-green">{description}</p>}

--- a/FE/src/components/backlog/SideNavigationBar.tsx
+++ b/FE/src/components/backlog/SideNavigationBar.tsx
@@ -27,7 +27,7 @@ const SideNavigationBar = () => {
   const currentURI = useLocation().pathname;
 
   return (
-    <nav className="flex flex-col items-center px-6 py-8 rounded-lg w-52 bg-house-green gap-2.5 mr-10">
+    <nav className="flex flex-col items-center px-6 py-8 rounded-lg w-52 bg-house-green gap-2.5 mr-10 min-w-[13.125rem] min-h-[calc(100vh-64px)] max-h-[calc(100vh-64px)] fixed">
       <div className="mb-5">
         <img src={lesserLogo} alt="로고" />
         <p className="text-xs font-medium text-true-white">적고 쉽고 애자일하게 일하자</p>
@@ -35,7 +35,7 @@ const SideNavigationBar = () => {
       <hr className="w-full h-px bg-true-white" />
       <ul>
         {navigationInformation.map(({ pageName, description, pageURI }) => (
-          <li key={pageName}>
+          <li key={pageName} className="max-w-[10rem]">
             <NavigationButton pageName={pageName} description={description} pageURI={pageURI} currentURI={currentURI} />
           </li>
         ))}
@@ -43,7 +43,7 @@ const SideNavigationBar = () => {
       <Link to={'project'} className="py-3 text-lg font-bold text-true-white">
         내 프로젝트
       </Link>
-      <button className="py-3 mb-12 text-lg font-bold text-true-white">로그아웃</button>
+      <button className="py-3 text-lg font-bold text-true-white">로그아웃</button>
     </nav>
   );
 };

--- a/FE/src/components/sprint/BoardHeader.tsx
+++ b/FE/src/components/sprint/BoardHeader.tsx
@@ -4,7 +4,7 @@ interface BaordHeaderProps {
   boardDescription: string;
 }
 const BoardHeader = ({ boardName, taskNumber, boardDescription }: BaordHeaderProps) => (
-  <div className="w-4/12 px-2.5 mb-2.5">
+  <div className="w-[18.75rem] px-2.5 mb-2.5">
     <p className="flex justify-between text-2xl font-bold text-house-green">
       <span>{boardName}</span>
       <span>{taskNumber}</span>

--- a/FE/src/components/sprint/ColumnBoard.tsx
+++ b/FE/src/components/sprint/ColumnBoard.tsx
@@ -6,7 +6,7 @@ interface ColumnBoardProps {
 }
 
 const ColumnBoard = ({ taskList }: ColumnBoardProps) => (
-  <ul className="flex flex-col w-4/12 min-h-full gap-3 p-5 border rounded-lg border-green-stroke">
+  <ul className="flex flex-col w-[18.75rem] min-h-full gap-3 p-5 border rounded-lg border-transparent-green">
     {taskList.map(({ id, title, userName, point }) => (
       <li>
         <TaskCard key={id} id={id} title={title} assignee={userName} point={point} />

--- a/FE/src/components/sprint/TaskCard.tsx
+++ b/FE/src/components/sprint/TaskCard.tsx
@@ -6,7 +6,7 @@ interface TaskCardProps {
 }
 
 const TaskCard = ({ id, title, assignee, point }: TaskCardProps) => (
-  <div className="flex flex-col gap-5 p-3 text-sm border rounded-lg border-green-stroke bg-cool-neutral">
+  <div className="flex flex-col gap-5 p-3 text-sm border rounded-lg border-transparent-green bg-cool-neutral">
     <p className="font-medium">{title}</p>
     <p className="flex justify-between text-starbucks-green">
       <span className="font-bold">{id}</span>

--- a/FE/src/pages/MainPage.tsx
+++ b/FE/src/pages/MainPage.tsx
@@ -3,7 +3,9 @@ import SideNavigationBar from '../components/backlog/SideNavigationBar';
 const MainPage = () => (
   <div className="flex p-8">
     <SideNavigationBar />
-    <Outlet />
+    <div className="ml-[15.75rem]">
+      <Outlet />
+    </div>
   </div>
 );
 

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -103,7 +103,7 @@ const SprintPage = () => {
   };
 
   return (
-    <section className="w-9/12">
+    <section className="min-w-[60.25rem]">
       <div className="flex mb-2.5">
         <h1 className="mr-2 text-2xl font-bold text-starbucks-green">스프린트 1</h1>
         <span className="self-end text-xs h-fit">백로그와 칸반보드가 보이는 이슈관리 프로토 타입을 만들자</span>


### PR DESCRIPTION
## Task

- [LES-164] 네비게이션 바 디자인 적용
- [LES-112] 칸반보드 렌더링 코드 작성

## 설명
- 칸반보드 페이지 width를 고정시켰습니다.
- 컬럼 보드와 태스크 카드 테두리 색 변경했습니다.
- 사이드 네비게이션 바의 높이가 항상 화면의 위, 아래와 32px 떨어지도록 고정했습니다.
- 스크롤이 생겨도 사이드 네비게이션 바의 위치는 고정되도록 했습니다.

![녹화_2023_11_23_11_47_30_746](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/33cc3ec7-3619-4fef-a4d3-d680ffa5d1fa)