### PR TITLE
백로그 sequence 데이터 추가

### DIFF
--- a/BE/src/backlogs/backlogs.module.ts
+++ b/BE/src/backlogs/backlogs.module.ts
@@ -6,12 +6,13 @@ import { Task } from 'src/backlogs/entities/task.entity';
 import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
 import { Member } from 'src/members/entities/member.entity';
 import { Project } from 'src/projects/entity/project.entity';
+import { ProjectCounter } from 'src/projects/entity/projectCounter.entity';
 import { BacklogsController } from './backlogs.controller';
 import { BacklogsService } from './backlogs.service';
 import { BacklogsAuthService } from './backlogsAuth.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Epic, Story, Task, Project, Member]), LesserJwtModule],
+  imports: [TypeOrmModule.forFeature([Epic, Story, Task, Project, Member, ProjectCounter]), LesserJwtModule],
   controllers: [BacklogsController],
   providers: [BacklogsService, BacklogsAuthService],
 })

--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -105,7 +105,7 @@ export class BacklogsService {
   }
 
   async createEpic(dto: CreateBacklogsEpicRequestDto): Promise<CreateBacklogsEpicResponseDto> {
-    const project = await this.projectRepository.findOne({ where: { id: dto.projectId } });
+    const project = await this.projectRepository.findOne({ where: { id: dto.parentId } });
     const epicCount = await this.getEpicCount(project.id);
     const newEpic = this.epicRepository.create({ title: dto.title, project: project, sequence: epicCount });
     const savedEpic = await this.epicRepository.save(newEpic);
@@ -120,7 +120,7 @@ export class BacklogsService {
   }
 
   async createStory(dto: CreateBacklogsStoryRequestDto): Promise<CreateBacklogsStoryResponseDto> {
-    const epic = await this.epicRepository.findOne({ where: { id: dto.epicId }, relations: ['project'] });
+    const epic = await this.epicRepository.findOne({ where: { id: dto.parentId }, relations: ['project'] });
     const storyCount = await this.getStoryCount(epic.project.id);
     const newStory = this.storyRepository.create({ title: dto.title, epic, sequence: storyCount });
     const savedStory = await this.storyRepository.save(newStory);
@@ -135,7 +135,7 @@ export class BacklogsService {
   }
 
   async createTask(dto: CreateBacklogsTaskRequestDto): Promise<CreateBacklogsTaskResponseDto> {
-    const story = await this.storyRepository.findOne({ where: { id: dto.storyId }, relations: ['epic'] });
+    const story = await this.storyRepository.findOne({ where: { id: dto.parentId }, relations: ['epic'] });
     const epic = await this.epicRepository.findOne({ where: { id: story.epic.id }, relations: ['project'] });
     const taskCount = await this.getTaskCount(epic.project.id);
     const newTask = this.taskRepository.create({

--- a/BE/src/backlogs/backlogs.service.ts
+++ b/BE/src/backlogs/backlogs.service.ts
@@ -6,6 +6,7 @@ import { Task } from 'src/backlogs/entities/task.entity';
 import { memberDecoratorType } from 'src/common/types/memberDecorator.type';
 import { Member } from 'src/members/entities/member.entity';
 import { Project } from 'src/projects/entity/project.entity';
+import { ProjectCounter } from 'src/projects/entity/projectCounter.entity';
 import { Repository } from 'typeorm';
 import {
   ReadBacklogTaskResponseDto,
@@ -40,6 +41,7 @@ export class BacklogsService {
     @InjectRepository(Story) private storyRepository: Repository<Story>,
     @InjectRepository(Task) private taskRepository: Repository<Task>,
     @InjectRepository(Member) private memberRepository: Repository<Member>,
+    @InjectRepository(ProjectCounter) private projectCounterRepository: Repository<ProjectCounter>,
   ) {}
 
   async readBacklog(id: number): Promise<ReadBacklogResponseDto> {
@@ -66,6 +68,7 @@ export class BacklogsService {
     const epic = new ReadBacklogEpicResponseDto();
     epic.id = epicData.id;
     epic.title = epicData.title;
+    epic.sequence = epicData.sequence;
     epic.storyList = await this.findStories(epic.id);
     return epic;
   }
@@ -79,6 +82,7 @@ export class BacklogsService {
     const story = new ReadBacklogStoryResponseDto();
     story.id = storyData.id;
     story.title = storyData.title;
+    story.sequence = storyData.sequence;
     story.taskList = await this.findTasks(story.id);
     return story;
   }
@@ -95,31 +99,51 @@ export class BacklogsService {
     task.state = taskData.state;
     task.condition = taskData.condition;
     task.title = taskData.title;
+    task.sequence = taskData.sequence;
     task.userId = taskData.member === null ? null : taskData.member.id;
     return task;
   }
 
   async createEpic(dto: CreateBacklogsEpicRequestDto): Promise<CreateBacklogsEpicResponseDto> {
     const project = await this.projectRepository.findOne({ where: { id: dto.projectId } });
-    const newEpic = this.epicRepository.create({ title: dto.title, project: project });
+    const epicCount = await this.getEpicCount(project.id);
+    const newEpic = this.epicRepository.create({ title: dto.title, project: project, sequence: epicCount });
     const savedEpic = await this.epicRepository.save(newEpic);
-    return { id: savedEpic.id };
+    return { id: savedEpic.id, sequence: epicCount };
+  }
+
+  private async getEpicCount(projectId: number) {
+    const projectCounter = await this.projectCounterRepository.findOne({ where: { projectId } });
+    projectCounter.epicCount++;
+    await projectCounter.save();
+    return projectCounter.epicCount;
   }
 
   async createStory(dto: CreateBacklogsStoryRequestDto): Promise<CreateBacklogsStoryResponseDto> {
-    const epic = await this.epicRepository.findOne({ where: { id: dto.epicId } });
-    const newStory = this.storyRepository.create({ title: dto.title, epic });
+    const epic = await this.epicRepository.findOne({ where: { id: dto.epicId }, relations: ['project'] });
+    const storyCount = await this.getStoryCount(epic.project.id);
+    const newStory = this.storyRepository.create({ title: dto.title, epic, sequence: storyCount });
     const savedStory = await this.storyRepository.save(newStory);
-    return { id: savedStory.id };
+    return { id: savedStory.id, sequence: storyCount };
+  }
+
+  private async getStoryCount(projectId: number) {
+    const projectCounter = await this.projectCounterRepository.findOne({ where: { projectId } });
+    projectCounter.storyCount++;
+    await projectCounter.save();
+    return projectCounter.storyCount;
   }
 
   async createTask(dto: CreateBacklogsTaskRequestDto): Promise<CreateBacklogsTaskResponseDto> {
-    const story = await this.storyRepository.findOne({ where: { id: dto.storyId } });
+    const story = await this.storyRepository.findOne({ where: { id: dto.storyId }, relations: ['epic'] });
+    const epic = await this.epicRepository.findOne({ where: { id: story.epic.id }, relations: ['project'] });
+    const taskCount = await this.getTaskCount(epic.project.id);
     const newTask = this.taskRepository.create({
       title: dto.title,
       state: dto.state,
       point: dto.point,
       condition: dto.condition,
+      sequence: taskCount,
       story,
     });
     if (dto.userId !== null) {
@@ -128,7 +152,15 @@ export class BacklogsService {
       newTask.member = member;
     } else newTask.member = null;
     const savedTask = await this.taskRepository.save(newTask);
-    return { id: savedTask.id };
+
+    return { id: savedTask.id, sequence: taskCount };
+  }
+
+  private async getTaskCount(projectId: number) {
+    const projectCounter = await this.projectCounterRepository.findOne({ where: { projectId } });
+    projectCounter.taskCount++;
+    await projectCounter.save();
+    return projectCounter.taskCount;
   }
 
   async updateEpic(dto: UpdateBacklogsEpicRequestDto): Promise<void> {

--- a/BE/src/backlogs/dto/Epic.dto.ts
+++ b/BE/src/backlogs/dto/Epic.dto.ts
@@ -1,7 +1,7 @@
 import { PickType } from '@nestjs/swagger';
 import { baseEpicDto } from './baseType.dto';
 
-export class CreateBacklogsEpicRequestDto extends PickType(baseEpicDto, ['projectId', 'title']) {}
+export class CreateBacklogsEpicRequestDto extends PickType(baseEpicDto, ['parentId', 'title']) {}
 export class UpdateBacklogsEpicRequestDto extends PickType(baseEpicDto, ['id', 'title']) {}
 export class DeleteBacklogsEpicRequestDto extends PickType(baseEpicDto, ['id']) {}
 

--- a/BE/src/backlogs/dto/Epic.dto.ts
+++ b/BE/src/backlogs/dto/Epic.dto.ts
@@ -5,4 +5,4 @@ export class CreateBacklogsEpicRequestDto extends PickType(baseEpicDto, ['projec
 export class UpdateBacklogsEpicRequestDto extends PickType(baseEpicDto, ['id', 'title']) {}
 export class DeleteBacklogsEpicRequestDto extends PickType(baseEpicDto, ['id']) {}
 
-export class CreateBacklogsEpicResponseDto extends PickType(baseEpicDto, ['id']) {}
+export class CreateBacklogsEpicResponseDto extends PickType(baseEpicDto, ['id', 'sequence']) {}

--- a/BE/src/backlogs/dto/Story.dto.ts
+++ b/BE/src/backlogs/dto/Story.dto.ts
@@ -1,7 +1,7 @@
 import { PickType } from '@nestjs/swagger';
 import { baseStoryDto } from './baseType.dto';
 
-export class CreateBacklogsStoryRequestDto extends PickType(baseStoryDto, ['epicId', 'title']) {}
+export class CreateBacklogsStoryRequestDto extends PickType(baseStoryDto, ['parentId', 'title']) {}
 export class UpdateBacklogsStoryRequestDto extends PickType(baseStoryDto, ['id', 'title']) {}
 export class DeleteBacklogsStoryRequestDto extends PickType(baseStoryDto, ['id']) {}
 

--- a/BE/src/backlogs/dto/Story.dto.ts
+++ b/BE/src/backlogs/dto/Story.dto.ts
@@ -5,4 +5,4 @@ export class CreateBacklogsStoryRequestDto extends PickType(baseStoryDto, ['epic
 export class UpdateBacklogsStoryRequestDto extends PickType(baseStoryDto, ['id', 'title']) {}
 export class DeleteBacklogsStoryRequestDto extends PickType(baseStoryDto, ['id']) {}
 
-export class CreateBacklogsStoryResponseDto extends PickType(baseStoryDto, ['id']) {}
+export class CreateBacklogsStoryResponseDto extends PickType(baseStoryDto, ['id', 'sequence']) {}

--- a/BE/src/backlogs/dto/Task.dto.ts
+++ b/BE/src/backlogs/dto/Task.dto.ts
@@ -1,11 +1,11 @@
 import { IntersectionType, OmitType, PartialType, PickType } from '@nestjs/swagger';
 import { baseTaskDto } from './baseType.dto';
 
-export class CreateBacklogsTaskRequestDto extends OmitType(baseTaskDto, ['id']) {}
+export class CreateBacklogsTaskRequestDto extends OmitType(baseTaskDto, ['id', 'sequence']) {}
 export class DeleteBacklogsTaskRequestDto extends PickType(baseTaskDto, ['id']) {}
 export class UpdateBacklogsRequestTaskDto extends IntersectionType(
   PickType(baseTaskDto, ['id']),
   PartialType(OmitType(baseTaskDto, ['id'])),
 ) {}
 
-export class CreateBacklogsTaskResponseDto extends PickType(baseTaskDto, ['id']) {}
+export class CreateBacklogsTaskResponseDto extends PickType(baseTaskDto, ['id', 'sequence']) {}

--- a/BE/src/backlogs/dto/backlog.dto.ts
+++ b/BE/src/backlogs/dto/backlog.dto.ts
@@ -1,7 +1,7 @@
 import { OmitType, PickType } from '@nestjs/swagger';
 import { baseEpicDto, baseStoryDto, baseTaskDto } from './baseType.dto';
 
-export class ReadBacklogTaskResponseDto extends OmitType(baseTaskDto, ['storyId']) {}
+export class ReadBacklogTaskResponseDto extends OmitType(baseTaskDto, ['parentId']) {}
 
 export class ReadBacklogStoryResponseDto extends PickType(baseStoryDto, ['id', 'title', 'sequence']) {
   taskList: ReadBacklogTaskResponseDto[];

--- a/BE/src/backlogs/dto/backlog.dto.ts
+++ b/BE/src/backlogs/dto/backlog.dto.ts
@@ -3,11 +3,11 @@ import { baseEpicDto, baseStoryDto, baseTaskDto } from './baseType.dto';
 
 export class ReadBacklogTaskResponseDto extends OmitType(baseTaskDto, ['storyId']) {}
 
-export class ReadBacklogStoryResponseDto extends PickType(baseStoryDto, ['id', 'title']) {
+export class ReadBacklogStoryResponseDto extends PickType(baseStoryDto, ['id', 'title', 'sequence']) {
   taskList: ReadBacklogTaskResponseDto[];
 }
 
-export class ReadBacklogEpicResponseDto extends PickType(baseEpicDto, ['id', 'title']) {
+export class ReadBacklogEpicResponseDto extends PickType(baseEpicDto, ['id', 'title', 'sequence']) {
   storyList: ReadBacklogStoryResponseDto[];
 }
 

--- a/BE/src/backlogs/dto/baseType.dto.ts
+++ b/BE/src/backlogs/dto/baseType.dto.ts
@@ -13,6 +13,8 @@ export class baseEpicDto {
   @IsString()
   @IsNotEmpty()
   title: string;
+
+  sequence: number;
 }
 
 export class baseStoryDto {
@@ -27,6 +29,8 @@ export class baseStoryDto {
   @IsString()
   @IsNotEmpty()
   title: string;
+
+  sequence: number;
 }
 
 export class baseTaskDto {
@@ -56,4 +60,6 @@ export class baseTaskDto {
   @IsString()
   @IsNotEmpty()
   condition: string;
+
+  sequence: number;
 }

--- a/BE/src/backlogs/dto/baseType.dto.ts
+++ b/BE/src/backlogs/dto/baseType.dto.ts
@@ -8,7 +8,7 @@ export class baseEpicDto {
 
   @IsInt()
   @IsNotEmpty()
-  projectId: number;
+  parentId: number;
 
   @IsString()
   @IsNotEmpty()
@@ -24,7 +24,7 @@ export class baseStoryDto {
 
   @IsInt()
   @IsNotEmpty()
-  epicId: number;
+  parentId: number;
 
   @IsString()
   @IsNotEmpty()
@@ -40,7 +40,7 @@ export class baseTaskDto {
 
   @IsInt()
   @IsNotEmpty()
-  storyId: number;
+  parentId: number;
 
   @IsString()
   @IsNotEmpty()

--- a/BE/src/backlogs/entities/epic.entity.ts
+++ b/BE/src/backlogs/entities/epic.entity.ts
@@ -9,6 +9,9 @@ export class Epic extends BaseEntity {
   @Column()
   title: string;
 
+  @Column()
+  sequence: number;
+
   @ManyToOne(() => Project, (Project) => Project.id, { nullable: false, onDelete: 'CASCADE' })
   project: Project;
 }

--- a/BE/src/backlogs/entities/story.entity.ts
+++ b/BE/src/backlogs/entities/story.entity.ts
@@ -9,6 +9,9 @@ export class Story extends BaseEntity {
   @Column()
   title: string;
 
+  @Column()
+  sequence: number;
+
   @ManyToOne(() => Epic, (Epic) => Epic.id, { nullable: false, onDelete: 'CASCADE' })
   epic: Epic;
 }

--- a/BE/src/backlogs/entities/task.entity.ts
+++ b/BE/src/backlogs/entities/task.entity.ts
@@ -20,6 +20,9 @@ export class Task extends BaseEntity {
   @Column()
   condition: string;
 
+  @Column()
+  sequence: number;
+
   @ManyToOne(() => Member, (Member) => Member.id, { nullable: true })
   member: Member;
 

--- a/BE/src/projects/entity/projectCounter.entity.ts
+++ b/BE/src/projects/entity/projectCounter.entity.ts
@@ -1,0 +1,21 @@
+import { BaseEntity, Column, Entity, JoinColumn, OneToOne, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity()
+export class ProjectCounter extends BaseEntity {
+  @PrimaryColumn()
+  projectId: number;
+
+  @OneToOne(() => Project)
+  @JoinColumn({ name: 'projectId' })
+  project: Project;
+
+  @Column({ default: 0 })
+  epicCount: number;
+
+  @Column({ default: 0 })
+  storyCount: number;
+
+  @Column({ default: 0 })
+  taskCount: number;
+}

--- a/BE/src/projects/projects.module.ts
+++ b/BE/src/projects/projects.module.ts
@@ -10,11 +10,12 @@ import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
 import { Member } from 'src/members/entities/member.entity';
 import { Project } from './entity/project.entity';
+import { ProjectCounter } from './entity/projectCounter.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project, Epic, Story, Task, Member]), LesserJwtModule],
+  imports: [TypeOrmModule.forFeature([Project, Epic, Story, Task, Member, ProjectCounter]), LesserJwtModule],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -14,6 +14,7 @@ import {
   ReadUserResponseDto,
 } from './dto/Project.dto';
 import { Project } from './entity/project.entity';
+import { ProjectCounter } from './entity/projectCounter.entity';
 
 @Injectable()
 export class ProjectsService {
@@ -23,6 +24,7 @@ export class ProjectsService {
     @InjectRepository(Story) private storyRepository: Repository<Story>,
     @InjectRepository(Task) private taskRepository: Repository<Task>,
     @InjectRepository(Member) private memberRepository: Repository<Member>,
+    @InjectRepository(ProjectCounter) private projectCounterRepository: Repository<ProjectCounter>,
   ) {}
 
   async createProject(
@@ -34,6 +36,8 @@ export class ProjectsService {
     const newProject = this.projectRespository.create({ name: dto.name, subject: dto.subject, members: [] });
     newProject.members.push(member);
     const savedProject = await this.projectRespository.save(newProject);
+    const newProjectCounter = this.projectCounterRepository.create({ projectId: newProject.id });
+    await this.projectCounterRepository.save(newProjectCounter);
     return { id: savedProject.id };
   }
 


### PR DESCRIPTION
## 설명
### feat: [backlog-create] 백로그 sequence 데이터 추가
    
    1. 프로젝트와 1대1 대응인 projectCounter 테이블 추가
    2. 프로젝트 생성시 카운터테이블 같이 생성
    3. 백로그DTO에 순서정보 추가
    4. 백로그 생성시 projectCounter 정보 갱신후 순서정보 응답
    4. 백로그 리스트 요청시 순서정보 함께 응답

### fix: [backlog-read] 백로그 상위프로퍼티 이름을 parentId로 수정
    상세내용 없습니다.

* 유저에게 노출되는 숫자를 저장해 사용하는 projectCounter 테이블을 추가했습니다.
* 매번 에픽, 스토리, 태스크의 개수를 계산하면 비효율적인것 같아 테이블을 하나 더 만들었습니다.
* 항상 감사합니다