### PR TITLE
사용자의 본인의 정보를 프로젝트 생성 시, 참여자에 자동으로 추가하는 로직을 작성

### DIFF
--- a/FE/src/components/project/ProjectCard.tsx
+++ b/FE/src/components/project/ProjectCard.tsx
@@ -4,7 +4,7 @@ import { projectElement } from '../../types/project';
 import { Link } from 'react-router-dom';
 
 const ProjectCard = ({ id, name, subject, nextPage, myTaskCount, userList }: projectElement) => {
-  const NEXT_URL = nextPage === 'backlogs' ? `${CLIENT_URL.BACKLOG}/${id}` : `/sprint/${id}`;
+  const NEXT_URL = nextPage === 'backlogs' ? CLIENT_URL.BACKLOG(id) : `/sprint/${id}`;
   const updateProjectData = useSelectedProjectState((state) => state.updateProjectData);
   const handleProjectCardClick = () => {
     updateProjectData({ id, userList });

--- a/FE/src/components/project/ProjectInviteForm.tsx
+++ b/FE/src/components/project/ProjectInviteForm.tsx
@@ -27,7 +27,7 @@ const ProjectInviteForm = ({ projectTitle, projectSubject }: ProjectInviteFormPr
           검색
         </button>
       </div>
-      <div className="flex flex-wrap w-[31.25rem] mx-auto">
+      <div className="flex flex-wrap w-[31.25rem] gap-1 mx-auto">
         {userList.map((user) => (
           <div
             key={user.userId}

--- a/FE/src/constants/constants.tsx
+++ b/FE/src/constants/constants.tsx
@@ -15,7 +15,7 @@ export const API_URL = {
 
 export const CLIENT_URL = {
   PROJECT: '/project',
-  BACKLOG: '/backlog',
+  BACKLOG: (id: number | string) => `/backlog/${id}`,
 };
 
 export const reviewTabs = ['스프린트 정보', '차트', '회고란'];

--- a/FE/src/hooks/pages/project/useCreateNewProject.ts
+++ b/FE/src/hooks/pages/project/useCreateNewProject.ts
@@ -1,3 +1,4 @@
+import { useUserState } from '../../../stores';
 import { ProjectUser } from '../../../types/project';
 import { usePostNewProject } from '../../queries/project';
 
@@ -8,8 +9,10 @@ interface UseCreateNewProjectProps {
 }
 
 const useCreateNewProject = ({ projectTitle, projectSubject, userList }: UseCreateNewProjectProps) => {
-  const { mutateAsync } = usePostNewProject(userList);
-  const memberList = userList.map((user) => user.userId);
+  const userIdState = useUserState((state) => state.id);
+  const usernameState = useUserState((state) => state.username);
+  const { mutateAsync } = usePostNewProject([{ userId: userIdState, userName: usernameState }, ...userList]);
+  const memberList = [userIdState, ...userList.map((user) => user.userId)];
   const handleCreateButtonClick = async () => {
     const body = {
       name: projectTitle,

--- a/FE/src/hooks/pages/project/useSearchUsername.ts
+++ b/FE/src/hooks/pages/project/useSearchUsername.ts
@@ -1,21 +1,28 @@
 import { useRef, useState } from 'react';
 import { ProjectUser } from '../../../types/project';
 import { fetchGetUsername } from '../../../apis/project';
+import { useUserState } from '../../../stores';
 
 const useSearchUsername = () => {
   const usernameInputRef = useRef<HTMLInputElement>(null);
   const [userList, setUserList] = useState<ProjectUser[]>([]);
+  const usernameState = useUserState((state) => state.username);
 
   const handleSearchClick = async () => {
     if (!usernameInputRef.current) return;
 
-    if (!usernameInputRef.current.value) {
+    if (!usernameInputRef.current.value.trim()) {
       window.alert('닉네임을 입력해주세요');
       return;
     }
 
     if (userList.some((user) => user.userName === usernameInputRef.current?.value)) {
-      window.alert('이미 존재하는 닉네임입니다.');
+      window.alert('이미 존재하는 닉네임입니다');
+      return;
+    }
+
+    if (usernameState === usernameInputRef.current.value) {
+      window.alert('자기 자신을 초대할 수 없습니다');
       return;
     }
 

--- a/FE/src/hooks/queries/project/usePostNewProject.ts
+++ b/FE/src/hooks/queries/project/usePostNewProject.ts
@@ -11,7 +11,7 @@ const usePostNewProject = (userList: ProjectUser[]) => {
   return useMutation({
     mutationFn: fetchPostProject,
     onSuccess: (data) => {
-      const NEXT_URL = `${CLIENT_URL.BACKLOG}/${data}`;
+      const NEXT_URL = CLIENT_URL.BACKLOG(data);
       updateProjectData({ id: data, userList });
       navigate(NEXT_URL);
     },


### PR DESCRIPTION
# 설명
1. 사용자의 본인의 정보를 프로젝트 생성 시, 참여자에 자동으로 추가하는 로직을 작성
- 사용자 정보(닉네임, id)를 전역에서 관리할 수 있게 되어, 본인이 생성하는 프로젝트에 자신의 정보를 자동으로 추가하는 로직을 추가
- 사용자 자신을 닉네임 검색 할 경우, 추가하지 않고 사용자에게 본인을 추가할 수 없도록 고지하는 로직을 추가
2. 복수의 인원을 추가했을 경우, 화면 스타일을 수정하는 코드 작성
<img width="539" alt="image" src="https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/01c9aa45-d4f6-47e1-b632-ce8678dd51cc">
