### PR TITLE
칸반보드 드래그 앤 드롭 구현

### DIFF
--- a/FE/src/components/sprint/ColumnBoard.tsx
+++ b/FE/src/components/sprint/ColumnBoard.tsx
@@ -1,18 +1,30 @@
 import TaskCard from './TaskCard';
-import { Task } from '../../types/sprint';
+import { Task, TaskState } from '../../types/sprint';
+import useKanbanDrag from '../../hooks/useKanbanDrag';
 
 interface ColumnBoardProps {
   taskList: Task[];
+  state: TaskState;
+  storyId?: number;
+  setTaskList: React.Dispatch<React.SetStateAction<Task[]>>;
 }
 
-const ColumnBoard = ({ taskList }: ColumnBoardProps) => (
-  <ul className="flex flex-col w-[18.75rem] min-h-full gap-3 p-5 border rounded-lg border-transparent-green">
-    {taskList.map(({ id, title, userName, point }) => (
-      <li key={id}>
-        <TaskCard id={id} title={title} assignee={userName} point={point} />
-      </li>
-    ))}
-  </ul>
-);
+const ColumnBoard = ({ taskList, state, storyId, setTaskList }: ColumnBoardProps) => {
+  const { handleDragStart, handleDragOver, handleDragDrop } = useKanbanDrag(setTaskList);
+
+  return (
+    <ul
+      className="flex flex-col w-[18.75rem] min-h-full gap-3 p-5 border rounded-lg border-transparent-green"
+      onDragOver={handleDragOver}
+      onDrop={(e) => handleDragDrop(e, state, storyId)}
+    >
+      {taskList.map(({ id, title, userName, point, storyId }) => (
+        <li key={id}>
+          <TaskCard {...{ title, userName, point, id, storyId }} onDragStart={handleDragStart} />
+        </li>
+      ))}
+    </ul>
+  );
+};
 
 export default ColumnBoard;

--- a/FE/src/components/sprint/KanbanBoard.tsx
+++ b/FE/src/components/sprint/KanbanBoard.tsx
@@ -1,27 +1,19 @@
-import { Task } from '../../types/sprint';
-import ColumnBoard from './ColumnBoard';
-
 interface KanbanBoardProps {
   storyTitle?: string;
-  storyId?: string;
-  todoList: Task[];
-  inProgressList: Task[];
-  doneList: Task[];
+  storyId?: number;
+  storyNumber?: number;
+  children: React.ReactNode;
 }
 
-const KanbanBoard = ({ storyId, storyTitle, todoList, inProgressList, doneList }: KanbanBoardProps) => (
+const KanbanBoard = ({ storyTitle, storyNumber, children }: KanbanBoardProps) => (
   <div>
     {storyTitle && (
       <p className="flex items-center gap-2 mb-2.5">
-        <span className="text-sm font-bold text-starbucks-green">{storyId}</span>
+        <span className="text-sm font-bold text-starbucks-green">LES-{storyNumber}</span>
         <span className="text-xs font-medium ">{storyTitle}</span>
       </p>
     )}
-    <div className="flex justify-between gap-8">
-      <ColumnBoard taskList={todoList} />
-      <ColumnBoard taskList={inProgressList} />
-      <ColumnBoard taskList={doneList} />
-    </div>
+    <div className="flex justify-between gap-8">{children}</div>
   </div>
 );
 

--- a/FE/src/components/sprint/TaskCard.tsx
+++ b/FE/src/components/sprint/TaskCard.tsx
@@ -1,16 +1,22 @@
 interface TaskCardProps {
   id: number;
   title: string;
-  assignee?: string;
+  userName?: string;
   point: number;
+  storyId: number;
+  onDragStart: (e: React.DragEvent, id: number, storyId: number) => void;
 }
 
-const TaskCard = ({ id, title, assignee, point }: TaskCardProps) => (
-  <div className="flex flex-col gap-5 p-3 text-sm border rounded-lg border-transparent-green bg-cool-neutral">
+const TaskCard = ({ id, title, userName, point, storyId, onDragStart }: TaskCardProps) => (
+  <div
+    className="flex flex-col gap-5 p-3 text-sm border rounded-lg border-transparent-green bg-cool-neutral"
+    draggable
+    onDragStart={(e) => onDragStart(e, id, storyId)}
+  >
     <p className="font-medium">{title}</p>
     <p className="flex justify-between text-starbucks-green">
       <span className="font-bold">{id}</span>
-      <span>{assignee}</span>
+      <span>{userName}</span>
       <span>{point} point</span>
     </p>
   </div>

--- a/FE/src/data/sprint.json
+++ b/FE/src/data/sprint.json
@@ -1,0 +1,70 @@
+{
+  "taskList": [
+    {
+      "id": 1,
+      "title": "피카피카하고 운다",
+      "userId": 1,
+      "userName": "피카츄",
+      "point": 3,
+      "state": "ToDo",
+      "storyId": 2,
+      "storyNumber": 235,
+      "storyTitle": "울 수 있다.",
+      "condition": "피카피카가 귀여워야 한다."
+    },
+    {
+      "id": 2,
+      "title": "불뿜기",
+      "userId": 2,
+      "userName": "파이리",
+      "point": 2,
+      "state": "ToDo",
+      "storyId": 1,
+      "storyNumber": 235,
+      "storyTitle": "능력을 사용할 수 있다.",
+      "condition": "불을 뿜어야한다."
+    },
+    {
+      "id": 3,
+      "title": "몸통박치기",
+      "userId": 3,
+      "userName": "꼬부기",
+      "point": 3,
+      "state": "ToDo",
+      "storyId": 1,
+      "storyNumber": 235,
+      "storyTitle": "능력을 사용할 수 있다.",
+      "condition": "데미지를 줘야 한다."
+    },
+    {
+      "id": 4,
+      "title": "잠자기",
+      "userId": 4,
+      "userName": "잠만보",
+      "point": 3,
+      "state": "ToDo",
+      "storyId": 3,
+      "storyNumber": 235,
+      "storyTitle": "잘 수 있다.",
+      "condition": "잠을 자야한다."
+    },
+    {
+      "id": 5,
+      "title": "백만볼트 공격하기",
+      "userId": 1,
+      "userName": "피카츄",
+      "point": 3,
+      "state": "ToDo",
+      "storyId": 1,
+      "storyNumber": 235,
+      "storyTitle": "능력을 사용할 수 있다.",
+      "condition": "찌릿찌릿해야 한다."
+    }
+  ],
+  "sprintEnd": true,
+  "sprintModal": false,
+  "sprintTitle": "스프린트 1",
+  "sprintEndDate": "23-11-12",
+  "sprintstartDate": "23-11-11",
+  "sprintGoal": "스케이트보드 만들기"
+}

--- a/FE/src/hooks/useKanbanDrag.tsx
+++ b/FE/src/hooks/useKanbanDrag.tsx
@@ -1,0 +1,29 @@
+import { Task, TaskState } from '../types/sprint';
+
+const useKanbanDrag = (setTaskList: React.Dispatch<React.SetStateAction<Task[]>>) => {
+  const handleDragStart = (e: React.DragEvent, id: number, storyId: number) => {
+    e.dataTransfer.setData('taskData', JSON.stringify({ id, storyId }));
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  const handleDragDrop = (e: React.DragEvent, state: TaskState, boardStoryId: number | undefined = undefined) => {
+    const { id: taskId, storyId } = JSON.parse(e.dataTransfer.getData('taskData'));
+
+    if (boardStoryId && storyId !== boardStoryId) {
+      return;
+    }
+
+    setTaskList((taskList: Task[]) => {
+      const targetTask = taskList.filter(({ id }) => id === taskId)[0];
+      targetTask.state = state;
+      return [...taskList.filter(({ id }) => id !== taskId), targetTask];
+    });
+  };
+
+  return { handleDragDrop, handleDragStart, handleDragOver };
+};
+
+export default useKanbanDrag;

--- a/FE/src/hooks/useKanbanDrag.tsx
+++ b/FE/src/hooks/useKanbanDrag.tsx
@@ -10,6 +10,12 @@ const useKanbanDrag = (setTaskList: React.Dispatch<React.SetStateAction<Task[]>>
   };
 
   const handleDragDrop = (e: React.DragEvent, state: TaskState, boardStoryId: number | undefined = undefined) => {
+    const taskData = e.dataTransfer.getData('taskData');
+
+    if (!taskData) {
+      return;
+    }
+
     const { id: taskId, storyId } = JSON.parse(e.dataTransfer.getData('taskData'));
 
     if (boardStoryId && storyId !== boardStoryId) {

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -2,11 +2,17 @@ export type TaskGroup = 'all' | 'story';
 
 export type UserFilter = '전체' | string;
 
+export type TaskState = 'ToDo' | 'InProgress' | 'Done';
+
 export interface Task {
   id: number;
   title: string;
+  userId: number;
   userName: string;
   point: number;
-  state: 'ToDo' | 'InProgress' | 'Done';
+  state: TaskState;
+  storyId: number;
+  storyNumber: number;
   storyTitle: string;
+  condition: string;
 }


### PR DESCRIPTION
## Task

- [LES-185] 드래그 앤 드롭을 구현한다.

## 설명
- 칸반보드에서 드래그 앤 드롭을 구현했습니다.
- Drag and Drop API를 이용해서 dragEvent를 통해 구현했습니다.
- 다른 스토리 그룹의 보드로 이동하지 못하도록 했습니다.

## 고민한 점
- 아직 API가 없어서 data 폴더에 데이터를 넣어 놓고 axios로 가져와서 state에 저장해주는 방식으로 진행했습니다.
- 드래그 앤 드롭 기능을 넣으면서 ColumnBoard에 전달해야 할 프롭들이 더 생겨났는데, KanbanBoard 자체에서 사용하는 props보다 ColumnBoard로 넘겨주는 props들이 더 많아져서 children을 이용하는 방식으로 변경했습니다. 두 단계만 내려가면 되기는 하지만 최대한 props만 전달하게 되는 걸 줄이고자 이렇게 했습니다.

![녹화_2023_11_28_16_35_10_916](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/3900c5e1-83b6-4e50-ade2-12658ee8bb23)