### PR TITLE
백엔드 리팩토링

### DIFF
--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -5,7 +5,12 @@ import { Story } from 'src/backlogs/entities/story.entity';
 import { Task } from 'src/backlogs/entities/task.entity';
 import { Project } from 'src/projects/entity/project.entity';
 import { Repository } from 'typeorm';
-import { MTask, MEpic, MStory, ReadBacklogResponseDto } from './dto/backlog.dto';
+import {
+  ReadBacklogTaskResponseDto,
+  ReadBacklogEpicResponseDto,
+  ReadBacklogStoryResponseDto,
+  ReadBacklogResponseDto,
+} from './dto/backlog.dto';
 import {
   CreateBacklogsEpicRequestDto,
   CreateBacklogsEpicResponseDto,
@@ -49,39 +54,39 @@ export class BacklogsService {
     return project;
   }
 
-  private async findEpics(projectId: number): Promise<MEpic[]> {
+  private async findEpics(projectId: number): Promise<ReadBacklogEpicResponseDto[]> {
     const epicDataList = await this.epicRepository.find({ where: { project: { id: projectId } } });
     return Promise.all(epicDataList.map(async (epicData) => this.buildEpic(epicData)));
   }
 
-  private async buildEpic(epicData: Epic): Promise<MEpic> {
-    const epic = new MEpic();
+  private async buildEpic(epicData: Epic): Promise<ReadBacklogEpicResponseDto> {
+    const epic = new ReadBacklogEpicResponseDto();
     epic.id = epicData.id;
     epic.title = epicData.title;
     epic.storyList = await this.findStories(epic.id);
     return epic;
   }
 
-  private async findStories(epicId: number): Promise<MStory[]> {
+  private async findStories(epicId: number): Promise<ReadBacklogStoryResponseDto[]> {
     const storyDataList = await this.storyRepository.find({ where: { epic: { id: epicId } } });
     return Promise.all(storyDataList.map(async (storyData) => this.buildStory(storyData)));
   }
 
-  private async buildStory(storyData: Story): Promise<MStory> {
-    const story = new MStory();
+  private async buildStory(storyData: Story): Promise<ReadBacklogStoryResponseDto> {
+    const story = new ReadBacklogStoryResponseDto();
     story.id = storyData.id;
     story.title = storyData.title;
     story.taskList = await this.findTasks(story.id);
     return story;
   }
 
-  private async findTasks(storyId: number): Promise<MTask[]> {
+  private async findTasks(storyId: number): Promise<ReadBacklogTaskResponseDto[]> {
     const taskDataList = await this.taskRepository.find({ where: { story: { id: storyId } } });
     return taskDataList.map((taskData) => this.buildTask(taskData));
   }
 
-  private buildTask(taskData: Task): MTask {
-    const task = new MTask();
+  private buildTask(taskData: Task): ReadBacklogTaskResponseDto {
+    const task = new ReadBacklogTaskResponseDto();
     task.id = taskData.id;
     task.point = taskData.point;
     task.state = taskData.state;

--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -5,7 +5,7 @@ import { Story } from 'src/backlogs/entities/story.entity';
 import { Task } from 'src/backlogs/entities/task.entity';
 import { Project } from 'src/projects/entity/project.entity';
 import { Repository } from 'typeorm';
-import { MEpic, ReadBacklogResponseDto } from './dto/backlog.dto';
+import { MTask, MEpic, MStory, ReadBacklogResponseDto } from './dto/backlog.dto';
 import {
   CreateBacklogsEpicRequestDto,
   CreateBacklogsEpicResponseDto,
@@ -35,36 +35,60 @@ export class BacklogsService {
   ) {}
 
   async readBacklog(id: number): Promise<ReadBacklogResponseDto> {
-    const project = await this.projectRepository.findOne({ where: { id } });
-    if (project === null) throw new NotFoundException(`Project with ID ${id} not found`);
-    const backlog: ReadBacklogResponseDto = { epicList: [] };
-    const epicDataList = await this.epicRepository.find({ where: { project: { id: project.id } } });
-    epicDataList.forEach((epicData) => {
-      backlog.epicList.push({ id: epicData.id, title: epicData.title, storyList: [] });
-    });
-    await Promise.all(backlog.epicList.map((epic) => this.populateEpicWithStories(epic)));
+    const project = await this.findProject(id);
+    const backlog = new ReadBacklogResponseDto();
+    backlog.epicList = await this.findEpics(project.id);
     return backlog;
   }
 
-  private async populateEpicWithStories(epic: MEpic) {
-    const storyDataList = await this.storyRepository.find({ where: { epic: { id: epic.id } } });
-    await Promise.all(storyDataList.map((storyData) => this.populateStoryWithTasks(storyData, epic)));
+  private async findProject(id: number): Promise<Project> {
+    const project = await this.projectRepository.findOne({ where: { id } });
+    if (project === null) {
+      throw new NotFoundException(`Project with ID ${id} not found`);
+    }
+    return project;
   }
 
-  private async populateStoryWithTasks(storyData: Story, epic: MEpic) {
-    const story = { id: storyData.id, title: storyData.title, taskList: [] };
-    const taskDataList = await this.taskRepository.find({ where: { story: { id: story.id } } });
-    taskDataList.forEach((taskData) => {
-      story.taskList.push({
-        userName: null,
-        id: taskData.id,
-        title: taskData.title,
-        state: taskData.state,
-        point: taskData.point,
-        condition: taskData.condition,
-      });
-    });
-    epic.storyList.push(story);
+  private async findEpics(projectId: number): Promise<MEpic[]> {
+    const epicDataList = await this.epicRepository.find({ where: { project: { id: projectId } } });
+    return Promise.all(epicDataList.map(async (epicData) => this.buildEpic(epicData)));
+  }
+
+  private async buildEpic(epicData: Epic): Promise<MEpic> {
+    const epic = new MEpic();
+    epic.id = epicData.id;
+    epic.title = epicData.title;
+    epic.storyList = await this.findStories(epic.id);
+    return epic;
+  }
+
+  private async findStories(epicId: number): Promise<MStory[]> {
+    const storyDataList = await this.storyRepository.find({ where: { epic: { id: epicId } } });
+    return Promise.all(storyDataList.map(async (storyData) => this.buildStory(storyData)));
+  }
+
+  private async buildStory(storyData: Story): Promise<MStory> {
+    const story = new MStory();
+    story.id = storyData.id;
+    story.title = storyData.title;
+    story.taskList = await this.findTasks(story.id);
+    return story;
+  }
+
+  private async findTasks(storyId: number): Promise<MTask[]> {
+    const taskDataList = await this.taskRepository.find({ where: { story: { id: storyId } } });
+    return taskDataList.map((taskData) => this.buildTask(taskData));
+  }
+
+  private buildTask(taskData: Task): MTask {
+    const task = new MTask();
+    task.id = taskData.id;
+    task.point = taskData.point;
+    task.state = taskData.state;
+    task.condition = taskData.condition;
+    task.title = taskData.title;
+    task.userName = null; //추후 유저로직 추가
+    return task;
   }
 
   async createEpic(dto: CreateBacklogsEpicRequestDto): Promise<CreateBacklogsEpicResponseDto> {

--- a/BE/src/backlogs/dto/backlog.dto.ts
+++ b/BE/src/backlogs/dto/backlog.dto.ts
@@ -1,18 +1,18 @@
 import { OmitType, PickType } from '@nestjs/swagger';
 import { baseEpicDto, baseStoryDto, baseTaskDto } from './baseType.dto';
 
-export class MTask extends OmitType(baseTaskDto, ['storyId', 'userId']) {
+export class ReadBacklogTaskResponseDto extends OmitType(baseTaskDto, ['storyId', 'userId']) {
   userName: string;
 }
 
-export class MStory extends PickType(baseStoryDto, ['id', 'title']) {
-  taskList: MTask[];
+export class ReadBacklogStoryResponseDto extends PickType(baseStoryDto, ['id', 'title']) {
+  taskList: ReadBacklogTaskResponseDto[];
 }
 
-export class MEpic extends PickType(baseEpicDto, ['id', 'title']) {
-  storyList: MStory[];
+export class ReadBacklogEpicResponseDto extends PickType(baseEpicDto, ['id', 'title']) {
+  storyList: ReadBacklogStoryResponseDto[];
 }
 
 export class ReadBacklogResponseDto {
-  epicList: MEpic[];
+  epicList: ReadBacklogEpicResponseDto[];
 }

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -7,7 +7,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('api');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
-  app.enableCors();
+  //추후에 origin을 Lesser사이트로 변경
+  app.enableCors({ origin: true, credentials: true });
 
   const config = new DocumentBuilder()
     .setTitle('Lesser API')


### PR DESCRIPTION
## 설명

### refector: [project-read] 유저의 프로젝트 조회 코드 리팩토링
    
    1. 유저의 태스크수를 구하는 로직을 2중 for루프 구조에서 비동기 map형태로 변경

### refactor: 백로그 조회 리팩토링
    
    1. readBacklog 함수분리
    2. forEach로 되어있었던 부분 map으로 변경
    3. 객체생성을 객체 리터럴에서 new로 변경

### refector: [backlog-read] 백로그DTO 이름변경
    
    1. ReadBacklogResponseDto가 nest하게 가지고있는 epic, story, task에 대해 적용하였다
    2. ex) MEpic -> ReadBacklogEpicResponseDto

### fix: [cors] CORS 세팅변경
    
    1. 기존에 전체허용하던 설정을, 접속한 사용자 개개인을 허용하는 설정으로 변경
    2. credential을 true로 설정

* 서정님이 이전에 말씀해주셨던 JOIN해 한번에 쿼리를 뽑아내는 방식도 고려중입니다. 트러블냉장고에 넣어놓고 추후에 공부가 끝나면 변경할지, 그대로 할지를 생각해보겠습니다 !
* 항상 감사합니다.