### PR TITLE
feat: 모달을 사용하기 위한 모듈 개발

### DIFF
--- a/FE/src/modal/ModalProvider.tsx
+++ b/FE/src/modal/ModalProvider.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { ReactElement, ReactNode, createContext, useCallback, useMemo, useState } from "react";
+
+interface ModalProviderProps {
+  children: ReactElement;
+}
+
+export const ModalContext = createContext<{
+  mount(id: string, element: ReactNode): void;
+  unmount(id: string): void;
+} | null>(null);
+
+export const ModalProvider = ({ children }: ModalProviderProps) => {
+  const [modalMapById, setModalMapById] = useState<Map<string, ReactNode>>(new Map());
+
+  const mount = useCallback((id: string, element: ReactNode) => {
+    setModalMapById((modalMapById) => {
+      const cloned = new Map(modalMapById);
+      cloned.set(id, element);
+      return cloned;
+    });
+  }, []);
+
+  const unmount = useCallback((id: string) => {
+    setModalMapById((modalMapById) => {
+      const cloned = new Map(modalMapById);
+      cloned.delete(id);
+      return cloned;
+    });
+  }, []);
+
+  const context = useMemo(() => ({ mount, unmount }), [mount, unmount]);
+
+  return (
+    <ModalContext.Provider value={context}>
+      <div className="relative">
+        {children}
+        {[...modalMapById.entries()].map(([id, element]) => (
+          <React.Fragment key={id}>{element}</React.Fragment>
+        ))}
+      </div>
+    </ModalContext.Provider>
+  );
+};

--- a/FE/src/modal/useModal.tsx
+++ b/FE/src/modal/useModal.tsx
@@ -1,0 +1,34 @@
+import { ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import { ModalContext } from "./ModalProvider";
+
+let elementId = 0;
+
+export const useModal = () => {
+  const [id] = useState(() => String(elementId++));
+
+  const context = useContext(ModalContext);
+
+  if (context == null) {
+    throw new Error("모달을 사용하기 위해선 ModalProvider 내에 컴포넌트가 존재해야 합니다.");
+  }
+
+  const { mount, unmount } = context;
+
+  useEffect(() => {
+    return () => {
+      unmount(id);
+    };
+  }, [id, unmount]);
+
+  return useMemo(
+    () => ({
+      open: (ModalElement: ReactNode) => {
+        mount(id, ModalElement);
+      },
+      close: () => {
+        unmount(id);
+      },
+    }),
+    [id, mount, unmount]
+  );
+};


### PR DESCRIPTION
# Task
[LES-198] 모달 생성 컴포넌트와 모달 내부를 구성하는 컴포넌트를 분리한다.

# 설명
모달을 다른 프로젝트에서도 쉽게 사용할 수 있도록 가능하면 모듈 형태로 모달 생성 기능을 개발했습니다.
모달의 원리는 App의 바깥 부분에서 modal 컴포넌트를 저장하는 상태값을 생성하고, 상태값을 순회하여 해당 컴포넌트를 렌더링 하는 방식입니다. 이를 구현하기 위해서는 "컴포넌트들을 저장하는 상태값을 관리"하는 기능과 "상태값에 모달로 띄울 컴포넌트를 전달"하는 기능 2가지를 개발해야 합니다.
### 1. modal을 전역에서 호출하기 위한 ModalProvider 개발
modal 컴포넌트를 저장하는 상태값을 관리하고, 해당 컴포넌트를 렌더링하는 기능을 가지고 있습니다. 상태값 내에 컴포넌트를 저장, 삭제하기 위한 mount, unmount 함수를 context API를 사용하여 전역에 전달합니다.
![image](https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/8a959919-4740-4eb8-8327-566fcf9abf8c)

### 2. modal을 호출하는 useModal 훅 개발
useModal은 context API를 통해 mount, unmount 함수를 전달 받습니다. useModal은 mount, unmount 함수를 사용하여 개발자들에게 원하는 컴포넌트를 모달로 띄울 수 있는 open, 닫을 수 있는 close 함수를 전달해줍니다.
![image](https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/f1b1f8f3-24c9-4256-8e81-6a5eef4455a3)
![image](https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/9a73b18a-7181-4b41-a2bc-93bb8d9b2284)
