### PR TITLE
회고 페이지 조회 API 작성

### DIFF
--- a/BE/src/reviews/dto/Review.dto.ts
+++ b/BE/src/reviews/dto/Review.dto.ts
@@ -1,5 +1,5 @@
 import { PickType } from '@nestjs/swagger';
-import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 class BaseReviewDto {
   @IsInt()
@@ -12,8 +12,13 @@ class BaseReviewDto {
 
   @IsInt()
   @IsNotEmpty()
+  projectId: number;
+
+  @IsInt()
+  @IsNotEmpty()
   sprintId: number;
 }
 
 export class CreateReviewRequestDto extends PickType(BaseReviewDto, ['content', 'sprintId']) {}
 export class CreateReviewResponseDto extends PickType(BaseReviewDto, ['id']) {}
+export class ReadReviewResponseDto extends PickType(BaseReviewDto, ['id', 'content']) {}

--- a/BE/src/reviews/dto/SprintReviewResponse.dto.ts
+++ b/BE/src/reviews/dto/SprintReviewResponse.dto.ts
@@ -1,0 +1,42 @@
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+class SprintListItem {
+  @IsInt()
+  @IsNotEmpty()
+  sprintId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+}
+
+class TaskInfo {
+  id: number;
+  point: number;
+  condition: string;
+  memberId: number;
+  completedAt?: Date;
+}
+
+class SprintInfo {
+  id: number;
+  title: string;
+  goal: string;
+  startDate: Date;
+  endDate: Date;
+  closedDate: Date;
+  completedCount: number;
+  incompleteCount: number;
+  taskList: TaskInfo[];
+  remi: ReviewInfo
+}
+
+class ReviewInfo {
+  id: number;
+  content: string;
+}
+
+export class SprintReviewResponseDto {
+  sprintList: SprintListItem[];
+  selectedSprint: SprintInfo;
+}

--- a/BE/src/reviews/reviews.controller.ts
+++ b/BE/src/reviews/reviews.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewRequestDto } from './dto/Review.dto';
 
@@ -9,5 +9,15 @@ export class ReviewsController {
   @Post()
   createReview(@Body() body: CreateReviewRequestDto) {
     return this.reviewService.createReview(body);
+  }
+
+  @Get()
+  getSprintReview(@Query('project') projectId: number, @Query('sprint') sprintId: number) {
+    return this.reviewService.getSprintReview(projectId, sprintId);
+  }
+
+  @Get('remi')
+  readReview(@Query('id') reviewId: number) {
+    return this.reviewService.readReview(reviewId);
   }
 }

--- a/BE/src/reviews/reviews.module.ts
+++ b/BE/src/reviews/reviews.module.ts
@@ -5,9 +5,13 @@ import { Review } from './entities/review.entity';
 import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
 import { ReviewsController } from './reviews.controller';
 import { Sprint } from 'src/sprints/entities/sprint.entity';
+import { Task } from 'src/backlogs/entities/task.entity';
+import { SprintToTask } from 'src/sprints/entities/sprint-task.entity';
+import { Member } from 'src/members/entities/member.entity';
+import { Project } from 'src/projects/entity/project.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Review, Sprint]), LesserJwtModule],
+  imports: [TypeOrmModule.forFeature([Review, Project, Sprint, Member, Task, SprintToTask]), LesserJwtModule],
   controllers: [ReviewsController],
   providers: [ReviewsService],
 })

--- a/BE/src/reviews/reviews.service.ts
+++ b/BE/src/reviews/reviews.service.ts
@@ -1,29 +1,99 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Review } from './entities/review.entity';
-import { Repository } from 'typeorm';
+import { IsNull, Not, Repository } from 'typeorm';
 import { Sprint } from 'src/sprints/entities/sprint.entity';
-import { CreateReviewRequestDto, CreateReviewResponseDto } from './dto/Review.dto';
+import {
+  CreateReviewRequestDto,
+  CreateReviewResponseDto,
+  ReadReviewResponseDto,
+} from './dto/Review.dto';
+import { SprintReviewResponseDto } from './dto/SprintReviewResponse.dto';
+import { SprintToTask } from 'src/sprints/entities/sprint-task.entity';
 
 @Injectable()
 export class ReviewsService {
   constructor(
     @InjectRepository(Review) private reviewRepository: Repository<Review>,
     @InjectRepository(Sprint) private sprintRepository: Repository<Sprint>,
+    @InjectRepository(SprintToTask) private sprintToTaskRepository: Repository<SprintToTask>,
   ) {}
 
-  async createReview(
-    dto: CreateReviewRequestDto,
-    // memberInfo: memberDecoratorType,
-  ): Promise<CreateReviewResponseDto> {
-    // const member = await this.memberRepository.findOne({ where: { id: memberInfo.id } });
-    // if (!member) throw new InternalServerErrorException();
+  async createReview(dto: CreateReviewRequestDto): Promise<CreateReviewResponseDto> {
+    const existingReview = await this.reviewRepository.findOne({ where: { sprint: { id: dto.sprintId } } });
+    if (existingReview) throw new ConflictException('A review already exists for this sprint.');
+
     const sprint = await this.sprintRepository.findOne({ where: { id: dto.sprintId } });
     const newReview = this.reviewRepository.create({
       content: dto.content,
       sprint: sprint,
     });
-    const savedReview = await this.sprintRepository.save(newReview);
+    const savedReview = await this.reviewRepository.save(newReview);
     return { id: savedReview.id };
+  }
+
+  async getSprintReview(requestProjectId: number, requestSprintId: number): Promise<SprintReviewResponseDto> {
+    const projectId = requestProjectId;
+    const sprintList = await this.sprintRepository.find({
+      where: { project: { id: projectId }, closed_date: Not(IsNull()) },
+      order: { closed_date: 'DESC' },
+    });
+    if (sprintList.length === 0) throw new NotFoundException('No closed sprints found for this project.');
+
+    const sprintId = Number(requestSprintId) === 0 ? sprintList[0].id : Number(requestSprintId);
+    const selectedSprint = await this.sprintRepository.findOne({ where: { id: sprintId } });
+    const sprintTasks = await this.sprintToTaskRepository
+      .createQueryBuilder('sprintToTask')
+      .leftJoinAndSelect('sprintToTask.sprint', 'sprint')
+      .leftJoinAndSelect('sprintToTask.task', 'task')
+      .leftJoinAndSelect('task.member', 'memberId')
+      .where('sprint.id = :sprintId', { sprintId: sprintId })
+      .getMany();
+
+    const { completedCount, incompleteCount } = sprintTasks.reduce(
+      (acc, sprintTask) => {
+        if (sprintTask.completed_at) acc.completedCount += 1;
+        else acc.incompleteCount += 1;
+        return acc;
+      },
+      { completedCount: 0, incompleteCount: 0 },
+    );
+
+    const taskList = sprintTasks.map((sprintTask) => ({
+      id: sprintTask.task.id,
+      point: sprintTask.task.point,
+      condition: sprintTask.task.condition,
+      memberId: sprintTask.task.member.id,
+      completedAt: sprintTask.completed_at,
+    }));
+
+    const remi = await this.reviewRepository
+      .createQueryBuilder('review')
+      .leftJoinAndSelect('review.sprint', 'sprint')
+      .where('sprint.id = :sprintId', { sprintId: sprintId })
+      .getOne();
+
+    const response: SprintReviewResponseDto = {
+      sprintList: sprintList.map((sprint) => ({ sprintId: sprint.id, title: sprint.title })),
+      selectedSprint: {
+        id: selectedSprint.id,
+        title: selectedSprint.title,
+        goal: selectedSprint.goal,
+        startDate: selectedSprint.start_date,
+        endDate: selectedSprint.end_date,
+        closedDate: selectedSprint.closed_date,
+        completedCount: completedCount,
+        incompleteCount: incompleteCount,
+        taskList: taskList,
+        remi: remi ? { id: remi.id, content: remi.content } : null,
+      },
+    };
+    return response;
+  }
+
+  async readReview(id: number): Promise<ReadReviewResponseDto> {
+    const review = await this.reviewRepository.findOne({ where: { id: id } });
+    if (!review) throw new NotFoundException('Review not found.');
+    return { id: review.id, content: review.content };
   }
 }

--- a/BE/src/sprints/entities/sprint-task.entity.ts
+++ b/BE/src/sprints/entities/sprint-task.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   CreateDateColumn,
   UpdateDateColumn,
+  JoinColumn,
 } from 'typeorm';
 import { Sprint } from './sprint.entity';
 import { Task } from 'src/backlogs/entities/task.entity';
@@ -19,9 +20,11 @@ export class SprintToTask extends BaseEntity {
   completed_at: Date;
 
   @ManyToOne(() => Sprint, (sprint) => sprint.id)
+  @JoinColumn({ name: 'sprintId' })
   sprint: Sprint;
 
   @ManyToOne(() => Task, (task) => task.id)
+  @JoinColumn({ name: 'taskId' })
   task: Task;
 
   @CreateDateColumn({ type: 'timestamp' })


### PR DESCRIPTION
## Task
[LES-215] 프로젝트 id를 받으면, 종료된 스프린트 목록(생성일과 종료일, 실제 종료일 포함), 각 스프린트의 (태스크 목록,  스프린트 목표, 스프린트 기간)을 전송하는 API
[LES-228] 회고 데이터를 전달하는 API

## 설명
회고 페이지 조회시 필요한 스프린트, 태스크, 회고글 정보를 가져오는 API를 만들었습니다. 스프린트, 스프린트-태스크, 태스크 테이블을 Join하여 스프린트에 포함된 태스크 정보를 가져옵니다.