### PR TITLE
스프린트 종료 API, 진행중인 스프린트 조회 API 수정

### DIFF
--- a/BE/src/projects/dto/GetSprintProgressRequest.dto.ts
+++ b/BE/src/projects/dto/GetSprintProgressRequest.dto.ts
@@ -20,6 +20,8 @@ export class GetSprintProgressTaskResponseDto extends PickType(baseTaskDto, [
 }
 
 export class GetSprintProgressResponseDto {
+  sprintId: number;
+
   sprintTitle: string;
 
   sprintGoal: string;

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -116,15 +116,18 @@ export class ProjectsService {
     return this.buildSprintProgressResponse(progressSprintData);
   }
 
-  private buildSprintProgressResponse(progressSprintData: Sprint): GetSprintProgressResponseDto {
+  private async buildSprintProgressResponse(progressSprintData: Sprint): Promise<GetSprintProgressResponseDto> {
     const sprintProgressResponse = new GetSprintProgressResponseDto();
+    sprintProgressResponse.sprintId = progressSprintData.id;
     sprintProgressResponse.sprintTitle = progressSprintData.title;
     sprintProgressResponse.sprintGoal = progressSprintData.goal;
     sprintProgressResponse.sprintStartDate = progressSprintData.start_date;
     sprintProgressResponse.sprintEndDate = progressSprintData.end_date;
     sprintProgressResponse.sprintEnd = false;
-    //나중에 end_date가 현재보다 과거일 때 스프린트 삭제로직 추가
     sprintProgressResponse.sprintModal = progressSprintData.end_date < new Date();
+    if (progressSprintData.end_date < new Date()) {
+      await this.sprintRepository.update({ id: progressSprintData.id }, { closed_date: new Date() });
+    }
     sprintProgressResponse.taskList = this.buildSprintProgressTask(progressSprintData.sprintToTasks);
     return sprintProgressResponse;
   }

--- a/BE/src/sprints/dto/Sprint.dto.ts
+++ b/BE/src/sprints/dto/Sprint.dto.ts
@@ -42,3 +42,4 @@ export class CreateSprintRequestDto extends PickType(BaseSprintDto, [
   'taskList',
 ]) {}
 export class CreateSprintResponseDto extends PickType(BaseSprintDto, ['id']) {}
+export class CompleteSprintRequestDto extends PickType(BaseSprintDto, ['id']) {}

--- a/BE/src/sprints/sprints.controller.ts
+++ b/BE/src/sprints/sprints.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Patch, Post, UseGuards } from '@nestjs/common';
 import { SprintsService } from './sprints.service';
-import { CreateSprintRequestDto, CreateSprintResponseDto } from './dto/Sprint.dto';
+import { CompleteSprintRequestDto, CreateSprintRequestDto, CreateSprintResponseDto } from './dto/Sprint.dto';
 import { Member } from 'src/common/decorators/memberDecorator';
 import { memberDecoratorType } from 'src/common/types/memberDecorator.type';
 import { IsLoginGuard } from 'src/common/auth/IsLogin.guard';
@@ -16,5 +16,11 @@ export class SprintsController {
     @Body() body: CreateSprintRequestDto,
   ): Promise<CreateSprintResponseDto> {
     return this.sprintsService.createSprint(body, memberInfo);
+  }
+
+  @Patch('/complete')
+  async completeSprint(@Body() body: CompleteSprintRequestDto): Promise<Record<string, never>> {
+    await this.sprintsService.completeSprint(body);
+    return {};
   }
 }

--- a/BE/src/sprints/sprints.service.ts
+++ b/BE/src/sprints/sprints.service.ts
@@ -1,9 +1,9 @@
-import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Sprint } from './entities/sprint.entity';
 import { Repository } from 'typeorm';
 import { Project } from 'src/projects/entity/project.entity';
-import { CreateSprintRequestDto, CreateSprintResponseDto } from './dto/Sprint.dto';
+import { CompleteSprintRequestDto, CreateSprintRequestDto, CreateSprintResponseDto } from './dto/Sprint.dto';
 import { memberDecoratorType } from 'src/common/types/memberDecorator.type';
 import { Review } from 'src/reviews/entities/review.entity';
 import { Member } from 'src/members/entities/member.entity';
@@ -48,5 +48,12 @@ export class SprintsService {
     await this.sprintToTaskRepository.save(sprintToTasks);
 
     return { id: savedSprint.id };
+  }
+
+  async completeSprint(dto: CompleteSprintRequestDto) {
+    const sprint = await this.sprintRepository.findOne({ where: { id: dto.id } });
+    if (sprint === null) throw new NotFoundException('not found sprint');
+    sprint.closed_date = new Date();
+    await sprint.save();
   }
 }


### PR DESCRIPTION
## task
LES-183 진행중인 스프린트 조회 API 노출하기
LES-282 스프린트 종료 API 작성하기

## 설명
### feat: [sprint-complete] 스프린트 종료 API
    
    1. 스프린트번호로 스프린트를 종료한다.
    2. 유저권한체크는 추후에 구현

### feat: 스프린트 종료일 이후 진행스프린트 조회시 스프린트 종료처리

## 고민인점

* GET요청으로 실제 데이터가 변경되게 하는것이 맞나 ? 이런 생각이 듭니다.
* 스프린트의 종료조건이 직접 종료하거나, 설정시간 이후면 자동으로 종료되는건데, 종료시간 이후 진행스프린트 조회시 서버에서 스프린트 종료처리를 하게 됩니다.
* 이 부분을 REST하기 위해서는 현재 GET을 받았을 때 종료처리를 하는게아니라, 프론트에서 한번 더 종료요청을 보내는게 더 적절한것 같습니다.
* 항상 감사합니다.