### PR TITLE
회고란 탭 기능 구현

### DIFF
--- a/FE/src/components/review/DonutChart.tsx
+++ b/FE/src/components/review/DonutChart.tsx
@@ -4,16 +4,22 @@ interface DountChartProps {
 
 const DountChart = ({ percent }: DountChartProps) => (
   <svg viewBox="0 0 200 200">
-    <circle
-      cx="100"
-      cy="100"
-      r="80"
-      fill="none"
-      stroke="#006241"
-      strokeWidth="30"
-      strokeDasharray={`${(2 * Math.PI * 80 * percent) / 100} ${2 * Math.PI * 80 * (1 - percent / 100)}`}
-      strokeDashoffset={2 * Math.PI * 80 * 0.25}
-    />
+    {percent === 0 || isNaN(percent) ? (
+      <text x="50" y="110" fontSize="30" fill="gray">
+        No data
+      </text>
+    ) : (
+      <circle
+        cx="100"
+        cy="100"
+        r="80"
+        fill="none"
+        stroke="#006241"
+        strokeWidth="30"
+        strokeDasharray={`${(2 * Math.PI * 80 * percent) / 100} ${2 * Math.PI * 80 * (1 - percent / 100)}`}
+        strokeDashoffset={2 * Math.PI * 80 * 0.25}
+      />
+    )}
   </svg>
 );
 

--- a/FE/src/components/review/ReviewChart.tsx
+++ b/FE/src/components/review/ReviewChart.tsx
@@ -24,7 +24,7 @@ const createChartData = (startDate: string, endDate: string, taskList: TaskList[
       remaining -= 1;
     }
 
-    chartData.push({ date: transformDate(currentDate.toString()), ideal: ideal.toFixed(2), remaining });
+    chartData.push({ date: transformDate(currentDate.toString()), ideal: ideal.toFixed(3), remaining });
     currentDate.setDate(currentDate.getDate() + 1);
     ideal -= tasksPerDay;
   }

--- a/FE/src/components/review/ReviewChart.tsx
+++ b/FE/src/components/review/ReviewChart.tsx
@@ -1,5 +1,6 @@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 import { SelectedSprint } from '../../types/review';
+import { transformDate } from '../../utils/date';
 interface TaskList {
   completedAt: string;
   condition: string;
@@ -23,20 +24,12 @@ const createChartData = (startDate: string, endDate: string, taskList: TaskList[
       remaining -= 1;
     }
 
-    chartData.push({ date: formatDate(currentDate), ideal: ideal.toFixed(2), remaining });
+    chartData.push({ date: transformDate(currentDate.toString()), ideal: ideal.toFixed(2), remaining });
     currentDate.setDate(currentDate.getDate() + 1);
     ideal -= tasksPerDay;
   }
 
   return chartData;
-};
-
-const formatDate = (date: Date) => {
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
 };
 
 const ReviewChart = (sprint: SelectedSprint) => {

--- a/FE/src/components/review/ReviewHeader.tsx
+++ b/FE/src/components/review/ReviewHeader.tsx
@@ -6,9 +6,10 @@ import { Sprint } from '../../types/review';
 interface ReviewHeaderProps {
   sprintList: Sprint[];
   currentSprintId: number;
+  setSprintId: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const ReviewHeader = ({ sprintList, currentSprintId }: ReviewHeaderProps) => {
+const ReviewHeader = ({ sprintList, currentSprintId, setSprintId }: ReviewHeaderProps) => {
   const reviewTabs = ['스프린트 정보', '차트', '회고란'];
   const { '*': currentReviewTab } = useParams();
 
@@ -45,7 +46,7 @@ const ReviewHeader = ({ sprintList, currentSprintId }: ReviewHeaderProps) => {
           ref={btnRef}
           onClick={handleSprintListButtonClick}
         >
-          SPRINT 1
+          SPRINT {currentSprintId}
           <ChevronDownIcon color="text-true-white" size={16} />
         </button>
 
@@ -53,8 +54,11 @@ const ReviewHeader = ({ sprintList, currentSprintId }: ReviewHeaderProps) => {
           <ul className="flex flex-col w-[5.75rem] gap-[0.313rem] absolute top-8 p-3 items-center border border-light-gray rounded-md bg-true-white z-10 text-light-gray">
             {Object.values(sprintList).map((sprint) => (
               <li key={sprint.title}>
-                <button className={`${currentSprintId === sprint.sprintId && 'font-bold text-starbucks-green'}`}>
-                  {sprint.title}
+                <button
+                  className={`${currentSprintId === sprint.sprintId && 'font-bold text-starbucks-green'}`}
+                  onClick={() => setSprintId(() => sprint.sprintId)}
+                >
+                  SPRINT {sprint.sprintId}
                 </button>
               </li>
             ))}

--- a/FE/src/components/review/ReviewReminiscing.tsx
+++ b/FE/src/components/review/ReviewReminiscing.tsx
@@ -1,18 +1,57 @@
-const ReviewReminiscing = () => (
-  <div className="flex flex-col w-[60.25rem] gap-6">
-    <textarea
-      className="w-[60.25rem] h-[31.438rem] p-6 border border-transparent-green placeholder:text-center placeholder:font-bold outline-transparent-green rounded-md resize-none"
-      placeholder={
-        '\n\n\n\n\n\n여러분의 스프린트를 회고해 보세요' +
-        '\n태스크를 잘 마무리했나요?' +
-        '\n어떤 부분이 미비했나요?' +
-        '\n스프린트 진행에 부족했던 점은 무엇인가요?'
-      }
-    />
-    <div className="flex justify-end">
-      <button className="px-4 py-1.5 rounded-md bg-starbucks-green text-true-white">작성하기</button>
-    </div>
-  </div>
-);
+import { SelectedSprint } from '../../types/review';
+import { useState } from 'react';
+import useReminiscing from './../../hooks/pages/review/useReminiscing';
+
+const ReviewReminiscing = (sprint: SelectedSprint) => {
+  const [editTextarea, setEditTextarea] = useState<boolean>(false);
+  const initialReminiscing = sprint.remi ? sprint.remi.content : '';
+  const [reminiscing, setReminiscing] = useState<string>(initialReminiscing);
+  const handleEditButtonClick = () => {
+    setEditTextarea(!editTextarea);
+    setReminiscing(initialReminiscing);
+  };
+
+  const { handleConfirmButtonClick } = useReminiscing(sprint, reminiscing, setEditTextarea);
+
+  const buttonName = initialReminiscing ? '수정하기' : '작성하기';
+
+  return (
+    <form className="flex flex-col w-[60.25rem] gap-6" onSubmit={handleConfirmButtonClick}>
+      <textarea
+        className="w-[60.25rem] h-[31.438rem] p-6 border border-transparent-green placeholder:text-center placeholder:font-bold outline-transparent-green rounded-md resize-none"
+        placeholder={
+          '\n\n\n\n\n\n여러분의 스프린트를 회고해 보세요' +
+          '\n태스크를 잘 마무리했나요?' +
+          '\n어떤 부분이 미비했나요?' +
+          '\n스프린트 진행에 부족했던 점은 무엇인가요?'
+        }
+        value={reminiscing}
+        onChange={(e) => {
+          setReminiscing(e.target.value);
+        }}
+        disabled={!editTextarea}
+      />
+      <div className="flex justify-end">
+        {editTextarea ? (
+          <div className="flex gap-2">
+            <button
+              className="px-4 py-1.5 rounded-md outline outline-1 bg-true-white text-starbucks-green"
+              onClick={handleEditButtonClick}
+            >
+              {'취소'}
+            </button>
+            <button type="submit" className="px-4 py-1.5 rounded-md bg-starbucks-green text-true-white">
+              {'확인'}
+            </button>
+          </div>
+        ) : (
+          <button className="px-4 py-1.5 rounded-md bg-starbucks-green text-true-white" onClick={handleEditButtonClick}>
+            {buttonName}
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};
 
 export default ReviewReminiscing;

--- a/FE/src/components/review/ReviewSprint.tsx
+++ b/FE/src/components/review/ReviewSprint.tsx
@@ -40,40 +40,52 @@ const ReviewSprint = (sprint: SelectedSprint) => {
           <ReviewSprintInfo label="전체 Task" content={`${totalCount} 개`} />
         </div>
       </div>
-      <div className="flex flex-col gap-6 w-full h-[24.313rem] p-6 bg-true-white border border-transparent-green rounded-md text-r text-house-green overflow-x-hidden overflow-y-auto">
+      <div className="flex flex-col gap-6 w-full p-6 bg-true-white border border-transparent-green rounded-md text-r text-house-green">
         <ul>
           <span className="w-[5.625rem] font-bold text-starbucks-green">완료 Task</span>
-          {completedTaskList.map((task) => (
-            <li
-              className="flex w-[57.25rem] justify-between py-[0.563rem] pl-2.5 pr-[0.438rem] border-t border-x last:border-b border-transparent-green font-medium"
-              key={task.id}
-            >
-              <span className="w-[4rem] font-bold">Task {task.id}</span>
-              <span className="w-[33.75rem]">{task.title}</span>
-              <span className="w-[6.25rem]"></span>
-              <span className="w-[5rem]">{task.point} POINT</span>
-              <span className="flex items-center font-bold">
-                상세보기 <ChevronRightIcon size={14} />
-              </span>
+          {completedTaskList.length ? (
+            completedTaskList.map((task) => (
+              <li
+                className="flex w-[57.25rem] justify-between py-[0.563rem] pl-2.5 pr-[0.438rem] border-t border-x last:border-b border-transparent-green font-medium"
+                key={task.id}
+              >
+                <span className="w-[4rem] font-bold">Task {task.id}</span>
+                <span className="w-[33.75rem]">{task.title}</span>
+                <span className="w-[6.25rem]"></span>
+                <span className="w-[5rem]">{task.point} POINT</span>
+                <span className="flex items-center font-bold">
+                  상세보기 <ChevronRightIcon size={14} />
+                </span>
+              </li>
+            ))
+          ) : (
+            <li className="flex w-[57.25rem] justify-center p-7 border border-transparent-green font-bold">
+              완료된 Task가 없습니다.
             </li>
-          ))}
+          )}
         </ul>
         <ul>
           <span className="w-[5.625rem] font-bold text-error-red">미완료 Task</span>
-          {uncompletedTaskList.map((task) => (
-            <li
-              className="flex w-[57.25rem] justify-between py-[0.563rem] pl-2.5 pr-[0.438rem] border-t border-x last:border-b border-transparent-green font-medium"
-              key={task.id}
-            >
-              <span className="w-[4rem] font-bold">Task {task.id}</span>
-              <span className="w-[33.75rem]">{task.title}</span>
-              <span className="w-[6.25rem]"></span>
-              <span className="w-[5rem]">{task.point} POINT</span>
-              <span className="flex items-center font-bold">
-                상세보기 <ChevronRightIcon size={14} />
-              </span>
+          {uncompletedTaskList.length ? (
+            uncompletedTaskList.map((task) => (
+              <li
+                className="flex w-[57.25rem] justify-between py-[0.563rem] pl-2.5 pr-[0.438rem] border-t border-x last:border-b border-transparent-green font-medium"
+                key={task.id}
+              >
+                <span className="w-[4rem] font-bold">Task {task.id}</span>
+                <span className="w-[33.75rem]">{task.title}</span>
+                <span className="w-[6.25rem]"></span>
+                <span className="w-[5rem]">{task.point} POINT</span>
+                <span className="flex items-center font-bold">
+                  상세보기 <ChevronRightIcon size={14} />
+                </span>
+              </li>
+            ))
+          ) : (
+            <li className="flex w-[57.25rem] justify-center p-7 border border-transparent-green font-bold">
+              미완료된 Task가 없습니다.
             </li>
-          ))}
+          )}
         </ul>
       </div>
     </div>

--- a/FE/src/hooks/pages/review/useReminiscing.tsx
+++ b/FE/src/hooks/pages/review/useReminiscing.tsx
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../../../apis/api';
+import { SelectedSprint } from '../../../types/review';
+
+const useReminiscing = (
+  sprint: SelectedSprint,
+  content: string,
+  setEditTextarea: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  const queryClient = useQueryClient();
+
+  const { mutateAsync } = useMutation({
+    mutationFn: async () => {
+      sprint.remi
+        ? await api.put('/reviews/remi', { id: sprint.remi.id, content })
+        : await api.post('/reviews', { sprintId: sprint.id, content });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['review', sprint.id] });
+      setEditTextarea(false);
+    },
+  });
+
+  const handleConfirmButtonClick = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!content.trim()) {
+      window.alert('값을 입력해주세요');
+      return;
+    }
+    await mutateAsync();
+  };
+
+  return { handleConfirmButtonClick };
+};
+
+export default useReminiscing;

--- a/FE/src/pages/ReviewPage.tsx
+++ b/FE/src/pages/ReviewPage.tsx
@@ -8,7 +8,7 @@ import { api } from '../apis/api';
 import { useState } from 'react';
 
 const ReviewPage = () => {
-  const [sprintId, setSprintId] = useState<number>(0);
+  const [sprintId, setSprintId] = useState<number>(3);
   const { isLoading, error, data } = useQuery({
     queryKey: ['review', sprintId],
     queryFn: () => api.get(`/reviews?project=1&sprint=${sprintId}`).then((res) => res.data),
@@ -29,7 +29,7 @@ const ReviewPage = () => {
           <Routes>
             <Route path="/" element={<ReviewSprint {...data.selectedSprint} />} />
             <Route path="/chart" element={<ReviewChart {...data.selectedSprint} />} />
-            <Route path="/remi" element={<ReviewReminiscing />} />
+            <Route path="/remi" element={<ReviewReminiscing {...data.selectedSprint} />} />
           </Routes>
         </>
       )}

--- a/FE/src/pages/ReviewPage.tsx
+++ b/FE/src/pages/ReviewPage.tsx
@@ -5,11 +5,14 @@ import ReviewReminiscing from '../components/review/ReviewReminiscing';
 import { Route, Routes } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../apis/api';
+import { useState } from 'react';
 
 const ReviewPage = () => {
+  const [sprintId, setSprintId] = useState<number>(0);
   const { isLoading, error, data } = useQuery({
-    queryKey: ['review'],
-    queryFn: () => api.get('/reviews?project=1&sprint=0').then((res) => res.data),
+    queryKey: ['review', sprintId],
+    queryFn: () => api.get(`/reviews?project=1&sprint=${sprintId}`).then((res) => res.data),
+    staleTime: 1000 * 60 * 5,
   });
 
   return (
@@ -18,7 +21,11 @@ const ReviewPage = () => {
       {error && <p>Something is wrong 😢</p>}
       {data && (
         <>
-          <ReviewHeader sprintList={data.sprintList} currentSprintId={data.selectedSprint.id} />
+          <ReviewHeader
+            sprintList={data.sprintList}
+            currentSprintId={data.selectedSprint.id}
+            setSprintId={setSprintId}
+          />
           <Routes>
             <Route path="/" element={<ReviewSprint {...data.selectedSprint} />} />
             <Route path="/chart" element={<ReviewChart {...data.selectedSprint} />} />

--- a/FE/src/types/review.ts
+++ b/FE/src/types/review.ts
@@ -18,14 +18,14 @@ export interface Sprint {
 }
 
 export interface SelectedSprint {
-  id?: number;
-  title?: string;
-  goal?: string;
-  startDate?: string;
-  endDate?: string;
-  closedDate?: string;
-  completedCount?: number;
-  incompleteCount?: number;
-  taskList?: Task[];
-  remi?: Remi;
+  id: number;
+  title: string;
+  goal: string;
+  startDate: string;
+  endDate: string;
+  closedDate: string;
+  completedCount: number;
+  incompleteCount: number;
+  taskList: Task[];
+  remi: Remi;
 }

--- a/FE/src/utils/date.ts
+++ b/FE/src/utils/date.ts
@@ -2,9 +2,8 @@ const transformDate = (date: string) => {
   const newDate = new Date(date);
   const year = newDate.getFullYear();
   const month = (newDate.getMonth() + 1).toString().padStart(2, '0');
-  const day = newDate.getDay().toString().padStart(2, '0');
+  const day = newDate.getDate().toString().padStart(2, '0');
 
   return `${year}-${month}-${day}`;
 };
-
 export { transformDate };

--- a/FE/src/utils/date.ts
+++ b/FE/src/utils/date.ts
@@ -1,7 +1,8 @@
 const transformDate = (date: string) => {
-  const year = new Date(date).getFullYear();
-  const month = new Date(date).getMonth() + 1;
-  const day = new Date(date).getDay();
+  const newDate = new Date(date);
+  const year = newDate.getFullYear();
+  const month = (newDate.getMonth() + 1).toString().padStart(2, '0');
+  const day = newDate.getDay().toString().padStart(2, '0');
 
   return `${year}-${month}-${day}`;
 };


### PR DESCRIPTION
## task
- [LES-220] 드롭다운에서 다른 스프린트를 클릭하면 /review 페이지에서 바뀐 스프린트 정보를 보여준다.
- [LES-224] 작성된 회고가 있다면 작성된 회고를 보여준다.
- [LES-225] 작성된 회고는 textarea 비활성화 상태를 보여준다.
- [LES-226] 작성된 회고가 없으면 스프린트에 대해 회고하라는 메시지를 보여준다.
- [LES-227] 작성된 회고가 없다면 "작성하기" 버튼을 보여주고, 작성된 회고가 있다면 "수정하기" 버튼을 보여준다.
- [LES-230] textarea 활성화되고 회고를 입력할 수 있다.
- [LES-231] 완료 버튼을 클릭하면 작성된 회고를 저장하도록 API 요청하고, 요청 성공시 작성된 회고를 화면에 보여준다.
- [LES-234] textarea 활성화되고 회고를 입력할 수 있다.
- [LES-235] 완료 버튼을 클릭하면 수정된 회고를 저장하도록 API 요청, 요청 성공시 수정된 회고를 화면에 보여준다.
- [LES-237] 유저는 작성/수정 취소 버튼을 클릭하면 회고 생성/수정 이전의 상태로 돌아간다.

## 설명
스프린트 리스트 드롭다운에서 다른 스프린트를 클릭하면 회고 페이지에서 바뀐 스프린트 정보를 출력합니다.
회고란 탭에서 회고를 작성하고 작성된 회고를 수정할 수 있는 기능을 구현하였습니다.
스프린트 정보 탭에서 데이터가 없을 때, 태스크의 완료 및 미완료 목록과 도넛 차트가 더 나은 형태로 표시되도록 개선하였습니다.
번다운 차트의 더 정확한 표현을 위해 'ideal' 데이터 포인트를 소수점 3자리까지 표시하도록 조정하였습니다.