### PR TITLE
refactor: [sprint-create] 스프린트 종료일 input type 변경

### DIFF
--- a/FE/src/components/sprint/sprintCreate/SprintGoalSetting.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintGoalSetting.tsx
@@ -1,5 +1,4 @@
-import { SetStateAction, useState } from 'react';
-import CalendarIcon from '../../../assets/icons/CalendarIcon';
+import { SetStateAction } from 'react';
 
 interface SprintGoalSettingProps {
   handleNextButtonClick: () => void;
@@ -16,7 +15,6 @@ const SprintGoalSetting = ({
   setSprintGoal,
   handleNextButtonClick,
 }: SprintGoalSettingProps) => {
-  const [isDateInput, setIsDateInput] = useState<boolean>(false);
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (sprintGoal.trim() === '') {
@@ -38,7 +36,7 @@ const SprintGoalSetting = ({
           이번 스프린트는 어떤 것을 만들 것인가요?
         </label>
         <input
-          className="p-3 border-2 rounded-md outline-none border-starbucks-green"
+          className="p-3 border-2 border-starbucks-green outline-house-green rounded-md"
           type="text"
           id="goal"
           placeholder="스프린트 목표"
@@ -46,26 +44,18 @@ const SprintGoalSetting = ({
           onChange={(e) => setSprintGoal(e.target.value)}
         />
         <label className="font-bold text-starbucks-green" htmlFor="date">
-          스프린트 기간은 어떻게 되나요?
+          스프린트 종료일은 어떻게 되나요?
         </label>
-        <div className="flex items-center w-[167px] h-[45px] px-3 border-2 border-starbucks-green outline-house-green rounded-md text-light-gray">
-          <input
-            className="w-full bg-transparent outline-none"
-            type={isDateInput ? 'date' : 'text'}
-            id="date"
-            placeholder="종료일"
-            value={sprintEndDate}
-            onFocus={() => setIsDateInput(true)}
-            onBlur={() => setIsDateInput(false)}
-            onChange={(e) => setSprintEndDate(e.target.value)}
-          />
-          {!isDateInput && (
-            <label htmlFor="date">
-              <CalendarIcon color="text-starbucks-green" />
-            </label>
-          )}
-        </div>
-        <button className="p-3 font-bold rounded-md bg-starbucks-green text-m text-true-white">다음으로</button>
+        <input
+          className={`flex items-center w-[167px] h-[45px] px-3 border-2 border-starbucks-green outline-house-green rounded-md ${
+            sprintEndDate === '' && 'text-light-gray'
+          }`}
+          type="date"
+          id="date"
+          value={sprintEndDate}
+          onChange={(e) => setSprintEndDate(e.target.value)}
+        />
+        <button className="p-3 bg-starbucks-green rounded-md font-bold text-m text-true-white">다음으로</button>
       </form>
     </div>
   );


### PR DESCRIPTION
- 기존 : 스프린트 기간을 설정하는 입력 필드에서 placeholder를 '종료일'로 표시하기 위해, 초기에는 text 타입으로 설정하고, 사용자가 입력란에 초점을 맞추거나 클릭했을 때, 자동으로 date 타입으로 변경되도록 코드를 수정

- 수정 : 스프린트 기간을 설정하는 입력 필드를 date 타입으로 설정

![스프린트 기간](https://github.com/boostcampwm2023/web10-Lesser/assets/84658111/b15a9132-8a82-4844-9389-ba8a29e5caa3)
![스프린트 종료일](https://github.com/boostcampwm2023/web10-Lesser/assets/84658111/678804a6-abba-4e7b-93ae-58076829acc3)