### PR TITLE
로그인 로직 수정

### DIFF
--- a/FE/src/apis/api.ts
+++ b/FE/src/apis/api.ts
@@ -27,7 +27,7 @@ const requestFail = async (error: AxiosError) => {
   }
 
   // 액세스 토큰 만료 지남
-  if (status === 401 && message === 'expired token') {
+  if (status === 401 && (message === 'expired token' || refreshToken)) {
     try {
       const response = await api.post('/member/refresh', {
         headers: {
@@ -41,7 +41,6 @@ const requestFail = async (error: AxiosError) => {
     }
   }
 
-  // 그냥 다시 로그인해야하는 상황
   if (status === 401) {
     return Promise.reject(newError);
   }
@@ -64,7 +63,7 @@ const refreshSucceed = async (response: AxiosResponse, config: InternalAxiosRequ
 };
 
 const refreshFail = (error: AxiosError) => {
-  const newError = structuredClone(error);
+  const newError = error;
   sessionStorage.removeItem('refresh-token');
   newError.status = 401;
   newError.message = '';


### PR DESCRIPTION
## 설명

- 토큰 갱신 과정에서 오류가 나던 부분을 수정했습니다. 
  - 모든 실패 응답에서 accesstoken을 undefined로 변경하던 것을 401 에러가 발생했을 때만 변경하는 것으로 수정했습니다.
  - structuredClone을 사용해 에러가 나던 것을 수정했습니다.