### PR TITLE
백로그 페이지 버그 및 디자인 수정

### DIFF
--- a/FE/src/components/backlog/TaskBlock.tsx
+++ b/FE/src/components/backlog/TaskBlock.tsx
@@ -32,16 +32,18 @@ const TaskBlock = ({ epicIndex, storyIndex, taskIndex, task, backlogState, setBa
 
   return (
     <div className="flex items-center justify-between border-t py-[0.563rem] pl-2.5 pr-[0.438rem] bg-white text-house-green text-r whitespace-nowrap">
-      <p className="flex gap-2.5">
+      <div className="flex items-center gap-2.5">
         <span className="w-16 font-bold">Task</span>
         {updateFormVisible ? (
-          <BlockForm
-            initialTitle={task.title}
-            placeholder="이 story를 구현하기 위한 구체적인 작업에는 어떤 것이 있나요? 예시) 로그인 페이지 UI 디자인"
-            formRef={formRef}
-            handleFormSubmit={(e) => handleFormSubmit(e, 'update', 'taskList')}
-            onClose={handleEditBlockButtonClick}
-          />
+          <div className="w-[33.75rem]">
+            <BlockForm
+              initialTitle={task.title}
+              placeholder="이 story를 구현하기 위한 구체적인 작업에는 어떤 것이 있나요? 예시) 로그인 페이지 UI 디자인"
+              formRef={formRef}
+              handleFormSubmit={(e) => handleFormSubmit(e, 'update', 'taskList')}
+              onClose={handleEditBlockButtonClick}
+            />
+          </div>
         ) : (
           <button
             className="w-[33.75rem] group flex gap-1 hover:underline items-center"
@@ -53,10 +55,10 @@ const TaskBlock = ({ epicIndex, storyIndex, taskIndex, task, backlogState, setBa
             </span>
           </button>
         )}
-      </p>
+      </div>
 
-      <p>{task.point} POINT</p>
-      <p>{task.userName}</p>
+      <span className="w-[6.25rem] truncate">{task.userName}</span>
+      <span className="w-[5rem] truncate">{task.point}POINT</span>
       <button className="flex items-center font-bold" onClick={handleAddBlockButtonClick}>
         상세보기 <ChevronRightIcon size={14} />
       </button>

--- a/FE/src/hooks/useBlock.tsx
+++ b/FE/src/hooks/useBlock.tsx
@@ -26,6 +26,7 @@ const useBlock = ({ block, setBlock, epicIndex, storyIndex, taskIndex }: BlockOp
   const handleOutsideClick = (e: MouseEvent) => {
     if (formRef.current && !formRef.current.contains(e.target as Node)) {
       setNewFormVisibility(false);
+      setUpdateFormVisibility(false);
     }
   };
 


### PR DESCRIPTION
## 설명
- 백로그 페이지 에픽 제목 수정과 스토리 생성을 동시에 할 수 없도록 수정
- 태스크를 수직으로 가운데 정렬하고 태스크 편집 폼, 담당자, 포인트 width 고정