### PR TITLE
/api/backlogs 기존 프로젝트 읽기 API작성

### DIFF
--- a/BE/src/projects/dto/Project.dto.ts
+++ b/BE/src/projects/dto/Project.dto.ts
@@ -13,3 +13,7 @@ class BaseProjectDto {
 
 export class CreateProjectRequestDto extends PickType(BaseProjectDto, ['name']) {}
 export class CreateProjectResponseDto extends PickType(BaseProjectDto, ['id']) {}
+
+export class ReadProjectListResponseDto extends BaseProjectDto {
+  nextPage: string;
+}

--- a/BE/src/projects/dto/Project.dto.ts
+++ b/BE/src/projects/dto/Project.dto.ts
@@ -9,9 +9,13 @@ class BaseProjectDto {
   @IsString()
   @IsNotEmpty()
   name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  subject: string;
 }
 
-export class CreateProjectRequestDto extends PickType(BaseProjectDto, ['name']) {}
+export class CreateProjectRequestDto extends PickType(BaseProjectDto, ['name', 'subject']) {}
 export class CreateProjectResponseDto extends PickType(BaseProjectDto, ['id']) {}
 
 export class ReadProjectListResponseDto extends BaseProjectDto {

--- a/BE/src/projects/entity/project.entity.ts
+++ b/BE/src/projects/entity/project.entity.ts
@@ -7,4 +7,7 @@ export class Project extends BaseEntity {
 
   @Column()
   name: string;
+
+  @Column()
+  subject: string;
 }

--- a/BE/src/projects/projects.controller.ts
+++ b/BE/src/projects/projects.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { CreateProjectRequestDto, CreateProjectResponseDto } from './dto/Project.dto';
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { CreateProjectRequestDto, CreateProjectResponseDto, ReadProjectListResponseDto } from './dto/Project.dto';
 import { ProjectsService } from './projects.service';
 
 @Controller('projects')
@@ -8,5 +8,10 @@ export class ProjectsController {
   @Post()
   createproject(@Body() body: CreateProjectRequestDto): Promise<CreateProjectResponseDto> {
     return this.projectsSevice.createProject(body);
+  }
+
+  @Get()
+  readProjectList(): Promise<ReadProjectListResponseDto[]> {
+    return this.projectsSevice.readProjectList();
   }
 }

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -9,7 +9,7 @@ export class ProjectsService {
   constructor(@InjectRepository(Project) private projectRespository: Repository<Project>) {}
 
   async createProject(dto: CreateProjectRequestDto): Promise<CreateProjectResponseDto> {
-    const newProject = this.projectRespository.create({ name: dto.name });
+    const newProject = this.projectRespository.create({ name: dto.name, subject: dto.subject });
     const savedProject = await this.projectRespository.save(newProject);
     return { id: savedProject.id };
   }
@@ -20,6 +20,7 @@ export class ProjectsService {
       const project = new ReadProjectListResponseDto();
       project.id = projectData.id;
       project.name = projectData.name;
+      project.subject = projectData.subject;
       project.nextPage = 'backlogs';
       return project;
     });

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -1,15 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateProjectRequestDto, CreateProjectResponseDto } from './dto/Project.dto';
+import { CreateProjectRequestDto, CreateProjectResponseDto, ReadProjectListResponseDto } from './dto/Project.dto';
 import { Project } from './entity/project.entity';
 
 @Injectable()
 export class ProjectsService {
   constructor(@InjectRepository(Project) private projectRespository: Repository<Project>) {}
+
   async createProject(dto: CreateProjectRequestDto): Promise<CreateProjectResponseDto> {
     const newProject = this.projectRespository.create({ name: dto.name });
     const savedProject = await this.projectRespository.save(newProject);
     return { id: savedProject.id };
+  }
+
+  async readProjectList(): Promise<ReadProjectListResponseDto[]> {
+    const projectListData = await this.projectRespository.find();
+    const projectList = projectListData.map((projectData) => {
+      const project = new ReadProjectListResponseDto();
+      project.id = projectData.id;
+      project.name = projectData.name;
+      project.nextPage = 'backlogs';
+      return project;
+    });
+    return projectList;
   }
 }


### PR DESCRIPTION
## task

## 설명
### feat: [backlog-read] /api/backlogs 기존 프로젝트 읽기 API작성
    
    1. 기존의 프로젝트를 모두 가져옴
    2. 추후 유저별로 찾도록 구현을 추가해야함
    
### feat: [project-read] 프로젝트에 subject 필드 추가
    
    1. project엔티티에 subject추가
    2. DTO에 subject 추가
    3. 서비스에 subject로직 추가

* GET /api/backlogs에서 기존 프로젝트 읽기를 데모이슈로 빠르게 구현했습니다.
* 우선 전체데이터를 보내게 해 놓았고, nextPage는 backlogs로 하드코딩해놓았습니다.
* project에 subject를 추가하는 요구사항을 알게되어서 추가해놓았습니다.
* 항상 감사합니다 ~