### PR TITLE
로그인 가드 구현, 태스크 설정 기능 수정

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -9,6 +9,7 @@ import ProjectCreatePage from './pages/project/ProjectCreatePage';
 import { ModalProvider } from './modal/ModalProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SprintCreatePage from './pages/sprint/SprintCreatePage';
+import PrivateRoute from './components/common/PrivateRoute';
 
 const queryClient = new QueryClient();
 
@@ -18,13 +19,16 @@ function App() {
       <ModalProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/projects" element={<ProjectPage />} />
-          <Route path="/projects/create" element={<ProjectCreatePage />} />
-          <Route path="/projects/:id/sprint/create" element={<SprintCreatePage />} />
-          <Route element={<MainPage />}>
-            <Route path="/projects/:id/backlog" element={<BacklogPage />} />
-            <Route path="/projects/:id/sprint" element={<SprintPage />} />
-            <Route path="/projects/:id/review" element={<ReviewPage />} />
+          <Route element={<PrivateRoute />}>
+            <Route path="/" />
+            <Route path="/projects" element={<ProjectPage />} />
+            <Route path="/projects/create" element={<ProjectCreatePage />} />
+            <Route path="/projects/:id/sprint/create" element={<SprintCreatePage />} />
+            <Route element={<MainPage />}>
+              <Route path="/projects/:id/backlog" element={<BacklogPage />} />
+              <Route path="/projects/:id/sprint" element={<SprintPage />} />
+              <Route path="/projects/:id/review" element={<ReviewPage />} />
+            </Route>
           </Route>
         </Routes>
       </ModalProvider>

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
             <Route element={<MainPage />}>
               <Route path="/projects/:id/backlog" element={<BacklogPage />} />
               <Route path="/projects/:id/sprint" element={<SprintPage />} />
-              <Route path="/projects/:id/review" element={<ReviewPage />} />
+              <Route path="/projects/:id/review/*" element={<ReviewPage />} />
             </Route>
           </Route>
         </Routes>

--- a/FE/src/apis/api.ts
+++ b/FE/src/apis/api.ts
@@ -7,6 +7,13 @@ const setAccessToken = (newAccessToken: string | undefined): void => {
   accessToken = newAccessToken;
 };
 
+const isAccessTokenExisting = () => !!accessToken;
+const isRefreshTokenExisting = () => {
+  const refreshToken = sessionStorage.getItem(REFRESH_TOKEN);
+
+  return !!refreshToken;
+};
+
 const api = axios.create({
   baseURL: import.meta.env.VITE_NEST_API_URL,
   headers: {
@@ -91,4 +98,4 @@ api.interceptors.request.use((config) => {
 
 api.interceptors.response.use(requestSucceed, requestFail);
 
-export { api, setAccessToken };
+export { api, setAccessToken, isAccessTokenExisting, isRefreshTokenExisting };

--- a/FE/src/components/common/NavigationButton.tsx
+++ b/FE/src/components/common/NavigationButton.tsx
@@ -1,20 +1,35 @@
 import { Link } from 'react-router-dom';
 import { NavigationInformation } from '../../types/navigation';
+import { useSelectedProjectState } from '../../stores';
 
 interface NavigationButtonProps extends NavigationInformation {
   currentURI: string;
 }
 
 const NavigationButton = ({ pageName, description, pageURI, currentURI }: NavigationButtonProps) => {
-  const sameURL = currentURI === pageURI;
+  const { id } = useSelectedProjectState();
+  const isSameURL = () => {
+    const currentUriList = currentURI.split('/');
+    const pageUriList = pageURI(id).split('/');
+    const currentUriLength = currentUriList.length;
+    const pageUriLength = pageUriList.length;
+
+    if (currentUriLength === pageUriLength && currentUriList[currentUriLength - 1] === pageUriList[pageUriLength - 1]) {
+      return true;
+    }
+
+    return false;
+  };
 
   return (
     <Link
-      to={pageURI}
-      className={`flex flex-col items-center gap-2.5 ${sameURL ? 'bg-true-white py-3 px-5 rounded-lg h-40' : 'py-3'}`}
+      to={pageURI(id)}
+      className={`flex flex-col items-center gap-2.5 ${
+        isSameURL() ? 'bg-true-white py-3 px-5 rounded-lg h-40' : 'py-3'
+      }`}
     >
-      <p className={`text-lg font-bold ${sameURL ? 'text-house-green' : 'text-true-white'}`}>{pageName}</p>
-      {sameURL && <p className="text-xs font-medium text-house-green">{description}</p>}
+      <p className={`text-lg font-bold ${isSameURL() ? 'text-house-green' : 'text-true-white'}`}>{pageName}</p>
+      {isSameURL() && <p className="text-xs font-medium text-house-green">{description}</p>}
     </Link>
   );
 };

--- a/FE/src/components/common/PrivateRoute.tsx
+++ b/FE/src/components/common/PrivateRoute.tsx
@@ -1,0 +1,27 @@
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { isAccessTokenExisting, isRefreshTokenExisting } from '../../apis/api';
+import { useEffect } from 'react';
+
+const PrivateRoute = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isAccessTokenExisting() && !isRefreshTokenExisting()) {
+      navigate('/login');
+      return;
+    }
+
+    if (location.pathname === '/') {
+      navigate(`projects`);
+    }
+  }, []);
+
+  return (
+    <>
+      <Outlet />
+    </>
+  );
+};
+
+export default PrivateRoute;

--- a/FE/src/components/common/SideNavigationBar.tsx
+++ b/FE/src/components/common/SideNavigationBar.tsx
@@ -7,19 +7,19 @@ import useLogout from '../../hooks/pages/useLogout';
 const navigationInformation: NavigationInformation[] = [
   {
     pageName: '백로그',
-    pageURI: '/backlog',
+    pageURI: (projectId) => `/projects/${projectId}/backlog`,
     description:
       '백로그 페이지 설명. 백로그는 제품백로그와 스프린트 백로그가 있으며 에픽, 스토리, 태스크로 이루어진다.',
   },
   {
     pageName: '스프린트',
-    pageURI: '/sprint',
+    pageURI: (projectId) => `/projects/${projectId}/sprint`,
     description:
       '스프린트 페이지 설명. 스프린트 시작하면 칸반보드를 확인할 수 있고, 드래그 앤 드롭을 이용해 티켓을 옮길 수 있다.',
   },
   {
     pageName: '회고',
-    pageURI: '/review/sprint',
+    pageURI: (projectId) => `/projects/${projectId}/review/sprint`,
     description: '회고하는 페이지 설명. 스프린트 백로그 태스트 상태 분석, 번다운 차트, 회고 글 작성 칸이 있을 예정',
   },
 ];
@@ -42,7 +42,7 @@ const SideNavigationBar = () => {
           </li>
         ))}
       </ul>
-      <Link to={'project'} className="py-3 text-lg font-bold text-true-white">
+      <Link to={'projects'} className="py-3 text-lg font-bold text-true-white">
         내 프로젝트
       </Link>
       <button className="py-3 text-lg font-bold text-true-white" onClick={handleLogoutButtonClick}>

--- a/FE/src/components/sprint/modal/SprintEndModal.tsx
+++ b/FE/src/components/sprint/modal/SprintEndModal.tsx
@@ -3,10 +3,11 @@ import { usePatchSprintEnd } from '../../../hooks/queries/sprint';
 interface SprintEndModalProps {
   id: number;
   close: () => void;
+  projectId: number;
 }
 
-const SprintEndModal = ({ id, close }: SprintEndModalProps) => {
-  const { mutateAsync } = usePatchSprintEnd();
+const SprintEndModal = ({ id, projectId, close }: SprintEndModalProps) => {
+  const { mutateAsync } = usePatchSprintEnd(projectId);
 
   const handleDeleteClick = async () => {
     await mutateAsync(id);

--- a/FE/src/components/sprint/sprintCreate/BacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/BacklogComponent.tsx
@@ -6,8 +6,8 @@ import {
 } from '../../../types/backlog';
 import EpicComponent from '../../backlog/EpicComponent';
 import StoryComponent from '../../backlog/StoryComponent';
-import TaskComponent from '../../backlog/TaskComponent';
 import PostButton from '../../backlog/PostButton';
+import SprintBacklogTask from './SprintBacklogTask';
 
 interface BacklogComponentProps {
   backlog: { epicList: ReadBacklogEpicResponseDto[] };
@@ -28,7 +28,7 @@ const BacklogComponent = ({ backlog }: BacklogComponentProps) => (
                         <Draggable draggableId={`${task.id}`} index={index} key={`TASK${task.id}`}>
                           {(provided) => (
                             <div {...provided.dragHandleProps} {...provided.draggableProps} ref={provided.innerRef}>
-                              <TaskComponent {...task} />
+                              <SprintBacklogTask {...task} />
                             </div>
                           )}
                         </Draggable>

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -1,9 +1,9 @@
 import { Draggable, Droppable } from 'react-beautiful-dnd';
-import TaskComponent from '../../backlog/TaskComponent';
 import ClosedIcon from '../../../assets/icons/ClosedIcon';
 import { SprintBacklog } from '../../../types/sprint';
 import { useQueryClient } from '@tanstack/react-query';
 import { ReadBacklogEpicResponseDto } from '../../../types/backlog';
+import SprintBacklogTask from './SprintBacklogTask';
 
 interface SprintBacklogComponentProps {
   sprintBacklog: SprintBacklog[];
@@ -59,7 +59,7 @@ const SprintBacklogComponent = ({ sprintBacklog, setSprintBacklog, projectId }: 
                       ref={provided.innerRef}
                     >
                       <div className="w-full">
-                        <TaskComponent {...task} />
+                        <SprintBacklogTask {...task} />
                       </div>
                       <button className="pr-2" onClick={() => handleDeleteButtonClick(task, index)}>
                         <ClosedIcon color="text-error-red" />

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -1,80 +1,54 @@
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import ClosedIcon from '../../../assets/icons/ClosedIcon';
 import { SprintBacklog } from '../../../types/sprint';
-import { useQueryClient } from '@tanstack/react-query';
-import { ReadBacklogEpicResponseDto } from '../../../types/backlog';
 import SprintBacklogTask from './SprintBacklogTask';
+import { SPRINT_BACKLOG_DROP_ID } from '../../../constants/constants';
 
 interface SprintBacklogComponentProps {
   sprintBacklog: SprintBacklog[];
-  setSprintBacklog: React.Dispatch<React.SetStateAction<SprintBacklog[]>>;
-  projectId: number;
+  deleteSprintBacklog: (task: SprintBacklog, index: number) => void;
 }
 
-const SprintBacklogComponent = ({ sprintBacklog, setSprintBacklog, projectId }: SprintBacklogComponentProps) => {
-  const queryClient = useQueryClient();
-  const handleDeleteButtonClick = (task: SprintBacklog, index: number) => {
-    const { epicIndex, storyIndex, taskIndex } = task;
-
-    queryClient.setQueryData(
-      ['backlogs', projectId, 'sprint'],
-      (prevBacklog: { epicList: ReadBacklogEpicResponseDto[] }) => {
-        const newBacklogData = structuredClone(prevBacklog);
-        newBacklogData.epicList[epicIndex].storyList[storyIndex].taskList.splice(taskIndex, 0, { ...task });
-        return newBacklogData;
-      },
-    );
-
-    setSprintBacklog((prevSprintBacklog) => {
-      const newSprintBacklog = structuredClone(prevSprintBacklog);
-      newSprintBacklog.splice(index, 1);
-      return newSprintBacklog;
-    });
-  };
-
-  return (
-    <Droppable droppableId="sprintBacklog">
-      {(provided) => (
-        <div
-          className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7"
-          {...provided.droppableProps}
-          ref={provided.innerRef}
-        >
-          {!sprintBacklog.length ? (
-            <>
-              <p className="mt-[11rem] mb-[1.25rem] font-bold text-ml text-light-gray">
-                이번 스프린트에서 진행할 과제를
-              </p>
-              <p className="font-bold text-ml text-light-gray">백로그에서 드래그 하세요</p>
-            </>
-          ) : (
-            <div className="w-full border-b border-x border-transparent-green">
-              {sprintBacklog.map((task, index) => (
-                <Draggable draggableId={String(task.id)} index={index} key={task.id}>
-                  {(provided) => (
-                    <div
-                      className="flex items-center justify-between"
-                      {...provided.dragHandleProps}
-                      {...provided.draggableProps}
-                      ref={provided.innerRef}
-                    >
-                      <div className="w-full">
-                        <SprintBacklogTask {...task} />
-                      </div>
-                      <button className="pr-2" onClick={() => handleDeleteButtonClick(task, index)}>
-                        <ClosedIcon color="text-error-red" />
-                      </button>
+const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBacklogComponentProps) => (
+  <Droppable droppableId={SPRINT_BACKLOG_DROP_ID}>
+    {(provided) => (
+      <div
+        className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7"
+        {...provided.droppableProps}
+        ref={provided.innerRef}
+      >
+        {!sprintBacklog.length ? (
+          <>
+            <p className="mt-[11rem] mb-[1.25rem] font-bold text-ml text-light-gray">이번 스프린트에서 진행할 과제를</p>
+            <p className="font-bold text-ml text-light-gray">백로그에서 드래그 하세요</p>
+          </>
+        ) : (
+          <div className="w-full border-b border-x border-transparent-green">
+            {sprintBacklog.map((task, index) => (
+              <Draggable draggableId={JSON.stringify(task)} index={index} key={task.id}>
+                {(provided) => (
+                  <div
+                    className="flex items-center justify-between"
+                    {...provided.dragHandleProps}
+                    {...provided.draggableProps}
+                    ref={provided.innerRef}
+                  >
+                    <div className="w-full">
+                      <SprintBacklogTask {...task} />
                     </div>
-                  )}
-                </Draggable>
-              ))}
-            </div>
-          )}
-          {provided.placeholder}
-        </div>
-      )}
-    </Droppable>
-  );
-};
+                    <button className="pr-2" onClick={() => deleteSprintBacklog(task, index)}>
+                      <ClosedIcon color="text-error-red" />
+                    </button>
+                  </div>
+                )}
+              </Draggable>
+            ))}
+          </div>
+        )}
+        {provided.placeholder}
+      </div>
+    )}
+  </Droppable>
+);
 
 export default SprintBacklogComponent;

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogTask.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogTask.tsx
@@ -1,20 +1,20 @@
-import ChevronRightIcon from '../../assets/icons/ChevronRightIcon';
-import { useModal } from '../../modal/useModal';
-import { ReadBacklogTaskResponseDto } from '../../types/backlog';
-import TaskModal from './Modal/TaskModal';
+import ChevronRightIcon from '../../../assets/icons/ChevronRightIcon';
+import { useModal } from '../../../modal/useModal';
+import { ReadBacklogTaskResponseDto } from '../../../types/backlog';
+import TaskModal from '../../backlog/Modal/TaskModal';
 
-const TaskComponent = (props: ReadBacklogTaskResponseDto) => {
+const SprintBacklogTask = (props: ReadBacklogTaskResponseDto) => {
   const { open, close } = useModal();
-  const { sequence, title, userId, point } = props;
+  const { sequence, title, userId } = props;
+
   return (
     <>
       <div className="flex items-center justify-between border-t py-[0.563rem] pl-2.5 pr-[0.438rem] bg-white text-house-green text-r whitespace-nowrap">
         <div className="flex items-center gap-2.5">
           <span className="w-16 font-bold">Task{sequence}</span>
-          <span className="w-[33.75rem]">{title}</span>
+          <span className="w-[18.75rem]">{title}</span>
         </div>
         <span className="w-[6.25rem] truncate">{userId}</span>
-        <span className="w-[5rem] truncate">{point}POINT</span>
         <button
           className="flex items-center font-bold hover:underline"
           onClick={() => {
@@ -29,4 +29,4 @@ const TaskComponent = (props: ReadBacklogTaskResponseDto) => {
   );
 };
 
-export default TaskComponent;
+export default SprintBacklogTask;

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogTask.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogTask.tsx
@@ -10,11 +10,11 @@ const SprintBacklogTask = (props: ReadBacklogTaskResponseDto) => {
   return (
     <>
       <div className="flex items-center justify-between border-t py-[0.563rem] pl-2.5 pr-[0.438rem] bg-white text-house-green text-r whitespace-nowrap">
-        <div className="flex items-center gap-2.5">
+        <div className="flex items-center gap-2.5 w-[80%]">
           <span className="w-16 font-bold">Task{sequence}</span>
-          <span className="w-[18.75rem]">{title}</span>
+          <span>{title}</span>
         </div>
-        <span className="w-[6.25rem] truncate">{userId}</span>
+        <span className="w-[5rem] truncate">{userId}</span>
         <button
           className="flex items-center font-bold hover:underline"
           onClick={() => {

--- a/FE/src/constants/constants.tsx
+++ b/FE/src/constants/constants.tsx
@@ -23,3 +23,5 @@ export const reviewTabs = ['스프린트 정보', '차트', '회고란'];
 export const BACKLOG_URL = {
   BACKLOG: '/backlogs',
 };
+
+export const SPRINT_BACKLOG_DROP_ID = 'sprintBacklog';

--- a/FE/src/hooks/pages/useLogin.tsx
+++ b/FE/src/hooks/pages/useLogin.tsx
@@ -17,7 +17,7 @@ const login = async (
       setAccessToken(accessToken);
       sessionStorage.setItem('refreshToken', refreshToken);
       updateUserState({ id: Number(id), username });
-      navigate('/project');
+      navigate('/projects');
     })
     .catch(() => {
       setSearchParams('');

--- a/FE/src/hooks/queries/sprint/usePatchSprintEnd.ts
+++ b/FE/src/hooks/queries/sprint/usePatchSprintEnd.ts
@@ -2,13 +2,13 @@ import { useMutation } from '@tanstack/react-query';
 import fetchPatchSprintEnd from '../../../apis/sprint/fetchPatchSprintEnd';
 import { useNavigate } from 'react-router-dom';
 
-const usePatchSprintEnd = () => {
+const usePatchSprintEnd = (projectId: number) => {
   const navigate = useNavigate();
 
   return useMutation({
     mutationFn: async (id: number) => await fetchPatchSprintEnd(id),
     onSuccess: () => {
-      navigate('/review/sprint');
+      navigate(`/projects/${projectId}/review/sprint`);
     },
   });
 };

--- a/FE/src/hooks/queries/sprint/usePostNewSprint.ts
+++ b/FE/src/hooks/queries/sprint/usePostNewSprint.ts
@@ -3,12 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import fetchPostSprint from '../../../apis/sprint/fetchPostSprint';
 import { SprintCreateBody } from '../../../types/sprint';
 
-const usePostNewSprint = () => {
+const usePostNewSprint = (projectId: number) => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: async (body: SprintCreateBody) => await fetchPostSprint(body),
     onSuccess: () => {
-      navigate('/sprint');
+      navigate(`/projects/${projectId}/sprint`);
     },
   });
 };

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -1,17 +1,19 @@
 import { useState, useEffect, useMemo } from 'react';
+import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import PrograssBar from '../components/common/ProgressBar/ProgressBar';
 import KanbanBoard from '../components/sprint/KanbanBoard';
 import ColumnBoard from '../components/sprint/ColumnBoard';
 import BoardHeader from '../components/sprint/BoardHeader';
 import FilterDropdown from '../components/sprint/FilterDropdown';
+import SprintEndModal from '../components/sprint/modal/SprintEndModal';
+import SprintLandingPage from './sprint/SprintLandingPage';
 import { Task } from '../types/sprint';
 import { UserFilter, TaskGroup } from '../types/sprint';
-import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import { transformDate } from '../utils/date';
 import { useSelectedProjectState } from '../stores';
 import { useGetProgressSprint, usePatchTaskState } from '../hooks/queries/sprint';
 import { useModal } from '../modal/useModal';
-import SprintEndModal from '../components/sprint/modal/SprintEndModal';
+import { useNavigate } from 'react-router-dom';
 
 interface BoardTaskListObject {
   storyId?: number;
@@ -33,6 +35,7 @@ const SprintPage = () => {
   const { data, isLoading } = useGetProgressSprint(projectId);
   const { mutate } = usePatchTaskState();
   const endModal = useModal();
+  const navigate = useNavigate();
   const userFilterList = useMemo(() => [{ userId: -1, userName: '전체' }, ...userList], [userList]);
 
   useEffect(() => {
@@ -104,7 +107,7 @@ const SprintPage = () => {
 
   const handleSprintEndButtonClick = () => {
     if (data) {
-      endModal.open(<SprintEndModal id={data.sprintId} close={endModal.close} />);
+      endModal.open(<SprintEndModal id={data.sprintId} close={endModal.close} projectId={projectId} />);
     }
   };
 
@@ -119,7 +122,7 @@ const SprintPage = () => {
   }, [data, userToFilter]);
 
   if (isLoading) {
-    return <div>칸반보드 로딩중</div>;
+    return <div className="min-w-[60.25rem]">칸반보드 로딩중</div>;
   }
 
   if (data?.sprintModal) {
@@ -127,13 +130,13 @@ const SprintPage = () => {
       <div className="flex flex-col items-center min-w-[60.25rem]">
         <p>스프린트가 종료되었습니다.</p>
         <p>회고를 진행하시겠습니까?</p>
-        <button>회고 진행하기</button>
+        <button onClick={() => navigate(`/projects/${projectId}/review/sprint`)}>회고 진행하기</button>
       </div>
     );
   }
 
   if (data?.sprintEnd) {
-    return <div className="min-w-[60.25rem]">진행 중인 스프린트가 없습니다.</div>;
+    return <SprintLandingPage />;
   }
 
   if (data) {

--- a/FE/src/pages/sprint/SprintCreatePage.tsx
+++ b/FE/src/pages/sprint/SprintCreatePage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '../../apis/api';
 import SprintBacklogSetting from '../../components/sprint/sprintCreate/SprintBacklogSetting';
 import { CreateProcessHeader, CreateProcessText } from '../../components/common/CreateProcess';
-import { BACKLOG_URL, PROCESS_NUMBER } from '../../constants/constants';
+import { CLIENT_URL, PROCESS_NUMBER } from '../../constants/constants';
 import { SprintBacklog, SprintCreateBody } from '../../types/sprint';
 import SprintGoalSetting from './../../components/sprint/sprintCreate/SprintGoalSetting';
 import usePostNewSprint from '../../hooks/queries/sprint/usePostNewSprint';
@@ -16,7 +16,7 @@ const SprintCreatePage = () => {
   const [sprintGoal, setSprintGoal] = useState<string>('');
   const [sprintEndDate, setSprintEndDate] = useState<string>('');
   const { id: projectId } = useSelectedProjectState();
-  const { mutateAsync } = usePostNewSprint();
+  const { mutateAsync } = usePostNewSprint(projectId);
   const { data: backlog, isLoading } = useQuery({
     queryKey: ['backlogs', projectId, 'sprint'],
     queryFn: async () => {
@@ -45,7 +45,7 @@ const SprintCreatePage = () => {
 
   return (
     <>
-      <CreateProcessHeader backLink={BACKLOG_URL.BACKLOG}>
+      <CreateProcessHeader backLink={CLIENT_URL.PROJECT}>
         <CreateProcessText processNum={1} processName="스프린트 이름" active={process >= 0} />
         <CreateProcessText processNum={2} processName="태스크 설정" active={process >= 1} />
       </CreateProcessHeader>

--- a/FE/src/pages/sprint/SprintCreatePage.tsx
+++ b/FE/src/pages/sprint/SprintCreatePage.tsx
@@ -29,6 +29,11 @@ const SprintCreatePage = () => {
   };
 
   const handleCreateButtonClick = () => {
+    if (!sprintBacklog.length) {
+      alert('스프린트 백로그를 추가해주세요.');
+      return;
+    }
+
     const dataBody: SprintCreateBody = {
       projectId,
       taskList: sprintBacklog.map(({ id }) => id),

--- a/FE/src/pages/sprint/SprintLandingPage.tsx
+++ b/FE/src/pages/sprint/SprintLandingPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import sprintLanding from '../../assets/images/sprint-landing.png';
 
 const SprintLandingPage = () => {
@@ -12,6 +13,12 @@ const SprintLandingPage = () => {
       ),
     url(${sprintLanding})`,
   };
+  const navigate = useNavigate();
+
+  const handleSprintCreateClick = () => {
+    navigate('create');
+  };
+
   return (
     <main className="w-[60.25rem]">
       <div className="flex justify-between">
@@ -42,7 +49,10 @@ const SprintLandingPage = () => {
 
         <div className="w-[450px] h-[550px] self-end" style={linearGradientStyle}></div>
       </div>
-      <button className="w-[60.25rem] h-[2.375rem] rounded-md bg-starbucks-green font-bold text-ml text-true-white">
+      <button
+        className="w-[60.25rem] h-[2.375rem] mt-[-2px] rounded-md bg-starbucks-green font-bold text-ml text-true-white"
+        onClick={handleSprintCreateClick}
+      >
         스프린트 생성하기
       </button>
     </main>

--- a/FE/src/types/navigation.ts
+++ b/FE/src/types/navigation.ts
@@ -1,5 +1,5 @@
 export interface NavigationInformation {
   pageName: string;
   description?: string;
-  pageURI: string;
+  pageURI: (projectId: number) => string;
 }


### PR DESCRIPTION
## 설명
- 스프린트 생성 시 태스크를 설정할 때 태스크의 길이를 고정해 `x` 아이콘이 튀어나오지 않도록 했습니다.
- 태스크를 다른 데로 드래그 하면 스프린트 백로그에서 제거되도록 했습니다.
- 스프린트 백로그를 설정하지 않으면 설정하라는 알림을 띄우도록 했습니다.
![녹화_2023_12_07_20_08_41_805](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/4bdf54b1-4038-4194-9b72-1372520e2040)

- 로그인하지 않았을 시 login 페이지로 리다이렉트 되도록 했습니다.
  - 루트페이지
![녹화_2023_12_07_20_07_09_621](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/bc5b3e2b-104e-458d-b977-cbd12749e915)
  - 다른 페이지
![녹화_2023_12_07_20_07_25_127](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/f80e9908-c8a8-41ba-8db8-31b5c2f0c0cf)

- 현재 정해진 url로 이동할 수 있도록 네비게이션에 있는 url을 수정했습니다.
``` typescript
const navigationInformation: NavigationInformation[] = [
  {
    pageName: '백로그',
    pageURI: (projectId) => `/projects/${projectId}/backlog`,
    description:
      '백로그 페이지 설명. 백로그는 제품백로그와 스프린트 백로그가 있으며 에픽, 스토리, 태스크로 이루어진다.',
  },
  {
    pageName: '스프린트',
    pageURI: (projectId) => `/projects/${projectId}/sprint`,
    description:
      '스프린트 페이지 설명. 스프린트 시작하면 칸반보드를 확인할 수 있고, 드래그 앤 드롭을 이용해 티켓을 옮길 수 있다.',
  },
  {
    pageName: '회고',
    pageURI: (projectId) => `/projects/${projectId}/review/sprint`,
    description: '회고하는 페이지 설명. 스프린트 백로그 태스트 상태 분석, 번다운 차트, 회고 글 작성 칸이 있을 예정',
  },
];
```
