### PR TITLE
feat: [kanban-task-read] 현재 진행하고 있는 스프린트 응답

### DIFF
--- a/BE/src/projects/dto/GetSprintProgressRequest.dto.ts
+++ b/BE/src/projects/dto/GetSprintProgressRequest.dto.ts
@@ -1,0 +1,41 @@
+import { PickType } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+
+import { baseTaskDto } from 'src/backlogs/dto/baseType.dto';
+
+export class GetSprintProgressTaskResponseDto extends PickType(baseTaskDto, [
+  'id',
+  'title',
+  'userId',
+  'sequence',
+  'point',
+  'state',
+  'condition',
+]) {
+  'storyId': number;
+
+  'storySequence': number;
+
+  'storyTitle': string;
+}
+
+export class GetSprintProgressResponseDto {
+  sprintTitle: string;
+
+  sprintGoal: string;
+
+  sprintStartDate: Date;
+
+  sprintEndDate: Date;
+
+  sprintEnd: boolean;
+
+  sprintModal: boolean;
+
+  taskList: GetSprintProgressTaskResponseDto[];
+}
+
+export class GetSprintNotProgressResponseDto extends PickType(GetSprintProgressResponseDto, [
+  'sprintEnd',
+  'sprintModal',
+]) {}

--- a/BE/src/projects/entity/project.entity.ts
+++ b/BE/src/projects/entity/project.entity.ts
@@ -1,5 +1,6 @@
 import { Member } from 'src/members/entities/member.entity';
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, JoinTable, ManyToMany } from 'typeorm';
+import { Sprint } from 'src/sprints/entities/sprint.entity';
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, JoinTable, ManyToMany, OneToMany } from 'typeorm';
 
 @Entity()
 export class Project extends BaseEntity {
@@ -15,4 +16,7 @@ export class Project extends BaseEntity {
   @ManyToMany(() => Member, (Member) => Member.projects)
   @JoinTable({ name: 'Member_Project' })
   members: Member[];
+
+  @OneToMany((type) => Sprint, (Sprint) => Sprint.project)
+  sprints: Sprint[];
 }

--- a/BE/src/projects/projects.controller.ts
+++ b/BE/src/projects/projects.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, UseGuards } from '@nestjs/common';
 import { IsLoginGuard } from 'src/common/auth/IsLogin.guard';
 import { Member } from 'src/common/decorators/memberDecorator';
 import { memberDecoratorType } from 'src/common/types/memberDecorator.type';
+import { GetSprintNotProgressResponseDto, GetSprintProgressResponseDto } from './dto/GetSprintProgressRequest.dto';
 import { CreateProjectRequestDto, CreateProjectResponseDto, ReadProjectListResponseDto } from './dto/Project.dto';
 import { ProjectsService } from './projects.service';
 
@@ -20,5 +21,13 @@ export class ProjectsController {
   @Get()
   readProjectList(@Member() memberInfo: memberDecoratorType): Promise<ReadProjectListResponseDto[]> {
     return this.projectsSevice.readProjectList(memberInfo);
+  }
+
+  @Get(':projectId/sprints/progress')
+  readProgressSprint(
+    @Member() memberInfo,
+    @Param('projectId', ParseIntPipe) projectId: number,
+  ): Promise<GetSprintProgressResponseDto | GetSprintNotProgressResponseDto> {
+    return this.projectsSevice.readProgressSprint(projectId);
   }
 }

--- a/BE/src/projects/projects.module.ts
+++ b/BE/src/projects/projects.module.ts
@@ -9,13 +9,14 @@ import { IsLoginGuard } from 'src/common/auth/IsLogin.guard';
 import { LesserJwtModule } from 'src/common/lesser-jwt/lesser-jwt.module';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
 import { Member } from 'src/members/entities/member.entity';
+import { Sprint } from 'src/sprints/entities/sprint.entity';
 import { Project } from './entity/project.entity';
 import { ProjectCounter } from './entity/projectCounter.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project, Epic, Story, Task, Member, ProjectCounter]), LesserJwtModule],
+  imports: [TypeOrmModule.forFeature([Project, Epic, Story, Task, Member, ProjectCounter, Sprint]), LesserJwtModule],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })

--- a/BE/src/sprints/entities/sprint.entity.ts
+++ b/BE/src/sprints/entities/sprint.entity.ts
@@ -8,6 +8,7 @@ import {
   UpdateDateColumn,
   ManyToOne,
   OneToMany,
+  JoinColumn,
 } from 'typeorm';
 import { SprintToTask } from './sprint-task.entity';
 
@@ -37,7 +38,11 @@ export class Sprint extends BaseEntity {
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
 
+  @Column()
+  project_id: number;
+
   @ManyToOne(() => Project, (project) => project.id, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'project_id' })
   project: Project;
 
   @OneToMany(() => SprintToTask, (sprintToTask) => sprintToTask.sprint)


### PR DESCRIPTION
## task
LES-183 스프린트 단일조회 API 노출하기

## 설명

1. 스프린트 엔티티의 project_id의 조인 없는 사용을 위해 joinColumn으로 이름 지정하고, 컬럼생성
2. DTO생성
3. progress인지 체크 후, 분기해서 응답

* 스프린트 종료 로직 작성 후 변경되는 로직에 대해 주석으로 표시해 놓았습니다.
       * 종료가 안된 스프린트에 대해 end-date 이후 요청에 대해 스프린트 종료처리하게 됩니다.
*  조인 부분 관련해서 리펙토링 예정입니다.
       * 현재 task의 member 엔티티참조입니다. 프로퍼티로 task는 있으나, taskId가 없어 실제 테이블은 taskId를 가지고 있으나 조인을 해야지만 task.member.id 로 참조할 수 있음
       <img width="571" alt="image" src="https://github.com/boostcampwm2023/web10-Lesser/assets/66576231/e473bd71-143f-4485-8d8c-02bd5586a335">
