### PR TITLE
스프린트 생성 시 태스크 설정 기능, 칸반보드, 스프린트 종료

### DIFF
--- a/FE/src/apis/sprint/fetchPatchSprintEnd.ts
+++ b/FE/src/apis/sprint/fetchPatchSprintEnd.ts
@@ -1,0 +1,8 @@
+import { api } from '../api';
+
+const fetchPatchSprintEnd = async (id: number) => {
+  const response = await api.patch('/sprints/complete', { id });
+  return response;
+};
+
+export default fetchPatchSprintEnd;

--- a/FE/src/components/sprint/FilterDropdown.tsx
+++ b/FE/src/components/sprint/FilterDropdown.tsx
@@ -1,12 +1,8 @@
+import { ProjectUser } from '../../types/project';
 import { UserFilter, TaskGroup } from '../../types/sprint';
 
-interface User {
-  id?: string;
-  name: string;
-}
-
 interface FilterDropdownProps {
-  userList: User[];
+  userList: ProjectUser[];
   userToFilter: UserFilter;
   taskGroup: TaskGroup;
   onUserFilterButtonClick: (user: UserFilter) => void;
@@ -22,15 +18,15 @@ const FilterDropdown = (props: FilterDropdownProps) => {
   return (
     <ul className="flex flex-col gap-1.5 absolute w-32 p-3 border rounded top-8 border-green-stroke bg-true-white">
       <p className="font-bold text-center ">멤버별 필터</p>
-      {userList.map(({ id, name }) => (
+      {userList.map(({ userId, userName }) => (
         <p
-          key={name}
+          key={userId}
           className={`text-center text-xs hover:cursor-pointer ${
-            id === userToFilter ? activeMenuClass : inactiveMenuClass
+            userId === userToFilter ? activeMenuClass : inactiveMenuClass
           }`}
-          onClick={() => onUserFilterButtonClick(id)}
+          onClick={() => onUserFilterButtonClick(userId)}
         >
-          {name}
+          {userName}
         </p>
       ))}
       <hr className="bg-green-stroke" />

--- a/FE/src/components/sprint/KanbanBoard.tsx
+++ b/FE/src/components/sprint/KanbanBoard.tsx
@@ -1,20 +1,31 @@
+import ChevronDownIcon from '../../assets/icons/ChevronDownIcon';
+import ChevronRightIcon from '../../assets/icons/ChevronRightIcon';
+import useDetail from '../../hooks/pages/backlog/useDetail';
+
 interface KanbanBoardProps {
   storyTitle?: string;
   storyId?: number;
-  storyNumber?: number;
+  storySequence?: number;
   children: React.ReactNode;
 }
 
-const KanbanBoard = ({ storyTitle, storyNumber, children }: KanbanBoardProps) => (
-  <div>
-    {storyTitle && (
-      <p className="flex items-center gap-2 mb-2.5">
-        <span className="text-sm font-bold text-starbucks-green">LES-{storyNumber}</span>
-        <span className="text-xs font-medium ">{storyTitle}</span>
-      </p>
-    )}
-    <div className="flex justify-between gap-8">{children}</div>
-  </div>
-);
+const KanbanBoard = ({ storyTitle, storySequence, children }: KanbanBoardProps) => {
+  const { detail, toggleDetail } = useDetail();
+
+  return (
+    <div>
+      {storyTitle && (
+        <button onClick={toggleDetail} className="flex items-center pb-2.5">
+          {detail ? <ChevronDownIcon /> : <ChevronRightIcon />}
+          <p className="flex items-center gap-2">
+            <span className="text-sm font-bold text-starbucks-green">LES-{storySequence}</span>
+            <span className="text-xs font-medium ">{storyTitle}</span>
+          </p>
+        </button>
+      )}
+      <div className={`${!detail && 'hidden'} flex justify-between gap-8 `}>{children}</div>
+    </div>
+  );
+};
 
 export default KanbanBoard;

--- a/FE/src/components/sprint/modal/SprintEndModal.tsx
+++ b/FE/src/components/sprint/modal/SprintEndModal.tsx
@@ -1,0 +1,39 @@
+import { usePatchSprintEnd } from '../../../hooks/queries/sprint';
+
+interface SprintEndModalProps {
+  id: number;
+  close: () => void;
+}
+
+const SprintEndModal = ({ id, close }: SprintEndModalProps) => {
+  const { mutateAsync } = usePatchSprintEnd();
+
+  const handleDeleteClick = async () => {
+    await mutateAsync(id);
+    close();
+  };
+
+  return (
+    <div className="fixed top-0 left-0 flex items-center justify-center w-screen h-screen bg-black bg-opacity-30 ">
+      <div className="bg-white h-[200px] w-[400px] pb-8 pt-16 px-8 flex flex-col justify-between rounded-md border border-light-gray">
+        <p className="font-bold text-center text-ml">스프린트를 종료하시겠습니까?</p>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={close}
+            className="w-[4.5rem] border-2 rounded-md border-starbucks-green px-4 py-1.5 font-bold text-starbucks-green text-s"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleDeleteClick}
+            className="w-[4.5rem] min-w-18 rounded-md px-4 py-1.5 font-bold text-true-white bg-error-red text-s"
+          >
+            종료
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SprintEndModal;

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -1,46 +1,76 @@
 import { Draggable, Droppable } from 'react-beautiful-dnd';
-import { ReadBacklogTaskResponseDto } from '../../../types/backlog';
 import TaskComponent from '../../backlog/TaskComponent';
+import ClosedIcon from '../../../assets/icons/ClosedIcon';
+import { SprintBacklog } from '../../../types/sprint';
+import { useQueryClient } from '@tanstack/react-query';
+import { ReadBacklogEpicResponseDto } from '../../../types/backlog';
 
 interface SprintBacklogComponentProps {
-  sprintBacklog: ReadBacklogTaskResponseDto[];
+  sprintBacklog: SprintBacklog[];
+  setSprintBacklog: React.Dispatch<React.SetStateAction<SprintBacklog[]>>;
 }
 
-const SprintBacklogComponent = ({ sprintBacklog }: SprintBacklogComponentProps) => (
-  <Droppable droppableId="sprintBacklog">
-    {(provided) => (
-      <div
-        className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7"
-        {...provided.droppableProps}
-        ref={provided.innerRef}
-      >
-        {!sprintBacklog.length ? (
-          <>
-            <p className="mt-[11rem] mb-[1.25rem] font-bold text-ml text-light-gray">이번 스프린트에서 진행할 과제를</p>
-            <p className="font-bold text-ml text-light-gray">백로그에서 드래그 하세요</p>
-          </>
-        ) : (
-          <div className="w-full border-b border-x border-transparent-green">
-            {sprintBacklog.map((task, index) => (
-              <Draggable draggableId={String(task.id)} index={index} key={task.id}>
-                {(provided) => (
-                  <div
-                    className="w-full border-transparent-green"
-                    {...provided.dragHandleProps}
-                    {...provided.draggableProps}
-                    ref={provided.innerRef}
-                  >
-                    <TaskComponent {...task} />
-                  </div>
-                )}
-              </Draggable>
-            ))}
-          </div>
-        )}
-        {provided.placeholder}
-      </div>
-    )}
-  </Droppable>
-);
+const SprintBacklogComponent = ({ sprintBacklog, setSprintBacklog }: SprintBacklogComponentProps) => {
+  const queryClient = useQueryClient();
+  const handleDeleteButtonClick = (task: SprintBacklog, index: number) => {
+    const { epicIndex, storyIndex, taskIndex } = task;
+
+    queryClient.setQueryData(['backlogs', 1, 'sprint'], (prevBacklog: { epicList: ReadBacklogEpicResponseDto[] }) => {
+      const newBacklogData = structuredClone(prevBacklog);
+      newBacklogData.epicList[epicIndex].storyList[storyIndex].taskList.splice(taskIndex, 0, { ...task });
+      return newBacklogData;
+    });
+
+    setSprintBacklog((prevSprintBacklog) => {
+      const newSprintBacklog = structuredClone(prevSprintBacklog);
+      newSprintBacklog.splice(index, 1);
+      return newSprintBacklog;
+    });
+  };
+
+  return (
+    <Droppable droppableId="sprintBacklog">
+      {(provided) => (
+        <div
+          className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7"
+          {...provided.droppableProps}
+          ref={provided.innerRef}
+        >
+          {!sprintBacklog.length ? (
+            <>
+              <p className="mt-[11rem] mb-[1.25rem] font-bold text-ml text-light-gray">
+                이번 스프린트에서 진행할 과제를
+              </p>
+              <p className="font-bold text-ml text-light-gray">백로그에서 드래그 하세요</p>
+            </>
+          ) : (
+            <div className="w-full border-b border-x border-transparent-green">
+              {sprintBacklog.map((task, index) => (
+                <Draggable draggableId={String(task.id)} index={index} key={task.id}>
+                  {(provided) => (
+                    <div
+                      className="flex items-center justify-between"
+                      {...provided.dragHandleProps}
+                      {...provided.draggableProps}
+                      ref={provided.innerRef}
+                    >
+                      <div className="w-full">
+                        <TaskComponent {...task} />
+                      </div>
+                      <button className="pr-2" onClick={() => handleDeleteButtonClick(task, index)}>
+                        <ClosedIcon color="text-error-red" />
+                      </button>
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+            </div>
+          )}
+          {provided.placeholder}
+        </div>
+      )}
+    </Droppable>
+  );
+};
 
 export default SprintBacklogComponent;

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogSetting.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogSetting.tsx
@@ -1,14 +1,15 @@
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import RightBracketIcon from '../../../assets/icons/RightBracketIcon';
-import { ReadBacklogEpicResponseDto, ReadBacklogTaskResponseDto } from '../../../types/backlog';
+import { ReadBacklogEpicResponseDto } from '../../../types/backlog';
 import BacklogComponent from './BacklogComponent';
 import SprintBacklogComponent from './SprintBacklogComponent';
 import { useQueryClient } from '@tanstack/react-query';
+import { SprintBacklog } from '../../../types/sprint';
 
 interface SprintBacklogSettingProps {
   backlog: { epicList: ReadBacklogEpicResponseDto[] };
-  sprintBacklog: ReadBacklogTaskResponseDto[];
-  setSprintBacklog: React.Dispatch<React.SetStateAction<ReadBacklogTaskResponseDto[]>>;
+  sprintBacklog: SprintBacklog[];
+  setSprintBacklog: React.Dispatch<React.SetStateAction<SprintBacklog[]>>;
 }
 
 const SprintBacklogSetting = (props: SprintBacklogSettingProps) => {
@@ -35,7 +36,13 @@ const SprintBacklogSetting = (props: SprintBacklogSettingProps) => {
 
     const [epicIndex, storyIndex] = source.droppableId.split(' ').map((id) => Number(id));
 
-    const targetTask = { ...backlog.epicList[epicIndex].storyList[storyIndex].taskList[source.index] };
+    const targetTask: SprintBacklog = {
+      ...backlog.epicList[epicIndex].storyList[storyIndex].taskList[source.index],
+      epicIndex,
+      storyIndex,
+      taskIndex: source.index,
+    };
+
     queryClient.setQueryData(['backlogs', 1, 'sprint'], (prevBacklog: { epicList: ReadBacklogEpicResponseDto[] }) => {
       const newBacklogData = structuredClone(prevBacklog);
       newBacklogData.epicList[epicIndex].storyList[storyIndex].taskList.splice(source.index, 1);
@@ -65,8 +72,8 @@ const SprintBacklogSetting = (props: SprintBacklogSettingProps) => {
               <p className="font-bold text-starbucks-green text-s">&</p>
               <p className="font-bold text-starbucks-green text-s">DROP</p>
             </div>
-            <div className="flex flex-col gap-3 min-w-[36.25rem]">
-              <SprintBacklogComponent sprintBacklog={sprintBacklog} />
+            <div className="flex flex-col gap-3 min-w-[36.25rem] max-w-[36.25rem]">
+              <SprintBacklogComponent sprintBacklog={sprintBacklog} setSprintBacklog={setSprintBacklog} />
               <button className="p-3 rounded bg-starbucks-green text-true-white">스프린트 생성하기</button>
             </div>
           </div>

--- a/FE/src/hooks/queries/sprint/index.ts
+++ b/FE/src/hooks/queries/sprint/index.ts
@@ -1,0 +1,2 @@
+export { default as useGetProgressSprint } from './useGetProgressSprint';
+export { default as usePatchTaskState } from './usePatchTaskState';

--- a/FE/src/hooks/queries/sprint/index.ts
+++ b/FE/src/hooks/queries/sprint/index.ts
@@ -1,2 +1,3 @@
 export { default as useGetProgressSprint } from './useGetProgressSprint';
 export { default as usePatchTaskState } from './usePatchTaskState';
+export { default as usePatchSprintEnd } from './usePatchSprintEnd';

--- a/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
+++ b/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
@@ -3,6 +3,7 @@ import { api } from '../../../apis/api';
 import { Task } from '../../../types/sprint';
 
 interface Sprint {
+  sprintId: number;
   sprintTitle: string;
   sprintGoal: string;
   sprintStartDate: string;

--- a/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
+++ b/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../../../apis/api';
+import { Task } from '../../../types/sprint';
+
+interface Sprint {
+  sprintTitle: string;
+  sprintGoal: string;
+  sprintStartDate: string;
+  sprintEndDate: string;
+  sprintEnd: boolean;
+  sprintModal: boolean;
+  taskList: Task[];
+}
+
+const useGetProgressSprint = (projectId: number) =>
+  useQuery<Sprint>({
+    queryKey: ['sprint'],
+    queryFn: async () => {
+      const response = await api.get(`/projects/${projectId}/sprints/progress`);
+      return response.data;
+    },
+  });
+
+export default useGetProgressSprint;

--- a/FE/src/hooks/queries/sprint/usePatchSprintEnd.ts
+++ b/FE/src/hooks/queries/sprint/usePatchSprintEnd.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import fetchPatchSprintEnd from '../../../apis/sprint/fetchPatchSprintEnd';
+import { useNavigate } from 'react-router-dom';
+
+const usePatchSprintEnd = () => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async (id: number) => await fetchPatchSprintEnd(id),
+    onSuccess: () => {
+      navigate('/review/sprint');
+    },
+  });
+};
+
+export default usePatchSprintEnd;

--- a/FE/src/hooks/queries/sprint/usePatchTaskState.ts
+++ b/FE/src/hooks/queries/sprint/usePatchTaskState.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../../../apis/api';
+
+const usePatchTaskState = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, state }: { id: number; state: string }) =>
+      await api.patch('/backlogs/task', { id, state }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sprint'] });
+    },
+  });
+};
+
+export default usePatchTaskState;

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -7,10 +7,11 @@ import FilterDropdown from '../components/sprint/FilterDropdown';
 import { Task } from '../types/sprint';
 import { UserFilter, TaskGroup } from '../types/sprint';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
-import { useNavigate } from 'react-router';
 import { transformDate } from '../utils/date';
 import { useSelectedProjectState } from '../stores';
 import { useGetProgressSprint, usePatchTaskState } from '../hooks/queries/sprint';
+import { useModal } from '../modal/useModal';
+import SprintEndModal from '../components/sprint/modal/SprintEndModal';
 
 interface BoardTaskListObject {
   storyId?: number;
@@ -31,7 +32,7 @@ const SprintPage = () => {
   const { id: projectId, userList } = useSelectedProjectState();
   const { data, isLoading } = useGetProgressSprint(projectId);
   const { mutate } = usePatchTaskState();
-  const navigate = useNavigate();
+  const endModal = useModal();
   const userFilterList = useMemo(() => [{ userId: -1, userName: '전체' }, ...userList], [userList]);
 
   useEffect(() => {
@@ -102,7 +103,9 @@ const SprintPage = () => {
   };
 
   const handleSprintEndButtonClick = () => {
-    navigate('/review');
+    if (data) {
+      endModal.open(<SprintEndModal id={data.sprintId} close={endModal.close} />);
+    }
   };
 
   const [todoNumber, inProgressNumber, doneNumber] = useMemo(() => {
@@ -121,12 +124,16 @@ const SprintPage = () => {
 
   if (data?.sprintModal) {
     return (
-      <div className="flex flex-col items-center">
+      <div className="flex flex-col items-center min-w-[60.25rem]">
         <p>스프린트가 종료되었습니다.</p>
         <p>회고를 진행하시겠습니까?</p>
         <button>회고 진행하기</button>
       </div>
     );
+  }
+
+  if (data?.sprintEnd) {
+    return <div className="min-w-[60.25rem]">진행 중인 스프린트가 없습니다.</div>;
   }
 
   if (data) {

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -119,6 +119,16 @@ const SprintPage = () => {
     return <div>칸반보드 로딩중</div>;
   }
 
+  if (data?.sprintModal) {
+    return (
+      <div className="flex flex-col items-center">
+        <p>스프린트가 종료되었습니다.</p>
+        <p>회고를 진행하시겠습니까?</p>
+        <button>회고 진행하기</button>
+      </div>
+    );
+  }
+
   if (data) {
     return (
       <section className="min-w-[60.25rem]">

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -14,7 +14,7 @@ import { useGetProgressSprint, usePatchTaskState } from '../hooks/queries/sprint
 
 interface BoardTaskListObject {
   storyId?: number;
-  storyNumber?: number;
+  storySequence?: number;
   storyTitle?: string;
   ToDo: Task[];
   InProgress: Task[];
@@ -190,12 +190,12 @@ const SprintPage = () => {
           </div>
           <ul className="flex flex-col gap-y-1.5">
             {boardTaskList?.map((taskListByStory, index) => {
-              const { storyId, storyNumber, storyTitle } = taskListByStory;
+              const { storyId, storySequence, storyTitle } = taskListByStory;
 
               return (
                 <li key={index}>
                   <DragDropContext onDragEnd={handleDragEnd}>
-                    <KanbanBoard {...{ storyId, storyNumber, storyTitle }}>
+                    <KanbanBoard {...{ storyId, storySequence, storyTitle }}>
                       <ColumnBoard taskList={taskListByStory?.ToDo} state="ToDo" {...{ storyId }} />
                       <ColumnBoard taskList={taskListByStory?.InProgress} state="InProgress" {...{ storyId }} />
                       <ColumnBoard taskList={taskListByStory?.Done} state="Done" {...{ storyId }} />

--- a/FE/src/pages/sprint/SprintCreatePage.tsx
+++ b/FE/src/pages/sprint/SprintCreatePage.tsx
@@ -4,11 +4,11 @@ import { api } from '../../apis/api';
 import SprintBacklogSetting from '../../components/sprint/sprintCreate/SprintBacklogSetting';
 import { CreateProcessHeader, CreateProcessText } from '../../components/common/CreateProcess';
 import { BACKLOG_URL, PROCESS_NUMBER } from '../../constants/constants';
-import { ReadBacklogTaskResponseDto } from '../../types/backlog';
+import { SprintBacklog } from '../../types/sprint';
 
 const SprintCreatePage = () => {
   const [process, setProcess] = useState<number>(PROCESS_NUMBER.PROCESS1);
-  const [sprintBacklog, setSprintBacklog] = useState<ReadBacklogTaskResponseDto[]>([]);
+  const [sprintBacklog, setSprintBacklog] = useState<SprintBacklog[]>([]);
   const { data: backlog, isLoading } = useQuery({
     queryKey: ['backlogs', 1, 'sprint'],
     queryFn: async () => {

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -1,6 +1,6 @@
 export type TaskGroup = 'all' | 'story';
 
-export type UserFilter = undefined | string;
+export type UserFilter = number;
 
 export type TaskState = 'ToDo' | 'InProgress' | 'Done' | string;
 
@@ -8,7 +8,7 @@ export interface Task {
   id: number;
   sequence: number;
   title: string;
-  userId: string;
+  userId: number;
   point: number;
   state: TaskState;
   storyId: number;

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -1,3 +1,5 @@
+import { ReadBacklogTaskResponseDto } from './backlog';
+
 export type TaskGroup = 'all' | 'story';
 
 export type UserFilter = number;
@@ -15,4 +17,10 @@ export interface Task {
   storySequence: number;
   storyTitle: string;
   condition: string;
+}
+
+export interface SprintBacklog extends ReadBacklogTaskResponseDto {
+  epicIndex: number;
+  storyIndex: number;
+  taskIndex: number;
 }


### PR DESCRIPTION
## Task

- [LES-196] 연동된 API로 받아오는 데이터에 맞게 필터링 로직을 수정한다.
- [LES-240] 드래그 앤 드롭을 통해 스프린트 백로그에 태스크 추가 기능 구현
- [LES-279] 스프린트 종료 API 연동

## 설명
### 스프린트 백로그에 추가된 태스크 제거
- 태스크 옆에 x 아이콘을 두고 클릭 시 백로그로 돌아가도록 했습니다. 
![녹화_2023_12_07_11_52_22_661](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/3dfe1522-3778-4960-96bf-351f9942a00b)

### 필터링 로직 수정
- projectState에서 useList를 가져와서 sprint 페이지 필터링에 반영되도록 했습니다.

### 스프린트 종료 API 연동
- 스프린트 종료를 누르면 종료를 확인하는 모달이 뜨고, 해당 모달에서 종료를 누르면 종료 요청이 가고 리뷰 페이지로 이동하도록 했습니다.

## 고민 사항
- 스프린트 백로그 태스크를 제거했을 때 이전 자리로 돌아가도록 했지만 완전히 순서가 일치하도록 하지는 못했습니다.
``` typescript
// 타겟 설정 시 이전에 있던 index 기억
const targetTask: SprintBacklog = {
  ...backlog.epicList[epicIndex].storyList[storyIndex].taskList[source.index],
  epicIndex,
  storyIndex,
  taskIndex: source.index,
};

// 삭제할 때 이전 인덱스를 기반으로 추가
queryClient.setQueryData(['backlogs', 1, 'sprint'], (prevBacklog: { epicList: ReadBacklogEpicResponseDto[] }) => {
    const newBacklogData = structuredClone(prevBacklog);
    newBacklogData.epicList[epicIndex].storyList[storyIndex].taskList.splice(taskIndex, 0, { ...task });
    return newBacklogData;
  });
```
- 위처럼 현재는 이전 index를 기억하고 그 부분으로 돌아가는 방식으로 로직을 작성했습니다. 그런데 이렇게 하면 태스크가 추가, 제거될 때마다 상대적인 index 값이 달라져서 이전과 동일한 순서가 보장되지 않습니다. 이전과 동일한 순서를 유지하는 게 필요할지, 필요하다면 어떻게 유지시킬지 고민이 됩니다.