### PR TITLE
프로젝트, 백로그 API를 멤버와 연동

### DIFF
--- a/BE/src/backlogs/backlogs.module.ts
+++ b/BE/src/backlogs/backlogs.module.ts
@@ -4,13 +4,14 @@ import { Epic } from 'src/backlogs/entities/epic.entity';
 import { Story } from 'src/backlogs/entities/story.entity';
 import { Task } from 'src/backlogs/entities/task.entity';
 import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
+import { Member } from 'src/members/entities/member.entity';
 import { Project } from 'src/projects/entity/project.entity';
 import { BacklogsController } from './backlogs.controller';
 import { BacklogsService } from './backlogs.service';
 import { BacklogsAuthService } from './backlogsAuth.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Epic, Story, Task, Project]), LesserJwtModule],
+  imports: [TypeOrmModule.forFeature([Epic, Story, Task, Project, Member]), LesserJwtModule],
   controllers: [BacklogsController],
   providers: [BacklogsService, BacklogsAuthService],
 })

--- a/BE/src/backlogs/dto/backlog.dto.ts
+++ b/BE/src/backlogs/dto/backlog.dto.ts
@@ -1,9 +1,7 @@
 import { OmitType, PickType } from '@nestjs/swagger';
 import { baseEpicDto, baseStoryDto, baseTaskDto } from './baseType.dto';
 
-export class ReadBacklogTaskResponseDto extends OmitType(baseTaskDto, ['storyId', 'userId']) {
-  userName: string;
-}
+export class ReadBacklogTaskResponseDto extends OmitType(baseTaskDto, ['storyId']) {}
 
 export class ReadBacklogStoryResponseDto extends PickType(baseStoryDto, ['id', 'title']) {
   taskList: ReadBacklogTaskResponseDto[];

--- a/BE/src/backlogs/dto/baseType.dto.ts
+++ b/BE/src/backlogs/dto/baseType.dto.ts
@@ -1,4 +1,5 @@
-import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Validate, ValidateIf } from 'class-validator';
+import { IsNullOrIntAndNotEmpty } from 'src/common/decorators/IsNullOrIntDecorator';
 
 export class baseEpicDto {
   @IsInt()
@@ -41,9 +42,8 @@ export class baseTaskDto {
   @IsNotEmpty()
   title: string;
 
-  @IsInt()
-  @IsOptional()
-  userId?: number;
+  @Validate(IsNullOrIntAndNotEmpty)
+  userId: number | null;
 
   @IsString()
   @IsNotEmpty()

--- a/BE/src/backlogs/entities/task.entity.ts
+++ b/BE/src/backlogs/entities/task.entity.ts
@@ -1,3 +1,4 @@
+import { Member } from 'src/members/entities/member.entity';
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, ManyToOne } from 'typeorm';
 import { Story } from './story.entity';
 
@@ -18,8 +19,8 @@ export class Task extends BaseEntity {
   @Column()
   condition: string;
 
-  @Column({ nullable: true })
-  userId: number;
+  @ManyToOne(() => Member, (Member) => Member.id, { nullable: true })
+  member: Member;
 
   @ManyToOne(() => Story, (Story) => Story.id, { nullable: false, onDelete: 'CASCADE' })
   story: Story;

--- a/BE/src/common/decorators/IsNullOrIntDecorator.ts
+++ b/BE/src/common/decorators/IsNullOrIntDecorator.ts
@@ -1,0 +1,13 @@
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+
+@ValidatorConstraint({ name: 'IsNullOrIntAndNotEmpty', async: false })
+export class IsNullOrIntAndNotEmpty implements ValidatorConstraintInterface {
+  validate(data: any, args: ValidationArguments) {
+    if (data === null || typeof data === 'number') return true;
+    return false;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return 'data ($value) is Not undefined and must null or int';
+  }
+}

--- a/BE/src/projects/dto/Project.dto.ts
+++ b/BE/src/projects/dto/Project.dto.ts
@@ -18,7 +18,12 @@ class BaseProjectDto {
 export class CreateProjectRequestDto extends PickType(BaseProjectDto, ['name', 'subject']) {}
 export class CreateProjectResponseDto extends PickType(BaseProjectDto, ['id']) {}
 
+export class ReadUserResponseDto {
+  userId: number;
+  userName: string;
+}
 export class ReadProjectListResponseDto extends BaseProjectDto {
   nextPage: string;
   myTaskCount: number;
+  userList: ReadUserResponseDto[];
 }


### PR DESCRIPTION
## task
LES-92 [BE] 태스크의 담당자를 추가, 수정할 수 있다.

## 설명
### feat: [project-read] 유저의 기존 프로젝트 리스트 조회에 프로젝트 멤버데이터 추가
    
    1. readProjectListResponseDTO에 유저DTO추가
    2. 프로젝트 서비스에서 프로젝트 목록 조회시 유저정보 함께 넘기게 추가

### feat: [backlog-read] null이나 int값을 받는 커스텀 데코레이터 정의

### feat: [backlog-read] 태스크담당자와 멤버 엔티티 연동
    
    1. 태스크 API에 userId제약조건을 notempty, int or null로 변경
    2. 백로그조회시 태스크의 담당자의 아이디를 반환하도록 변경
    3. 태스크 추가시 태스크의 담당자정보를 null or int로 받도록 추가
    4. 태스크 수정시 태스크의 담당자정보를 다룰수있도록 변경

* 태스크 담당자 추가 OR 수정시 해당 담당자가 프로젝트의 소속인지 확인하는 로직이 필요합니다.
* 트러블 냉장고에 넣어놓았고, 주말중에 수정하겠습니다.
* 항상감사합니다.