### PR TITLE
fix: Backlog 생성/수정/삭제 시, 화면이 즉시 적용 되지 않는 문제 해결

### DIFF
--- a/FE/src/components/backlog/Modal/BacklogDeleteModal.tsx
+++ b/FE/src/components/backlog/Modal/BacklogDeleteModal.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../../../apis/api';
-import { useSelectedProjectState } from '../../../stores';
 
 interface BacklogDeleteModalProps {
   id: number;
@@ -10,15 +9,13 @@ interface BacklogDeleteModalProps {
 
 const BacklogDeleteModal = ({ id, url, close }: BacklogDeleteModalProps) => {
   const queryClient = useQueryClient();
-  const projectId = useSelectedProjectState((state) => state.id);
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
       const response = await api.delete(`/backlogs${url}`, { data: { id: id } });
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId, 'sprint'] });
+      queryClient.invalidateQueries({ queryKey: ['backlogs'] });
     },
   });
 

--- a/FE/src/components/backlog/Modal/TaskPostModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskPostModal.tsx
@@ -3,7 +3,6 @@ import { useRef } from 'react';
 import { api } from '../../../apis/api';
 import TaskForm from '../taskForm/TaskForm';
 import useTaskManager from '../../../hooks/pages/backlog/useTaskManager';
-import { useSelectedProjectState } from '../../../stores';
 
 interface TaskPostModalProps {
   parentId: number;
@@ -35,15 +34,13 @@ const TaskPostModal = ({ parentId, close }: TaskPostModalProps) => {
       { parentId, userId: taskManagerId } as TaskPostBody,
     );
   };
-  const projectId = useSelectedProjectState((state) => state.id);
   const queryClient = useQueryClient();
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
       return await api.post('/backlogs/task', getBody());
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId, 'sprint'] });
+      queryClient.invalidateQueries({ queryKey: ['backlogs'] });
     },
   });
 

--- a/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
@@ -5,7 +5,6 @@ import TaskForm from '../taskForm/TaskForm';
 import { TaskModalProps } from './TaskModal';
 import { ReadBacklogTaskResponseDto } from '../../../types/backlog';
 import useTaskManager from '../../../hooks/pages/backlog/useTaskManager';
-import { useSelectedProjectState } from '../../../stores';
 
 const TaskUpdateModal = ({ close, id, title, userId, point, condition }: TaskModalProps) => {
   const formRef = useRef<HTMLFormElement>(null);
@@ -25,14 +24,12 @@ const TaskUpdateModal = ({ close, id, title, userId, point, condition }: TaskMod
     );
   };
   const queryClient = useQueryClient();
-  const projectId = useSelectedProjectState((state) => state.id);
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
       return await api.patch('/backlogs/task', getBody());
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId, 'sprint'] });
+      queryClient.invalidateQueries();
     },
   });
 

--- a/FE/src/constants/constants.tsx
+++ b/FE/src/constants/constants.tsx
@@ -15,6 +15,7 @@ export const API_URL = {
 
 export const CLIENT_URL = {
   PROJECT: '/projects',
+  PROJECT_CREATE: '/projects/create',
   BACKLOG: (id: number | string) => `/projects/${id}/backlog`,
   SPRINT: (id: number | string) => `/projects/${id}/sprint`,
 };

--- a/FE/src/hooks/pages/backlog/usePostBacklog.tsx
+++ b/FE/src/hooks/pages/backlog/usePostBacklog.tsx
@@ -17,8 +17,7 @@ const usePostBacklog = (url: string, getBody: () => BacklogPostBody, toggleButto
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId, 'sprint'] });
+      queryClient.invalidateQueries();
     },
   });
 

--- a/FE/src/hooks/pages/backlog/useUpdateBacklog.tsx
+++ b/FE/src/hooks/pages/backlog/useUpdateBacklog.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../../../apis/api';
-import { useSelectedProjectState } from '../../../stores';
 
 interface BacklogUpdateBody {
   id: number;
@@ -9,15 +8,13 @@ interface BacklogUpdateBody {
 
 const useUpdateBacklog = (url: string, getBody: () => BacklogUpdateBody, toggleButton: () => void) => {
   const queryClient = useQueryClient();
-  const projectId = useSelectedProjectState((state) => state.id);
   const { mutateAsync } = useMutation({
     mutationFn: async () => {
       const response = await api.put(`/backlogs${url}`, getBody());
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId] });
-      queryClient.invalidateQueries({ queryKey: ['backlogs', projectId, 'sprint'] });
+      queryClient.invalidateQueries({ queryKey: ['backlogs'] });
     },
   });
 

--- a/FE/src/pages/project/ProjectPage.tsx
+++ b/FE/src/pages/project/ProjectPage.tsx
@@ -4,6 +4,7 @@ import whiteCross from '../../assets/images/cross.png';
 import useLogout from '../../hooks/pages/useLogout';
 import { useGetMyProjects } from '../../hooks/queries/project';
 import { ProjectCard } from '../../components/project';
+import { CLIENT_URL } from '../../constants/constants';
 
 const ProjectPage = () => {
   const handleLogoutButtonClick = useLogout();
@@ -32,7 +33,7 @@ const ProjectPage = () => {
           </li>
         ))}
         <Link
-          to={'/project/create'}
+          to={CLIENT_URL.PROJECT_CREATE}
           className="w-[7.5rem] h-[7.5rem] flex flex-col justify-center content-center gap-2 bg-starbucks-green rounded-[0.25rem] cursor-pointer"
         >
           <p className="font-bold text-center text-true-white font-pretendard text-r">새 프로젝트 생성</p>


### PR DESCRIPTION
# 설명
### 1. Backlog 생성/수정/삭제 시, 화면이 즉시 적용 되지 않는 문제 해결
- invalidQuries의 queryKey를 ['backlog'] 하나만 설정하면 'backlog'로 시작하는 모든 query를 invalid 상태로 변경 가능
- onSuccess 의 queryKey를 상기의 방법으로 수정

### 2. 프로젝트 생성 페이지 이동 url 수정
- 프로젝트 생성 페이지의 url로 이동하는 코드를 수정하여 정상적으로 생성 페이지로 이동