### PR TITLE
회원 닉네임(username)으로 조회하는 API 구현

### DIFF
--- a/BE/src/common/types/githubResource.type.ts
+++ b/BE/src/common/types/githubResource.type.ts
@@ -1,0 +1,4 @@
+export interface GithubEmail {
+  primary: boolean;
+  email: string;
+}

--- a/BE/src/members/dto/github-user.dto.ts
+++ b/BE/src/members/dto/github-user.dto.ts
@@ -1,11 +1,6 @@
-import { PickType } from '@nestjs/swagger';
-import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
-class BaseMemberDto {
-  @IsInt()
-  @IsNotEmpty()
-  id: number;
-
+export class GithubUser {
   @IsString()
   @IsNotEmpty()
   github_id: string;
@@ -22,4 +17,3 @@ class BaseMemberDto {
   @IsNotEmpty()
   image_url: string;
 }
-

--- a/BE/src/members/dto/member.dto.ts
+++ b/BE/src/members/dto/member.dto.ts
@@ -8,7 +8,7 @@ class BaseMemberDto {
 
   @IsString()
   @IsNotEmpty()
-  github_id: string;
+  githubId: string;
 
   @IsString()
   @IsNotEmpty()
@@ -20,6 +20,7 @@ class BaseMemberDto {
 
   @IsString()
   @IsNotEmpty()
-  image_url: string;
+  imageUrl: string;
 }
 
+export class MemberSearchResponseDto extends PickType(BaseMemberDto, ['id', 'username', 'imageUrl']) {}

--- a/BE/src/members/members.controller.ts
+++ b/BE/src/members/members.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Header, Post, Req } from '@nestjs/common';
+import { Body, Controller, Get, Header, Post, Query, Req } from '@nestjs/common';
 import { MembersService } from './members.service';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
@@ -36,5 +36,10 @@ export class MembersController {
     this.lesserJwtService.veifryToken(token);
     const tokens = await this.membersService.refresh(token);
     return tokens;
+  }
+
+  @Get('search')
+  async searchMembersByName(@Query('username') username: string) {
+    return this.membersService.searchMembersByName(username);
   }
 }

--- a/BE/src/members/members.service.ts
+++ b/BE/src/members/members.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ILike, Repository } from 'typeorm';
 import { Member } from './entities/member.entity';
-import { Repository } from 'typeorm';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { GithubUser } from './dto/member.dto';
 import { Tokens } from './dto/tokens.dto';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
-import { ConfigService } from '@nestjs/config';
 import { GithubEmail } from 'src/common/types/githubResource.type';
 
 @Injectable()
@@ -138,5 +138,11 @@ export class MembersService {
     } catch (err) {
       throw new Error(err.message);
     }
+  }
+
+  async searchMembersByName(username: string) {
+    const members = await this.memberRepository.find({ where: { username: ILike(`%${username}%`) } });
+    if (members.length === 0) throw new NotFoundException(`Member with username '${username}' not found.`);
+    return members;
   }
 }

--- a/BE/src/members/members.service.ts
+++ b/BE/src/members/members.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ILike, Repository } from 'typeorm';
 import { Member } from './entities/member.entity';
 import { LoginRequestDto } from './dto/login-request.dto';
+import { MemberSearchResponseDto } from './dto/member.dto';
 import { GithubUser } from './dto/github-user.dto';
 import { Tokens } from './dto/tokens.dto';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
@@ -140,9 +141,14 @@ export class MembersService {
     }
   }
 
-  async searchMembersByName(username: string) {
+  async searchMembersByName(username: string): Promise<MemberSearchResponseDto[]> {
     const members = await this.memberRepository.find({ where: { username: ILike(`%${username}%`) } });
     if (members.length === 0) throw new NotFoundException(`Member with username '${username}' not found.`);
-    return members;
+    const response: MemberSearchResponseDto[] = members.map((member) => ({
+      id: member.id,
+      username: member.username,
+      imageUrl: member.image_url,
+    }));
+    return response;
   }
 }

--- a/BE/src/members/members.service.ts
+++ b/BE/src/members/members.service.ts
@@ -7,6 +7,7 @@ import { GithubUser } from './dto/member.dto';
 import { Tokens } from './dto/tokens.dto';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
 import { ConfigService } from '@nestjs/config';
+import { GithubEmail } from 'src/common/types/githubResource.type';
 
 @Injectable()
 export class MembersService {
@@ -131,7 +132,7 @@ export class MembersService {
           Authorization: `Bearer ${accessToken}`,
         },
       });
-      const emailList = await response.json();
+      const emailList: GithubEmail[] = await response.json();
       const primaryEmail = emailList.find((email) => email.primary === true);
       return primaryEmail.email;
     } catch (err) {

--- a/BE/src/members/members.service.ts
+++ b/BE/src/members/members.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ILike, Repository } from 'typeorm';
 import { Member } from './entities/member.entity';
 import { LoginRequestDto } from './dto/login-request.dto';
-import { GithubUser } from './dto/member.dto';
+import { GithubUser } from './dto/github-user.dto';
 import { Tokens } from './dto/tokens.dto';
 import { LesserJwtService } from 'src/common/lesser-jwt/lesser-jwt.service';
 import { GithubEmail } from 'src/common/types/githubResource.type';


### PR DESCRIPTION
## Task
[LES-281] 회원 조회 API

## 설명
- GET method
- URI: /members/search?username={username}
- 회원 엔티티의 username(깃허브 계정 닉네임)으로 검색
- TypeORM의 ILike 사용(대소문자 구분x), % 와일드카드 사용하여 검색어를 일부 포함한 모든 회원 검색
  ```ts
  const members = await this.memberRepository.find({ where: { username: ILike(`%${username}%`) } });
  ```