### PR TITLE
프로젝트 회원 추가 API 구현

### DIFF
--- a/BE/src/members/dto/member.dto.ts
+++ b/BE/src/members/dto/member.dto.ts
@@ -24,3 +24,4 @@ class BaseMemberDto {
 }
 
 export class MemberSearchResponseDto extends PickType(BaseMemberDto, ['id', 'username', 'imageUrl']) {}
+export class ProjectMemberDto extends PickType(BaseMemberDto, ['id', 'username', 'imageUrl']) {}

--- a/BE/src/projects/dto/Project.dto.ts
+++ b/BE/src/projects/dto/Project.dto.ts
@@ -1,5 +1,6 @@
 import { PickType } from '@nestjs/swagger';
 import { ArrayNotEmpty, IsArray, IsInt, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { ProjectMemberDto } from 'src/members/dto/member.dto';
 
 class BaseProjectDto {
   @IsInt()
@@ -32,4 +33,24 @@ export class ReadProjectListResponseDto extends BaseProjectDto {
   nextPage: string;
   myTaskCount: number;
   userList: ReadUserResponseDto[];
+}
+
+export class AddProjectMemberRequestDto {
+  @IsInt()
+  @IsNotEmpty()
+  id: number;
+
+  @IsArray()
+  @IsNotEmpty()
+  memberList: number[];
+}
+
+export class AddProjectMemberResponseDto {
+  @IsInt()
+  @IsNotEmpty()
+  id: number;
+
+  @IsArray()
+  @IsNotEmpty()
+  memberList: ProjectMemberDto[];
 }

--- a/BE/src/projects/projects.controller.ts
+++ b/BE/src/projects/projects.controller.ts
@@ -3,7 +3,12 @@ import { IsLoginGuard } from 'src/common/auth/IsLogin.guard';
 import { Member } from 'src/common/decorators/memberDecorator';
 import { memberDecoratorType } from 'src/common/types/memberDecorator.type';
 import { GetSprintNotProgressResponseDto, GetSprintProgressResponseDto } from './dto/GetSprintProgressRequest.dto';
-import { CreateProjectRequestDto, CreateProjectResponseDto, ReadProjectListResponseDto } from './dto/Project.dto';
+import {
+  CreateProjectRequestDto,
+  CreateProjectResponseDto,
+  AddProjectMemberRequestDto,
+  ReadProjectListResponseDto,
+} from './dto/Project.dto';
 import { ProjectsService } from './projects.service';
 
 @UseGuards(IsLoginGuard)
@@ -29,5 +34,10 @@ export class ProjectsController {
     @Param('projectId', ParseIntPipe) projectId: number,
   ): Promise<GetSprintProgressResponseDto | GetSprintNotProgressResponseDto> {
     return this.projectsSevice.readProgressSprint(projectId);
+  }
+
+  @Post('members')
+  addProjectMember(@Body() body: AddProjectMemberRequestDto) {
+    return this.projectsSevice.addProjectMember(body);
   }
 }


### PR DESCRIPTION
## Task
[LES-280] 프로젝트 회원초대 API

## 설명
- 프로젝트 id와 추가할 회원 id 리스트를 받고, 해당 프로젝트의 구성원 목록에 회원을 추가한다.
- 이미 프로젝트 구성원 목록에 있는 회원은 제외하여 추가한다.
  ```ts
  const projectMemberIdList = project.members.map((member) => member.id);
  const newMemberIdList = dto.memberList.filter((memberId) => !projectMemberIdList.includes(memberId));
  const newMembers = await this.memberRepository.find({ where: { id: In(newMemberIdList) } });
  ```