### PR TITLE
프로젝트 조회시 멤버정보로 깃허브 아이디 반환, 프로젝트 생성시 멤버리스트 함께 요청받음

### DIFF
--- a/BE/src/projects/dto/Project.dto.ts
+++ b/BE/src/projects/dto/Project.dto.ts
@@ -1,5 +1,5 @@
 import { PickType } from '@nestjs/swagger';
-import { IsInt, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsInt, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 class BaseProjectDto {
   @IsInt()
@@ -13,9 +13,15 @@ class BaseProjectDto {
   @IsString()
   @IsNotEmpty()
   subject: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsNumber({}, { each: true })
+  @IsNotEmpty()
+  memberList: number[];
 }
 
-export class CreateProjectRequestDto extends PickType(BaseProjectDto, ['name', 'subject']) {}
+export class CreateProjectRequestDto extends PickType(BaseProjectDto, ['name', 'subject', 'memberList']) {}
 export class CreateProjectResponseDto extends PickType(BaseProjectDto, ['id']) {}
 
 export class ReadUserResponseDto {

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -97,7 +97,7 @@ export class ProjectsService {
     return projectData.members.map((member) => {
       const readUserResponse = new ReadUserResponseDto();
       readUserResponse.userId = member.id;
-      readUserResponse.userName = member.email;
+      readUserResponse.userName = member.github_id;
       return readUserResponse;
     });
   }

--- a/BE/src/projects/projects.service.ts
+++ b/BE/src/projects/projects.service.ts
@@ -40,10 +40,10 @@ export class ProjectsService {
     dto: CreateProjectRequestDto,
     memberInfo: memberDecoratorType,
   ): Promise<CreateProjectResponseDto> {
-    const member = await this.memberRepository.findOne({ where: { id: memberInfo.id } });
-    if (!member) throw new InternalServerErrorException();
     const newProject = this.projectRespository.create({ name: dto.name, subject: dto.subject, members: [] });
-    newProject.members.push(member);
+    newProject.members = await Promise.all(
+      dto.memberList.map((member) => this.memberRepository.findOne({ where: { id: member } })),
+    );
     const savedProject = await this.projectRespository.save(newProject);
     const newProjectCounter = this.projectCounterRepository.create({ projectId: newProject.id });
     await this.projectCounterRepository.save(newProjectCounter);


### PR DESCRIPTION
## task
### fix: [project-read] 유저 프로젝트 리스트 조회 API 수정
### fix: 프로젝트 생성시 유저리스트를 받도록 변경