### PR TITLE
유저 로그인 시, 유저이름과 id를 전역 상태로 관리

### DIFF
--- a/FE/src/hooks/pages/useLogin.tsx
+++ b/FE/src/hooks/pages/useLogin.tsx
@@ -2,15 +2,21 @@ import { NavigateFunction, useNavigate } from 'react-router';
 import { api, setAccessToken } from '../../apis/api';
 import { SetURLSearchParams, useSearchParams } from 'react-router-dom';
 import { useEffect } from 'react';
+import { useUserState } from '../../stores';
 
-const login = async (code: string | null, navigate: NavigateFunction, setSearchParams: SetURLSearchParams) => {
+const login = async (
+  code: string | null,
+  navigate: NavigateFunction,
+  setSearchParams: SetURLSearchParams,
+  updateUserState: ({ id, username }: { id: number; username: string }) => void,
+) => {
   api
     .post(`/members/login`, { code })
     .then((response) => {
-      const { accessToken, refreshToken } = response.data;
+      const { accessToken, refreshToken, id, username } = response.data;
       setAccessToken(accessToken);
       sessionStorage.setItem('refreshToken', refreshToken);
-
+      updateUserState({ id: Number(id), username });
       navigate('/project');
     })
     .catch(() => {
@@ -22,6 +28,7 @@ const useLogin = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const code = searchParams.get('code');
   const navigate = useNavigate();
+  const updateUserState = useUserState((state) => state.updateUserState);
 
   const handleLoginButtonClick = (): void => {
     location.href = `${import.meta.env.VITE_GITHUB_OAUTH_URL}?client_id=${
@@ -31,7 +38,7 @@ const useLogin = () => {
 
   useEffect(() => {
     if (code) {
-      login(code, navigate, setSearchParams);
+      login(code, navigate, setSearchParams, updateUserState);
     }
   }, []);
 

--- a/FE/src/hooks/pages/useLogout.tsx
+++ b/FE/src/hooks/pages/useLogout.tsx
@@ -1,20 +1,23 @@
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 import { api, setAccessToken } from '../../apis/api';
 import { REFRESH_TOKEN } from '../../constants/constants';
+import { useUserState } from '../../stores';
 
-const logout = (navigate: NavigateFunction) => {
+const logout = (navigate: NavigateFunction, deleteUserState: () => void) => {
   api.post('/members/logout').then(() => {
     setAccessToken(undefined);
     sessionStorage.removeItem(REFRESH_TOKEN);
+    deleteUserState();
     navigate('/login');
   });
 };
 
 const useLogout = () => {
   const navigate = useNavigate();
+  const deleteUserState = useUserState((state) => state.deleteUserState);
 
   const handleLogoutButtonClick = () => {
-    logout(navigate);
+    logout(navigate, deleteUserState);
   };
 
   return handleLogoutButtonClick;

--- a/FE/src/stores/index.ts
+++ b/FE/src/stores/index.ts
@@ -1,1 +1,2 @@
 export { default as useSelectedProjectState } from './useSelectedProjectState';
+export { default as useUserState } from './useUserState';

--- a/FE/src/stores/useUserState.ts
+++ b/FE/src/stores/useUserState.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+
+interface UserType {
+  id: number;
+  username: string;
+}
+
+interface UserStateType extends UserType {
+  updateUserState: ({ id, username }: UserType) => void;
+  deleteUserState: () => void;
+}
+
+const initialState: UserType = {
+  id: -1,
+  username: '',
+};
+
+const useUserState = create<UserStateType>()(
+  devtools(
+    persist(
+      (set) => ({
+        ...initialState,
+        updateUserState: ({ id, username }) => set(() => ({ id, username })),
+        deleteUserState: () => set(initialState),
+      }),
+      { name: 'userState' },
+    ),
+  ),
+);
+
+export default useUserState;


### PR DESCRIPTION
# 설명
- 로그인 시, 서버로 username과 id를 전달받고 해당 데이터를 zustand를 사용하여 전역 상태로 관리
1. zustand에 사용자 정보를 저장하기 위한 useUserState 생성
2. login 시, 전달 받는 id, username을 useUserState에 저장
3. logout 시, 전달 받는 id, username을 초기화

- 사용자가 새로고침을 하더라도 데이터 초기화를 막기 위해 useUserState의 데이터를 localStorage에 저장하여 관리
<img width="578" alt="스크린샷 2023-12-06 오후 5 32 32" src="https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/b5e37c42-a6d6-46cf-b692-bd7e32e494be">
