### PR TITLE
회고 페이지 리팩토링

### DIFF
--- a/FE/src/components/review/ReviewHeader.tsx
+++ b/FE/src/components/review/ReviewHeader.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import ChevronDownIcon from './../../assets/icons/ChevronDownIcon';
 import { Link, useParams } from 'react-router-dom';
 import { Sprint } from '../../types/review';
+import { reviewTabs } from '../../constants/constants';
 
 interface ReviewHeaderProps {
   sprintList: Sprint[];
@@ -10,7 +11,6 @@ interface ReviewHeaderProps {
 }
 
 const ReviewHeader = ({ sprintList, currentSprintId, setSprintId }: ReviewHeaderProps) => {
-  const reviewTabs = ['스프린트 정보', '차트', '회고란'];
   const { '*': currentReviewTab } = useParams();
 
   const [sprintListVisibility, setSprintListVisibility] = useState<boolean>(false);
@@ -67,7 +67,7 @@ const ReviewHeader = ({ sprintList, currentSprintId, setSprintId }: ReviewHeader
 
         <ul className="flex gap-3 text-r text-light-gray">
           {reviewTabs.map((tab, index) => {
-            const urlSegment = tab === '차트' ? '/chart' : tab === '회고란' ? '/remi' : '';
+            const urlSegment = tab === '차트' ? '/chart' : tab === '회고란' ? '/reminiscing' : '';
             return (
               <li key={index}>
                 <Link

--- a/FE/src/components/review/ReviewReminiscing.tsx
+++ b/FE/src/components/review/ReviewReminiscing.tsx
@@ -1,15 +1,19 @@
 import { SelectedSprint } from '../../types/review';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import useReminiscing from './../../hooks/pages/review/useReminiscing';
 
 const ReviewReminiscing = (sprint: SelectedSprint) => {
   const [editTextarea, setEditTextarea] = useState<boolean>(false);
-  const initialReminiscing = sprint.remi ? sprint.remi.content : '';
-  const [reminiscing, setReminiscing] = useState<string>(initialReminiscing);
+  const initialReminiscing = sprint.reminiscing ? sprint.reminiscing.content : '';
+  const [reminiscing, setReminiscing] = useState<string>('');
   const handleEditButtonClick = () => {
     setEditTextarea(!editTextarea);
     setReminiscing(initialReminiscing);
   };
+
+  useEffect(() => {
+    setReminiscing(initialReminiscing);
+  }, [initialReminiscing]);
 
   const { handleConfirmButtonClick } = useReminiscing(sprint, reminiscing, setEditTextarea);
 

--- a/FE/src/components/review/ReviewSprint.tsx
+++ b/FE/src/components/review/ReviewSprint.tsx
@@ -1,5 +1,5 @@
 import { SelectedSprint } from '../../types/review';
-import ChevronRightIcon from './../../assets/icons/ChevronRightIcon';
+import TaskComponent from '../backlog/TaskComponent';
 import DountChart from './DonutChart';
 import ReviewSprintInfo from './ReviewSprintInfo';
 
@@ -41,52 +41,26 @@ const ReviewSprint = (sprint: SelectedSprint) => {
         </div>
       </div>
       <div className="flex flex-col gap-6 w-full p-6 bg-true-white border border-transparent-green rounded-md text-r text-house-green">
-        <ul>
+        <div>
           <span className="w-[5.625rem] font-bold text-starbucks-green">완료 Task</span>
-          {completedTaskList.length ? (
-            completedTaskList.map((task) => (
-              <li
-                className="flex w-[57.25rem] justify-between py-[0.563rem] pl-2.5 pr-[0.438rem] border-t border-x last:border-b border-transparent-green font-medium"
-                key={task.id}
-              >
-                <span className="w-[4rem] font-bold">Task {task.id}</span>
-                <span className="w-[33.75rem]">{task.title}</span>
-                <span className="w-[6.25rem]"></span>
-                <span className="w-[5rem]">{task.point} POINT</span>
-                <span className="flex items-center font-bold">
-                  상세보기 <ChevronRightIcon size={14} />
-                </span>
-              </li>
-            ))
-          ) : (
-            <li className="flex w-[57.25rem] justify-center p-7 border border-transparent-green font-bold">
-              완료된 Task가 없습니다.
-            </li>
-          )}
-        </ul>
-        <ul>
+          <ul className={`${completedTaskList.length ? 'border-x border-b' : 'border'}`}>
+            {completedTaskList.length ? (
+              completedTaskList.map((task) => <TaskComponent state={''} {...task} key={`TASK${task.id}`} />)
+            ) : (
+              <li className="flex w-[57.25rem] justify-center p-7 font-bold">완료된 Task가 없습니다.</li>
+            )}
+          </ul>
+        </div>
+        <div>
           <span className="w-[5.625rem] font-bold text-error-red">미완료 Task</span>
-          {uncompletedTaskList.length ? (
-            uncompletedTaskList.map((task) => (
-              <li
-                className="flex w-[57.25rem] justify-between py-[0.563rem] pl-2.5 pr-[0.438rem] border-t border-x last:border-b border-transparent-green font-medium"
-                key={task.id}
-              >
-                <span className="w-[4rem] font-bold">Task {task.id}</span>
-                <span className="w-[33.75rem]">{task.title}</span>
-                <span className="w-[6.25rem]"></span>
-                <span className="w-[5rem]">{task.point} POINT</span>
-                <span className="flex items-center font-bold">
-                  상세보기 <ChevronRightIcon size={14} />
-                </span>
-              </li>
-            ))
-          ) : (
-            <li className="flex w-[57.25rem] justify-center p-7 border border-transparent-green font-bold">
-              미완료된 Task가 없습니다.
-            </li>
-          )}
-        </ul>
+          <ul className={`${uncompletedTaskList.length ? 'border-x border-b' : 'border'}`}>
+            {uncompletedTaskList.length ? (
+              uncompletedTaskList.map((task) => <TaskComponent state={''} {...task} key={`TASK${task.id}`} />)
+            ) : (
+              <li className="flex w-[57.25rem] justify-center p-7 font-bold">미완료된 Task가 없습니다.</li>
+            )}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/FE/src/constants/constants.tsx
+++ b/FE/src/constants/constants.tsx
@@ -13,3 +13,5 @@ export const API_URL = {
 export const PROJECT_URL = {
   PROJECT: '/project',
 };
+
+export const reviewTabs = ['스프린트 정보', '차트', '회고란'];

--- a/FE/src/hooks/pages/review/useReminiscing.tsx
+++ b/FE/src/hooks/pages/review/useReminiscing.tsx
@@ -11,8 +11,8 @@ const useReminiscing = (
 
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
-      sprint.remi
-        ? await api.put('/reviews/remi', { id: sprint.remi.id, content })
+      sprint.reminiscing
+        ? await api.put('/reviews/remi', { id: sprint.reminiscing.id, content })
         : await api.post('/reviews', { sprintId: sprint.id, content });
     },
     onSuccess: () => {
@@ -27,6 +27,11 @@ const useReminiscing = (
       window.alert('값을 입력해주세요');
       return;
     }
+    if (content.trim() === sprint.reminiscing.content) {
+      setEditTextarea(false);
+      return;
+    }
+
     await mutateAsync();
   };
 

--- a/FE/src/pages/ReviewPage.tsx
+++ b/FE/src/pages/ReviewPage.tsx
@@ -15,24 +15,22 @@ const ReviewPage = () => {
     staleTime: 1000 * 60 * 5,
   });
 
+  if (isLoading) {
+    return <p>Loading...</p>;
+  }
+
+  if (error) {
+    return <p>Something is wrong 😢</p>;
+  }
+
   return (
     <>
-      {isLoading && <p>Loading...</p>}
-      {error && <p>Something is wrong 😢</p>}
-      {data && (
-        <>
-          <ReviewHeader
-            sprintList={data.sprintList}
-            currentSprintId={data.selectedSprint.id}
-            setSprintId={setSprintId}
-          />
-          <Routes>
-            <Route path="/" element={<ReviewSprint {...data.selectedSprint} />} />
-            <Route path="/chart" element={<ReviewChart {...data.selectedSprint} />} />
-            <Route path="/remi" element={<ReviewReminiscing {...data.selectedSprint} />} />
-          </Routes>
-        </>
-      )}
+      <ReviewHeader sprintList={data.sprintList} currentSprintId={data.selectedSprint.id} setSprintId={setSprintId} />
+      <Routes>
+        <Route path="/" element={<ReviewSprint {...data.selectedSprint} />} />
+        <Route path="/chart" element={<ReviewChart {...data.selectedSprint} />} />
+        <Route path="/reminiscing" element={<ReviewReminiscing {...data.selectedSprint} />} />
+      </Routes>
     </>
   );
 };

--- a/FE/src/types/review.ts
+++ b/FE/src/types/review.ts
@@ -2,12 +2,13 @@ interface Task {
   id: number;
   point: number;
   condition: string;
-  memberId: number;
+  userId: string;
   completedAt: string;
   title: string;
+  sequence: number;
 }
 
-interface Remi {
+interface Reminiscing {
   id: number;
   content: string;
 }
@@ -27,5 +28,5 @@ export interface SelectedSprint {
   completedCount: number;
   incompleteCount: number;
   taskList: Task[];
-  remi: Remi;
+  reminiscing: Reminiscing;
 }


### PR DESCRIPTION
- reviewTabs 변수 constants에서 관리하도록 수정
- remi -> reminiscing 풀네임으로 수정
- reminiscing의 초기값을 useEffect를 통해 변경하도록 수정
- task 완료, 미완료 목록 TaskComponent 재사용
- 회고란을 수정할 때 이전 값과 비교해서 같으면 요청을 보내지 않도록 수정