### PR TITLE
토큰 refresh 로직 수정, 칸반보드 API 연결, 칸반보드 모달 연결

### DIFF
--- a/FE/src/components/common/ProgressBar/ProgressBar.tsx
+++ b/FE/src/components/common/ProgressBar/ProgressBar.tsx
@@ -1,19 +1,23 @@
 interface PrograssBarProps {
   startText: string;
   endText: string;
-  totalAmount?: number;
-  currentAmount?: number;
+  totalAmount: number;
+  currentAmount: number;
 }
 
 const PrograssBar = (props: PrograssBarProps) => {
-  const { startText, endText } = props;
+  const { startText, endText, totalAmount, currentAmount } = props;
 
   return (
     <div className="flex items-center gap-3">
       <span className="text-xs font-bold">{startText}</span>
       <div className="relative">
-        <div className="h-2 rounded-lg w-44 bg-green-stroke"></div>
-        <div className="absolute top-0 w-12 h-2 rounded-lg bg-starbucks-green"></div>
+        <div className="h-2 rounded-lg w-[11rem] bg-green-stroke"></div>
+        <div
+          className={`absolute top-0 w-[${Math.round(
+            (currentAmount / totalAmount) * 11,
+          )}rem] h-2 rounded-lg bg-starbucks-green`}
+        ></div>
       </div>
       <span className="text-xs font-bold">{endText}</span>
     </div>

--- a/FE/src/components/sprint/BoardHeader.tsx
+++ b/FE/src/components/sprint/BoardHeader.tsx
@@ -1,9 +1,9 @@
 interface BaordHeaderProps {
   boardName: string;
-  taskNumber: number;
+  taskNumber?: number;
   boardDescription: string;
 }
-const BoardHeader = ({ boardName, taskNumber, boardDescription }: BaordHeaderProps) => (
+const BoardHeader = ({ boardName, taskNumber = 0, boardDescription }: BaordHeaderProps) => (
   <div className="w-[18.75rem] px-2.5 mb-2.5">
     <p className="flex justify-between text-2xl font-bold text-house-green">
       <span>{boardName}</span>

--- a/FE/src/components/sprint/ColumnBoard.tsx
+++ b/FE/src/components/sprint/ColumnBoard.tsx
@@ -16,9 +16,9 @@ const ColumnBoard = ({ taskList, state, storyId }: ColumnBoardProps) => (
         {...provided.droppableProps}
         ref={provided.innerRef}
       >
-        {taskList?.map(({ id, title, userId, point, storyId }, index) => (
-          <li key={id}>
-            <TaskCard {...{ title, userId, point, id, storyId, index }} />
+        {taskList?.map((taskData, index) => (
+          <li key={taskData.id}>
+            <TaskCard {...{ ...taskData, index }} />
           </li>
         ))}
         {provided.placeholder}

--- a/FE/src/components/sprint/TaskCard.tsx
+++ b/FE/src/components/sprint/TaskCard.tsx
@@ -1,34 +1,47 @@
 import { Draggable } from 'react-beautiful-dnd';
+import { useModal } from '../../modal/useModal';
+import TaskModal from '../backlog/Modal/TaskModal';
 
 interface TaskCardProps {
+  userId: string;
   id: number;
   title: string;
-  userId?: number;
+  state: string;
   point: number;
-  storyId: number;
+  condition: string;
+  sequence: number;
   index: number;
 }
 
-const TaskCard = ({ id, title, userId, point, index }: TaskCardProps) => (
-  <Draggable draggableId={String(id)} index={index}>
-    {(provided, snapshop) => (
-      <div
-        className={`flex flex-col gap-5 p-3 text-sm border rounded-lg border-transparent-green bg-cool-neutral ${
-          snapshop.isDragging && 'bg-transparent-green'
-        }`}
-        {...provided.draggableProps}
-        {...provided.dragHandleProps}
-        ref={provided.innerRef}
-      >
-        <p className="font-medium">{title}</p>
-        <p className="flex justify-between text-starbucks-green">
-          <span className="font-bold">{id}</span>
-          <span>{userId}</span>
-          <span>{point} point</span>
-        </p>
-      </div>
-    )}
-  </Draggable>
-);
+const TaskCard = (props: TaskCardProps) => {
+  const { id, title, userId, point, index } = props;
+  const { open, close } = useModal();
+  const handleTaskClick = () => {
+    open(<TaskModal {...props} close={close} />);
+  };
+
+  return (
+    <Draggable draggableId={String(id)} index={index}>
+      {(provided, snapshop) => (
+        <div
+          className={`flex flex-col gap-5 p-3 text-sm border rounded-lg border-transparent-green bg-cool-neutral ${
+            snapshop.isDragging && 'bg-transparent-green'
+          }`}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          ref={provided.innerRef}
+          onClick={handleTaskClick}
+        >
+          <p className="font-medium">{title}</p>
+          <p className="flex justify-between text-starbucks-green">
+            <span className="font-bold">{id}</span>
+            <span>{userId}</span>
+            <span>{point} point</span>
+          </p>
+        </div>
+      )}
+    </Draggable>
+  );
+};
 
 export default TaskCard;

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -1,14 +1,14 @@
 export type TaskGroup = 'all' | 'story';
 
-export type UserFilter = undefined | number;
+export type UserFilter = undefined | string;
 
 export type TaskState = 'ToDo' | 'InProgress' | 'Done' | string;
 
 export interface Task {
   id: number;
-  sequencd: number;
+  sequence: number;
   title: string;
-  userId: number;
+  userId: string;
   point: number;
   state: TaskState;
   storyId: number;


### PR DESCRIPTION
## Task

- [LES-186] 태스크를 클릭했을 때 태스크 디테일 모달을 띄운다.
- [LES-191] 태스크 수정 API를 연동한다.
- [LES-181] API 연동을 통해 태스크 데이터를 가져오고 화면에 보여준다.

## 설명
- 요청이 실패할 때마다(401이 아니더라도) refresh 토큰을 삭제하던 것을 401에러가 뜨거나, 토큰 갱신에 실패했을 때만 삭제하는 것으로 수정했습니다.
- react-query를 이용해 데이터를 가져오고 수정하도록 연동했습니다.
- 이미 완성된 모달 컴포넌트를 사용해 태스크 모달을 띄울 수 있도록 했습니다.