### PR TITLE
로그인 회원 정보를 메모리에 저장, 로그아웃 및 토큰 리프레쉬 구현

### DIFF
--- a/BE/src/members/dto/tokens.dto.ts
+++ b/BE/src/members/dto/tokens.dto.ts
@@ -1,0 +1,1 @@
+export type Tokens = { accessToken: string; refreshToken: string };

--- a/BE/src/members/members.service.ts
+++ b/BE/src/members/members.service.ts
@@ -83,48 +83,59 @@ export class MembersService {
       client_secret: this.configService.get('GITHUB_CLIENT_SECRET'),
       code: code,
     };
-    const response = await fetch('https://github.com/login/oauth/access_token', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-    const oauthData = await response.json();
-    const accessToken = oauthData.access_token;
-    return accessToken;
+    try {
+      const response = await fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const oauthData = await response.json();
+      const accessToken = oauthData.access_token;
+      return accessToken;
+    } catch (err) {
+      throw new Error(err.message);
+    }
   }
 
   async fetchGithubUser(accessToken: string): Promise<GithubUser> {
-    const response = await fetch('https://api.github.com/user', {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    const data = await response.json();
-    const githubUser: GithubUser = {
-      github_id: data.id,
-      username: data.login,
-      email: data.email,
-      image_url: data.avatar_url,
-    };
-    return githubUser;
+    try {
+      const response = await fetch('https://api.github.com/user', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      const data = await response.json();
+      const githubUser: GithubUser = {
+        github_id: data.id,
+        username: data.login,
+        email: data.email,
+        image_url: data.avatar_url,
+      };
+      return githubUser;
+    } catch (err) {
+      throw new Error(err.message);
+    }
   }
 
   async fetchGithubEmail(accessToken: string): Promise<string> {
-    const response = await fetch('https://api.github.com/user/emails', {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    const emailList = await response.json();
-    if (!Array.isArray(emailList)) throw new Error('Email list is not an array.');
-    const primaryEmail = emailList.find((email) => email.primary === true);
-    return primaryEmail.email;
+    try {
+      const response = await fetch('https://api.github.com/user/emails', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      const emailList = await response.json();
+      const primaryEmail = emailList.find((email) => email.primary === true);
+      return primaryEmail.email;
+    } catch (err) {
+      throw new Error(err.message);
+    }
   }
 }


### PR DESCRIPTION
## 설명
1. 로그인하면 메모리에 refresh token(key), 회원 id(value)를 Map 구조에 저장
2. 로그아웃하면 메모리의 회원 로그인 정보 삭제
3. 리프레쉬 요청시 기존 로그인 정보 삭제, 새로 발급한 refresh token으로 로그인 정보 저장