### PR TITLE
프로젝트, 백로그 유저 인가

### DIFF
--- a/BE/src/backlogs/backlogs.controller.ts
+++ b/BE/src/backlogs/backlogs.controller.ts
@@ -61,47 +61,79 @@ export class BacklogsController {
   }
 
   @Put('epic')
-  async updateEpic(@Body() body: UpdateBacklogsEpicRequestDto): Promise<Record<string, never>> {
+  async updateEpic(
+    @Body() body: UpdateBacklogsEpicRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<Record<string, never>> {
+    await this.backlogsAuthService.checkEpicAuth(body.id, memberInfo);
     await this.backlogsService.updateEpic(body);
     return {};
   }
 
   @Delete('epic')
-  async DeleteEpic(@Body() body: DeleteBacklogsEpicRequestDto): Promise<Record<string, never>> {
+  async DeleteEpic(
+    @Body() body: DeleteBacklogsEpicRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<Record<string, never>> {
+    await this.backlogsAuthService.checkEpicAuth(body.id, memberInfo);
     await this.backlogsService.deleteEpic(body);
     return {};
   }
 
   @Post('story')
-  async createStory(@Body() body: CreateBacklogsStoryRequestDto): Promise<CreateBacklogsStoryResponseDto> {
+  async createStory(
+    @Body() body: CreateBacklogsStoryRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<CreateBacklogsStoryResponseDto> {
+    await this.backlogsAuthService.checkEpicAuth(body.epicId, memberInfo);
     return this.backlogsService.createStory(body);
   }
 
   @Put('story')
-  async updateStory(@Body() body: UpdateBacklogsStoryRequestDto): Promise<Record<string, never>> {
+  async updateStory(
+    @Body() body: UpdateBacklogsStoryRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<Record<string, never>> {
+    await this.backlogsAuthService.checkStoryAuth(body.id, memberInfo);
     await this.backlogsService.updateStory(body);
     return {};
   }
 
   @Delete('story')
-  async DeleteStory(@Body() body: DeleteBacklogsStoryRequestDto): Promise<Record<string, never>> {
+  async DeleteStory(
+    @Body() body: DeleteBacklogsStoryRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<Record<string, never>> {
+    await this.backlogsAuthService.checkStoryAuth(body.id, memberInfo);
     await this.backlogsService.deleteStory(body);
     return {};
   }
 
   @Post('task')
-  async createTask(@Body() body: CreateBacklogsTaskRequestDto): Promise<CreateBacklogsTaskResponseDto> {
+  async createTask(
+    @Body() body: CreateBacklogsTaskRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<CreateBacklogsTaskResponseDto> {
+    await this.backlogsAuthService.checkStoryAuth(body.storyId, memberInfo);
     return this.backlogsService.createTask(body);
   }
 
   @Patch('task')
-  async updateTask(@Body() body: UpdateBacklogsRequestTaskDto): Promise<Record<string, never>> {
+  async updateTask(
+    @Body() body: UpdateBacklogsRequestTaskDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<Record<string, never>> {
+    await this.backlogsAuthService.checkTaskAuth(body.id, memberInfo);
     await this.backlogsService.updateTask(body);
     return {};
   }
 
   @Delete('task')
-  async DeleteTask(@Body() body: DeleteBacklogsTaskRequestDto): Promise<Record<string, never>> {
+  async DeleteTask(
+    @Body() body: DeleteBacklogsTaskRequestDto,
+    @Member() memberInfo: memberDecoratorType,
+  ): Promise<Record<string, never>> {
+    await this.backlogsAuthService.checkTaskAuth(body.id, memberInfo);
     await this.backlogsService.deleteTask(body);
     return {};
   }

--- a/BE/src/backlogs/backlogs.module.ts
+++ b/BE/src/backlogs/backlogs.module.ts
@@ -7,10 +7,11 @@ import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
 import { Project } from 'src/projects/entity/project.entity';
 import { BacklogsController } from './backlogs.controller';
 import { BacklogsService } from './backlogs.service';
+import { BacklogsAuthService } from './backlogsAuth.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Epic, Story, Task, Project]), LesserJwtModule],
   controllers: [BacklogsController],
-  providers: [BacklogsService],
+  providers: [BacklogsService, BacklogsAuthService],
 })
 export class BacklogsModule {}

--- a/BE/src/backlogs/backlogsAuth.service.ts
+++ b/BE/src/backlogs/backlogsAuth.service.ts
@@ -1,0 +1,29 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { memberDecoratorType } from 'src/common/types/memberDecorator.type';
+import { Project } from 'src/projects/entity/project.entity';
+import { Repository } from 'typeorm';
+import { Epic } from './entities/epic.entity';
+import { Story } from './entities/story.entity';
+import { Task } from './entities/task.entity';
+
+@Injectable()
+export class BacklogsAuthService {
+  constructor(
+    @InjectRepository(Project) private projectRepository: Repository<Project>,
+    @InjectRepository(Epic) private epicRepository: Repository<Epic>,
+    @InjectRepository(Story) private storyRepository: Repository<Story>,
+    @InjectRepository(Task) private taskRepository: Repository<Task>,
+  ) {}
+  async checkProjectAuth(projectId: number, memberInfo: memberDecoratorType) {
+    const project = await this.projectRepository.findOne({ where: { id: projectId }, relations: ['members'] });
+    if (project === null) throw new NotFoundException(`Project with ID ${projectId} not found`);
+    const isMember = project.members.some((member) => member.id === memberInfo.id);
+    if (!isMember) throw new ForbiddenException();
+  }
+  async checkEpicAuth(epicId: number, memberInfo: memberDecoratorType) {
+    // await this.epicRepository();
+  }
+  async checkStoryAuth(storyId: number, memberInfo: memberDecoratorType) {}
+  async checkTaskAuth(taskId: number, memberInfo: memberDecoratorType) {}
+}

--- a/BE/src/members/entities/member.entity.ts
+++ b/BE/src/members/entities/member.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, BaseEntity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Project } from 'src/projects/entity/project.entity';
+import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, ManyToMany } from 'typeorm';
 
 @Entity()
 export class Member extends BaseEntity {
@@ -16,4 +17,7 @@ export class Member extends BaseEntity {
 
   @Column()
   image_url: string;
+
+  @ManyToMany(() => Project, (Project) => Project.members)
+  projects: Project[];
 }

--- a/BE/src/projects/entity/project.entity.ts
+++ b/BE/src/projects/entity/project.entity.ts
@@ -12,7 +12,7 @@ export class Project extends BaseEntity {
   @Column()
   subject: string;
 
-  @ManyToMany(() => Member)
-  @JoinTable()
+  @ManyToMany(() => Member, (Member) => Member.projects)
+  @JoinTable({ name: 'Member_Project' })
   members: Member[];
 }

--- a/BE/src/projects/projects.controller.ts
+++ b/BE/src/projects/projects.controller.ts
@@ -18,7 +18,7 @@ export class ProjectsController {
   }
 
   @Get()
-  readProjectList(): Promise<ReadProjectListResponseDto[]> {
-    return this.projectsSevice.readProjectList();
+  readProjectList(@Member() memberInfo: memberDecoratorType): Promise<ReadProjectListResponseDto[]> {
+    return this.projectsSevice.readProjectList(memberInfo);
   }
 }

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -31,8 +31,13 @@ export class ProjectsService {
     return { id: savedProject.id };
   }
 
-  async readProjectList(): Promise<ReadProjectListResponseDto[]> {
-    const projectListData = await this.projectRespository.find();
+  async readProjectList(memberInfo: memberDecoratorType): Promise<ReadProjectListResponseDto[]> {
+    const projectListData = await this.projectRespository
+      .createQueryBuilder('project')
+      .innerJoinAndSelect('project.members', 'members')
+      .where('members.id = :id', { id: memberInfo.id })
+      .getMany();
+
     const projectList = Promise.all(
       projectListData.map(async (projectData) => {
         const project = new ReadProjectListResponseDto();


### PR DESCRIPTION
## Task
LES-151 [BE]유저가 가지고있는 프로젝트의 목록을 반환한다.
LES-150 [BE] 프로젝트 데이터가 유효하지 않거나 권한이 없을때 실패한다
LES-68 [BE] 에픽생성이 실패했을때 실패이유를 반환한다.
LES-71 [BE] 스토리 생성이 실패했을때 실패이유를 반환한다.
LES-74 [BE] 태스크 생성이 실패했을때 실패이유를 반환한다.

## 설명
### feat: [project-create] 프로젝트 생성, 조회 멤버 
엔티티와 연동
    
    1. 멤버, 유저 엔티티에 반대편 엔티티와 멤버 명시
    2. 프로젝트 추가할 때 유저-프로젝트 테이블에 유저 + 프로젝트 정보 추가하도록 변경
    3. 프로젝트 조회시 유저의 프로젝트만 조회할 수 있도록 변경

### feat: [backlog-read] project 인가처리
    
    1. 백로그에 백로그 인가하는 서비스생성
    2. 프로젝트 존재여부, 프로젝트 인가가능 확인해 
적절한 에러를 던짐

### feat: [backlog-read] 백로그 인가처리
    
    1. backlogAuth 서비스에 프로젝트, 에픽, 스토리, 태스크 인가로직 작성
    2. 컨트롤러 엔드포인트 각각에 데이터 형태에 맞는 인가서비스 사용

* 프로젝트 생성시 로그인 한 멤버가 프로젝트-멤버 테이블에 추가되게 했습니다.
* 프로젝트 조회시 로그인 한 멤버의 프로젝트만 조회되도록 했습니다.
* 백로그(에픽, 태스크, 스토리) 접근시 권한을 확인하게 했습니다.
* 백로그에서 사용자가 접근하는 리소스가 없는지 혹은 권한이 없는지를 구분하지 못하게 403 forbidden으로 통일했습니다.
* 항상감사합니다.