### PR TITLE
feat: [user-login] 깃허브 OAuth 회원가입/로그인

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -40,7 +40,7 @@ import { LesserJwtModule } from './common/lesser-jwt/lesser-jwt.module';
     SprintsModule,
     LesserJwtModule,
   ],
-  controllers: [AppController, SprintsController, MembersController, ReviewsController],
+  controllers: [AppController, SprintsController, ReviewsController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/BE/src/members/dto/login-request.dto.ts
+++ b/BE/src/members/dto/login-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class LoginRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+}

--- a/BE/src/members/dto/member.dto.ts
+++ b/BE/src/members/dto/member.dto.ts
@@ -1,0 +1,26 @@
+import { PickType } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+class BaseMemberDto {
+  @IsInt()
+  @IsNotEmpty()
+  id: number;
+
+  @IsString()
+  @IsNotEmpty()
+  github_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+
+  @IsString()
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  image_url: string;
+}
+
+export class GithubUser extends PickType(BaseMemberDto, ['github_id', 'username', 'email', 'image_url']) {}

--- a/BE/src/members/entities/member.entity.ts
+++ b/BE/src/members/entities/member.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from 'typeorm';
+import { Entity, BaseEntity, PrimaryGeneratedColumn, Column } from 'typeorm';
 
 @Entity()
 export class Member extends BaseEntity {
@@ -6,11 +6,14 @@ export class Member extends BaseEntity {
   id: number;
 
   @Column()
-  email: string;
+  github_id: string;
 
   @Column()
   username: string;
 
   @Column()
-  password: string;
+  email: string;
+
+  @Column()
+  image_url: string;
 }

--- a/BE/src/members/members.controller.ts
+++ b/BE/src/members/members.controller.ts
@@ -1,4 +1,13 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import { MembersService } from './members.service';
+import { LoginRequestDto } from './dto/login-request.dto';
 
 @Controller('members')
-export class MembersController {}
+export class MembersController {
+  constructor(private readonly membersService: MembersService) {}
+
+  @Post('login')
+  login(@Body() body: LoginRequestDto) {
+    return this.membersService.githubLogin(body);
+  }
+}

--- a/BE/src/members/members.module.ts
+++ b/BE/src/members/members.module.ts
@@ -1,7 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MembersService } from './members.service';
+import { Member } from './entities/member.entity';
+import { MembersController } from './members.controller';
+import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
 
 @Module({
-  providers: [MembersService]
+  imports: [TypeOrmModule.forFeature([Member]), LesserJwtModule],
+  controllers: [MembersController],
+  providers: [MembersService],
 })
 export class MembersModule {}

--- a/BE/src/members/members.service.ts
+++ b/BE/src/members/members.service.ts
@@ -1,4 +1,97 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Member } from './entities/member.entity';
+import { Repository } from 'typeorm';
+import { LoginRequestDto } from './dto/login-request.dto';
+import { GithubUser } from './dto/member.dto';
+import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
 
 @Injectable()
-export class MembersService {}
+export class MembersService {
+  constructor(
+    @InjectRepository(Member) private memberRepository: Repository<Member>,
+    private lesserJwtService: LesserJwtService,
+  ) {}
+
+  async githubLogin(dto: LoginRequestDto) {
+    const githubAccessToken = await this.getGithubAccessToken(dto.code);
+    const [githubUser, githubEmail] = await Promise.all([
+      this.fetchGithubUser(githubAccessToken),
+      this.fetchGithubEmail(githubAccessToken),
+    ]);
+    githubUser.email = githubEmail;
+    const { github_id } = githubUser;
+
+    const findMember = await this.memberRepository.findOne({ where: { github_id } });
+    let memberId = findMember ? findMember.id : null;   // user 정보 없으면 회원가입
+    if (!findMember) {
+      const newMember = this.memberRepository.create({
+        github_id: githubUser.github_id,
+        username: githubUser.username,
+        email: githubUser.email,
+        image_url: githubUser.image_url,
+      });
+      const savedMember = await this.memberRepository.save(newMember);
+      memberId = savedMember.id;
+    }
+
+    const [lesserAccessToken, lesserRefreshToken] = await Promise.all([
+      this.lesserJwtService.getAccessToken(memberId),
+      this.lesserJwtService.getRefreshToken(),
+    ]);
+    return {
+      accessToken: lesserAccessToken,
+      refreshToken: lesserRefreshToken,
+    };
+  }
+
+  async getGithubAccessToken(code: string) {
+    const body = {
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code: code,
+    };
+    const response = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const oauthData = await response.json();
+    const accessToken = oauthData.access_token;
+    return accessToken;
+  }
+
+  async fetchGithubUser(accessToken: string): Promise<GithubUser> {
+    const response = await fetch('https://api.github.com/user', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    const data = await response.json();
+    const githubUser: GithubUser = {
+      github_id: data.id,
+      username: data.login,
+      email: data.email,
+      image_url: data.avatar_url,
+    };
+    return githubUser;
+  }
+
+  async fetchGithubEmail(accessToken: string): Promise<string> {
+    const response = await fetch('https://api.github.com/user/emails', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    const data = await response.json();
+    const [primaryEmail] = data.filter((email) => email.primary === true);
+    return primaryEmail.email;
+  }
+}


### PR DESCRIPTION

## Task
LES-168 [BE] 깃허브 OAuth 회원가입
LES-169 [BE] 깃허브 OAuth 로그인

## 설명
- 로그인 API 구현: POST `/api/members/login`
  - 클라이언트로부터 auth code 값을 받아서 깃허브 Access Token 받아온다.
  - 깃허브 Access Token 사용하여 깃허브 API로 유저 정보를 요청해서 가져온다.
  - 우리 서비스의 회원인지 확인한다. 현재 로직에서는 회원이면 로그인, 회원이 아니면 회원가입
  - 우리 서비스의 `Lesser Access Token`, `Lesser Refresh Token` 발급하여 클라이언트에게 반환한다.

## 추후 보완할 점
- 우리 서비스 회원이 아닐시 회원가입하는 부분을 함수로 따로 빼는 것이 좋을 것 같다.