### PR TITLE
fix: update modal 타입 에러 수정

### DIFF
--- a/FE/src/components/backlog/Modal/TaskModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskModal.tsx
@@ -3,7 +3,7 @@ import { ReadBacklogTaskResponseDto } from '../../../types/backlog';
 import BacklogDeleteModal from './BacklogDeleteModal';
 import TaskUpdateModal from './TaskUpdateModal';
 
-interface TaskModalProps extends ReadBacklogTaskResponseDto {
+export interface TaskModalProps extends ReadBacklogTaskResponseDto {
   close: () => void;
 }
 
@@ -76,7 +76,7 @@ const TaskModal = (props: TaskModalProps) => {
             type="button"
             className="border-2 rounded-md border-starbucks-green px-4 py-1.5 bg-starbucks-green font-bold text-true-white text-s"
             onClick={() => {
-              updateModal.open(<TaskUpdateModal close={updateModal.close} defaultData={props} />);
+              updateModal.open(<TaskUpdateModal {...{ ...props, close: updateModal.close }} />);
               close();
             }}
           >

--- a/FE/src/components/backlog/Modal/TaskPostModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskPostModal.tsx
@@ -11,7 +11,7 @@ interface TaskPostModalProps {
 interface TaskPostBody {
   parentId: number;
   title: string;
-  userId: string;
+  userId: string | number;
   point: number;
   condition: string;
 }

--- a/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
@@ -3,25 +3,28 @@ import { useRef } from 'react';
 import { api } from '../../../apis/api';
 import TaskForm from '../TaskForm';
 
-interface TaskUpdateModalProps {
-  close: () => void;
-  defaultData: TaskUpdateBody;
-}
+// interface TaskUpdateModalProps {
+//   close: () => void;
+//   defaultData: TaskUpdateBody;
+// }
 
-interface TaskUpdateBody {
-  id: number;
-  title: string;
-  userId: string;
-  point: number;
-  condition: string;
-}
+// interface TaskUpdateBody {
+//   id: number;
+//   title: string;
+//   userId: string | string;
+//   point: number;
+//   condition: string;
+// }
 
-const TaskUpdateModal = ({ close, defaultData }: TaskUpdateModalProps) => {
+import { TaskModalProps } from './TaskModal';
+import { ReadBacklogTaskResponseDto } from '../../../types/backlog';
+
+const TaskUpdateModal = ({ close, id, title, userId, point, condition }: TaskModalProps) => {
   const formRef = useRef<HTMLFormElement>(null);
   const getBody = () => {
-    if (!formRef.current) return defaultData as TaskUpdateBody;
+    if (!formRef.current) return { id, title, userId, point, condition };
     return [...formRef.current.querySelectorAll('input'), formRef.current.querySelector('textarea')].reduce(
-      (acc: TaskUpdateBody, cur: HTMLInputElement | HTMLTextAreaElement | null) => {
+      (acc: ReadBacklogTaskResponseDto, cur: HTMLInputElement | HTMLTextAreaElement | null) => {
         if (!cur) return acc;
         const newData = {
           ...acc,
@@ -29,7 +32,7 @@ const TaskUpdateModal = ({ close, defaultData }: TaskUpdateModalProps) => {
         };
         return newData;
       },
-      { id: defaultData.id } as TaskUpdateBody,
+      { id } as ReadBacklogTaskResponseDto,
     );
   };
   const queryClient = useQueryClient();
@@ -50,7 +53,12 @@ const TaskUpdateModal = ({ close, defaultData }: TaskUpdateModalProps) => {
 
   return (
     <>
-      <TaskForm close={close} handleSubmit={handleSubmit} formRef={formRef} defaultData={defaultData} />
+      <TaskForm
+        close={close}
+        handleSubmit={handleSubmit}
+        formRef={formRef}
+        defaultData={{ id, title, userId, point, condition }}
+      />
     </>
   );
 };

--- a/FE/src/components/backlog/TaskForm.tsx
+++ b/FE/src/components/backlog/TaskForm.tsx
@@ -5,7 +5,7 @@ interface TaskFormProps {
   defaultData?: {
     id: number;
     title: string;
-    userId: string;
+    userId: string | number;
     point: number;
     condition: string;
   } | null;
@@ -15,11 +15,7 @@ const TaskForm = ({ handleSubmit, close, formRef, defaultData = null }: TaskForm
   return (
     <div className="fixed top-0 left-0 bg-black w-screen h-screen bg-opacity-30 flex justify-center items-center font-pretendard">
       <div className="w-[31.875rem] h-[33.75rem] rounded-md bg-white p-6 text-house-green">
-        <form
-          className="flex flex-col h-full justify-between"
-          onSubmit={handleSubmit}
-          ref={formRef}
-        >
+        <form className="flex flex-col h-full justify-between" onSubmit={handleSubmit} ref={formRef}>
           <p className="text-l font-bold">Task</p>
           <label className="text-s" htmlFor="title">
             <span className="text-m font-bold pr-2">업무 내용</span>
@@ -44,9 +40,9 @@ const TaskForm = ({ handleSubmit, close, formRef, defaultData = null }: TaskForm
               id="condition"
               name="condition"
               placeholder={
-                "예시 조건)\n" +
-                "몇 개의 테스트 코드를 통과해야 합니다\n" +
-                "사전에 작성한 예상 유저 시나리오와 비교하여 동작을 확인합니다"
+                '예시 조건)\n' +
+                '몇 개의 테스트 코드를 통과해야 합니다\n' +
+                '사전에 작성한 예상 유저 시나리오와 비교하여 동작을 확인합니다'
               }
               defaultValue={defaultData?.condition}
             />

--- a/FE/src/components/sprint/TaskCard.tsx
+++ b/FE/src/components/sprint/TaskCard.tsx
@@ -3,7 +3,7 @@ import { useModal } from '../../modal/useModal';
 import TaskModal from '../backlog/Modal/TaskModal';
 
 interface TaskCardProps {
-  userId: string;
+  userId: string | number;
   id: number;
   title: string;
   state: string;

--- a/FE/src/types/backlog.ts
+++ b/FE/src/types/backlog.ts
@@ -5,7 +5,7 @@ export interface CompositionComponentProps {
 }
 
 export interface ReadBacklogTaskResponseDto {
-  userId: string;
+  userId: string | number;
   id: number;
   title: string;
   state: string;


### PR DESCRIPTION
# 설명
1. type을 각자 작성해서 호출하여 사용하는 문제로 인해 각자가 작성한 타입간 불일치(userId: string 혹은 number를 혼재하여 사용)
2. 해당 타입 에러의 문제를 임시로 string|number로 설정하여 리팩토링 전 임시 문제 해결
3. UpdateModal의 경우 prop으로 데이터를 전달할 때, 불필요한 "defaultData" 형태를 구성하여 전달하였기 때문에, 데이터 전달 간 타입 에러 발생
    - 해당 코드에 불필요한 defaultData 형태를 제거하고, prop data를 데이터를 전달하는 형태의 타입을 재사용하여 전달