### PR TITLE
Fix: Backlog page 입력값 수정, Task Modal 입력 및 디자인 수정

### DIFF
--- a/FE/src/assets/icons/ChevronUpIcon.tsx
+++ b/FE/src/assets/icons/ChevronUpIcon.tsx
@@ -1,0 +1,16 @@
+import { IconProps } from '../../types/icon';
+
+const ChevronUpIcon = ({ color = 'text-black', backgroundColor = 'bg-transparent', size = 24 }: IconProps) => (
+  <svg
+    className={`${color} ${backgroundColor}`}
+    width={size}
+    height={size}
+    viewBox="0 0 24 25"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M6 15.5L12 9.5L18 15.5" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export default ChevronUpIcon;

--- a/FE/src/components/backlog/BacklogTitle.tsx
+++ b/FE/src/components/backlog/BacklogTitle.tsx
@@ -18,7 +18,7 @@ const BacklogTitle = ({ title, id, url }: { title: string; id: number; url: stri
   return (
     <>
       {!postForm ? (
-        <div className="group flex gap-1 hover:underline items-center">
+        <div className="group w-full flex gap-1 hover:underline items-center">
           <button onClick={toggleButton}>{title}</button>
           <div className="hidden group-hover:flex">
             <button onClick={toggleButton}>

--- a/FE/src/components/backlog/EpicComponent.tsx
+++ b/FE/src/components/backlog/EpicComponent.tsx
@@ -16,7 +16,7 @@ const EpicComponent = ({ title, id, children, sequence }: EpicComponentProps) =>
   const { detail, toggleDetail } = useDetail();
 
   return (
-    <div className="flex flex-col gap-4 py-3 px-3 border border-house-green rounded-md">
+    <div className="flex flex-col gap-4 py-3 px-3 border bg-true-white border-house-green rounded-md">
       <div className="flex gap-1 items-center">
         <button onClick={toggleDetail}>{detail ? <ChevronDownIcon /> : <ChevronRightIcon />}</button>
         <div className="flex gap-2 w-full text-house-green font-bold">

--- a/FE/src/components/backlog/MemberDropdown.tsx
+++ b/FE/src/components/backlog/MemberDropdown.tsx
@@ -2,8 +2,10 @@ import { useSelectedProjectState, useUserState } from '../../stores';
 
 const MemberDropdown = ({
   setNewTaskManager,
+  resetTaskManager,
 }: {
   setNewTaskManager: ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) => void;
+  resetTaskManager: () => void;
 }) => {
   const clientUserId = useUserState((state) => state.id);
   const userList = useSelectedProjectState((state) => state.userList);
@@ -21,6 +23,13 @@ const MemberDropdown = ({
           {user.userId === clientUserId && <span>(나에게 할당)</span>}
         </button>
       ))}
+      <button
+        type="button"
+        className="flex gap-1 p-2 text-xs hover:bg-light-gray hover:text-true-white"
+        onClick={resetTaskManager}
+      >
+        미할당
+      </button>
     </div>
   );
 };

--- a/FE/src/components/backlog/MemberDropdown.tsx
+++ b/FE/src/components/backlog/MemberDropdown.tsx
@@ -1,16 +1,20 @@
+import React from 'react';
 import { useSelectedProjectState, useUserState } from '../../stores';
 
-const MemberDropdown = ({
-  setNewTaskManager,
-  resetTaskManager,
-}: {
-  setNewTaskManager: ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) => void;
-  resetTaskManager: () => void;
-}) => {
+const MemberDropdown = React.forwardRef<
+  HTMLDivElement,
+  {
+    setNewTaskManager: ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) => void;
+    resetTaskManager: () => void;
+  }
+>(({ setNewTaskManager, resetTaskManager }, ref) => {
   const clientUserId = useUserState((state) => state.id);
   const userList = useSelectedProjectState((state) => state.userList);
   return (
-    <div className="absolute top-10 left-0 flex flex-col w-fit h-fit gap-0 bg-true-white border border-starbucks-green rounded-sm">
+    <div
+      className="absolute top-10 left-0 flex flex-col w-fit h-fit gap-0 bg-true-white border border-starbucks-green rounded-sm"
+      ref={ref}
+    >
       {userList.map((user) => (
         <button
           type="button"
@@ -32,6 +36,6 @@ const MemberDropdown = ({
       </button>
     </div>
   );
-};
+});
 
 export default MemberDropdown;

--- a/FE/src/components/backlog/Modal/TaskModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskModal.tsx
@@ -1,6 +1,7 @@
 import useGetUsername from '../../../hooks/pages/backlog/useGetUsername';
 import { useModal } from '../../../modal/useModal';
 import { ReadBacklogTaskResponseDto } from '../../../types/backlog';
+import TaskModalItemLayout from '../TaskModalItemLayout';
 import BacklogDeleteModal from './BacklogDeleteModal';
 import TaskUpdateModal from './TaskUpdateModal';
 
@@ -19,57 +20,43 @@ const TaskModal = (props: TaskModalProps) => {
       <div className="w-[31.875rem] h-[33.75rem] rounded-md bg-white p-6 text-house-green flex flex-col justify-between">
         <p className="text-l font-bold">Task</p>
         <div className="flex flex-col gap-2">
-          <div className="flex gap-2 items-baseline">
-            <span className="text-m font-bold pr-2">업무 내용</span>
-            <span className="text-s">Story를 구현하기 위해 필요한 업무를 작성합니다</span>
-          </div>
-          <div className="w-full py-2 px-2.5 rounded-sm text-s border border-starbucks-green outline-starbucks-green">
-            {title}
-          </div>
+          <TaskModalItemLayout title="업무 내용" description="Story를 구현하기 위해 필요한 업무를 작성합니다">
+            <div className="w-full py-2 px-2.5 rounded-sm text-s border border-transperant-green bg-cool-neutral">
+              {title}
+            </div>
+          </TaskModalItemLayout>
         </div>
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2 items-baseline">
-            <span className="text-m font-bold pr-2">인수조건</span>
-            <span className="text-s">Task를 완료하기 위한 조건을 작성합니다.</span>
-          </div>
+        <TaskModalItemLayout title="인수 조건" description="Task를 완료하기 위한 조건을 작성합니다">
           <textarea
-            className="w-full py-2 px-2.5 resize-none border rounded-sm border-starbucks-green text-s bg-true-white"
+            className="w-full py-2 px-2.5 resize-none border rounded-sm text-s border-transperant-green bg-cool-neutral"
             rows={4}
             value={condition}
             disabled
           />
-        </div>
-        <div className="flex flex-col gap-2">
-          <div className="text-s">
-            <span className="text-m font-bold pr-2">담당자</span>
-            Task를 수행할 멤버를 선정합니다
-          </div>
-          <div className="w-[9.375rem] py-2 px-2.5 border rounded-sm text-s border-starbucks-green">
+        </TaskModalItemLayout>
+        <TaskModalItemLayout title="담당자" description="Task를 수행할 멤버를 선정합니다">
+          <p className="w-[9.375rem] py-2 px-2.5 border rounded-sm text-s font-bold border-transperant-green bg-cool-neutral">
             {getUsernameByUserid(Number(userId))}
-          </div>
-        </div>
-        <div className="flex flex-col gap-2">
-          <span className="text-s">
-            <span className="text-m font-bold pr-2">Point</span>
-            Task를 완료하기 위해 소요되는 시간을 예상합니다
-          </span>
-
-          <div className="flex w-[9.375rem] pr-3 items-center border rounded-sm border-starbucks-green justify-between">
+          </p>
+        </TaskModalItemLayout>
+        <TaskModalItemLayout title="Task Point" description="Task를 완료하기 위해 소요되는 시간을 예상합니다">
+          <div className="flex w-[9.375rem] pr-3 items-center border rounded-sm border-transperant-green bg-cool-neutral justify-between">
             <p className="w-full py-2 px-2.5 text-s outline-none">{point}</p>
             <p className="font-bold text-starbucks-green">Point</p>
           </div>
-        </div>
+        </TaskModalItemLayout>
+
         <div className="flex justify-end gap-3">
           <button
             type="button"
-            className="border-2 rounded-md border-starbucks-green px-4 py-1.5 font-bold text-starbucks-green text-s"
+            className="border w-14 rounded-md border-starbucks-green py-1.5 font-bold text-starbucks-green text-s"
             onClick={close}
           >
             취소
-          </button>{' '}
+          </button>
           <button
             type="button"
-            className="rounded-md px-4 py-1.5 font-bold text-true-white bg-error-red text-s"
+            className="rounded-md w-14 py-1.5 font-bold text-true-white bg-error-red text-s"
             onClick={() => {
               deleteModal.open(<BacklogDeleteModal url="/task" id={id} close={deleteModal.close} />);
             }}
@@ -78,7 +65,7 @@ const TaskModal = (props: TaskModalProps) => {
           </button>
           <button
             type="button"
-            className="border-2 rounded-md border-starbucks-green px-4 py-1.5 bg-starbucks-green font-bold text-true-white text-s"
+            className="w-14 rounded-md py-1.5 bg-starbucks-green font-bold text-true-white text-s"
             onClick={() => {
               updateModal.open(<TaskUpdateModal {...{ ...props, close: updateModal.close }} />);
               close();

--- a/FE/src/components/backlog/Modal/TaskPostModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskPostModal.tsx
@@ -12,7 +12,7 @@ interface TaskPostModalProps {
 interface TaskPostBody {
   parentId: number;
   title: string;
-  userId: string | number;
+  userId: string | number | null;
   point: number;
   condition: string;
 }

--- a/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
@@ -29,7 +29,7 @@ const TaskUpdateModal = ({ close, id, title, userId, point, condition }: TaskMod
       return await api.patch('/backlogs/task', getBody());
     },
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['backlogs'] });
     },
   });
 

--- a/FE/src/components/backlog/StoryComponent.tsx
+++ b/FE/src/components/backlog/StoryComponent.tsx
@@ -23,10 +23,13 @@ const StoryComponent = ({ title, id, children, sequence, point }: StoryComponent
     <div className="border border-transparent-green rounded-md bg-cool-neutral ">
       <div className="flex gap-1 py-2 px-2.5">
         <button onClick={toggleDetail}>{detail ? <ChevronDownIcon /> : <ChevronRightIcon />}</button>
-        <div className="flex w-full gap-2.5 text-house-green font-bold">
-          <p className="flex items-center text-starbucks-green">Story{sequence}</p>
+        <div className="flex w-full gap-2.5 text-house-green font-bold items-center">
+          <p className="text-starbucks-green">Story{sequence}</p>
           <BacklogTitle title={title} id={id} url="/story" />
-          <div>{point}</div>
+          <div className="flex gap-1 text-starbucks-green font-bold">
+            <p>{point}</p>
+            <p>POINT</p>
+          </div>
         </div>
       </div>
       <div className={`${!detail && 'hidden'}`}>

--- a/FE/src/components/backlog/StoryComponent.tsx
+++ b/FE/src/components/backlog/StoryComponent.tsx
@@ -12,9 +12,10 @@ interface StoryComponentProps {
   id: number;
   children: ReactElement;
   sequence: number;
+  point: number;
 }
 
-const StoryComponent = ({ title, id, children, sequence }: StoryComponentProps) => {
+const StoryComponent = ({ title, id, children, sequence, point }: StoryComponentProps) => {
   const { detail, toggleDetail } = useDetail();
   const { open, close } = useModal();
 
@@ -25,6 +26,7 @@ const StoryComponent = ({ title, id, children, sequence }: StoryComponentProps) 
         <div className="flex w-full gap-2.5 text-house-green font-bold">
           <p className="flex items-center text-starbucks-green">Story{sequence}</p>
           <BacklogTitle title={title} id={id} url="/story" />
+          <div>{point}</div>
         </div>
       </div>
       <div className={`${!detail && 'hidden'}`}>

--- a/FE/src/components/backlog/TaskModalItemLayout.tsx
+++ b/FE/src/components/backlog/TaskModalItemLayout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface TaskModalItemLayoutProps {
+  children: ReactNode;
+  title: string;
+  description: string;
+}
+
+const TaskModalItemLayout = ({ children, title, description }: TaskModalItemLayoutProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <span className="text-m font-bold pr-2">{title}</span>
+        <span className="text-s">{description}</span>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default TaskModalItemLayout;

--- a/FE/src/components/backlog/taskForm/TaskForm.tsx
+++ b/FE/src/components/backlog/taskForm/TaskForm.tsx
@@ -1,7 +1,10 @@
-import useDetail from '../../../hooks/pages/backlog/useDetail';
 import MemberDropdown from '../MemberDropdown';
 import TaskInputLayout from './TaskInputLayout';
 import useTaskUsername from '../../../hooks/pages/backlog/useTaskUsername';
+import ChevronUpIcon from '../../../assets/icons/ChevronUpIcon';
+import ChevronDownIcon from '../../../assets/icons/ChevronDownIcon';
+import { useEffect } from 'react';
+import useDropdownToggle from '../../../hooks/pages/backlog/useDropdownToggle';
 
 interface TaskFormProps {
   handleSubmit: (e: React.FormEvent) => void;
@@ -18,7 +21,7 @@ interface TaskFormProps {
 }
 
 const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData = null }: TaskFormProps) => {
-  const { detail, toggleDetail } = useDetail();
+  const { detail, toggleDetail, detailRef, handleOutsideClick } = useDropdownToggle();
   const { username, setNewUsername, resetUsername } = useTaskUsername(Number(defaultData?.userId));
   const handleDropdownClick = ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) => {
     setNewTaskManager(Number(currentTarget.id));
@@ -30,6 +33,14 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
     resetUsername();
     toggleDetail();
   };
+  useEffect(() => {
+    addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, []);
+
   return (
     <div className="fixed top-0 left-0 bg-black w-screen h-screen bg-opacity-30 flex justify-center items-center">
       <form
@@ -64,7 +75,7 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
         </TaskInputLayout>
         <TaskInputLayout title="담당자" description="Task를 수행할 멤버를 선정합니다" htmlFor="userId">
           <div className="relative">
-            <div className="w-[9.375rem] py-2 px-2.5 border rounded-sm border-starbucks-green outline-starbucks-green text-s flex">
+            <div className="w-[9.375rem] py-2 px-2.5 border rounded-sm border-starbucks-green outline-starbucks-green text-s flex items-center">
               <p className="w-full">{username}</p>
               <button
                 type="button"
@@ -72,11 +83,15 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
                   toggleDetail();
                 }}
               >
-                click
+                {detail ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
               </button>
             </div>
-            {!detail && (
-              <MemberDropdown setNewTaskManager={handleDropdownClick} resetTaskManager={handleDropdownResetClick} />
+            {detail && (
+              <MemberDropdown
+                ref={detailRef}
+                setNewTaskManager={handleDropdownClick}
+                resetTaskManager={handleDropdownResetClick}
+              />
             )}
           </div>
         </TaskInputLayout>
@@ -101,15 +116,12 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
         <div className="flex justify-end gap-3">
           <button
             type="button"
-            className="border-2 rounded-md border-starbucks-green px-4 py-1.5 font-bold text-starbucks-green text-s"
+            className="border rounded-md border-starbucks-green w-14 py-1.5 font-bold text-starbucks-green text-s"
             onClick={close}
           >
             취소
           </button>
-          <button
-            type="submit"
-            className="border-2 rounded-md border-starbucks-green px-4 py-1.5 bg-starbucks-green font-bold text-true-white text-s"
-          >
+          <button type="submit" className="rounded-md w-14 py-1.5 bg-starbucks-green font-bold text-true-white text-s">
             확인
           </button>
         </div>

--- a/FE/src/components/backlog/taskForm/TaskForm.tsx
+++ b/FE/src/components/backlog/taskForm/TaskForm.tsx
@@ -5,13 +5,13 @@ import useTaskUsername from '../../../hooks/pages/backlog/useTaskUsername';
 
 interface TaskFormProps {
   handleSubmit: (e: React.FormEvent) => void;
-  setNewTaskManager: (newId: number) => void;
+  setNewTaskManager: (newId: number | null) => void;
   close: () => void;
   formRef: React.RefObject<HTMLFormElement>;
   defaultData?: {
     id: number;
     title: string;
-    userId: string | number | undefined;
+    userId: string | number | null;
     point: number;
     condition: string;
   } | null;
@@ -19,10 +19,15 @@ interface TaskFormProps {
 
 const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData = null }: TaskFormProps) => {
   const { detail, toggleDetail } = useDetail();
-  const { username, setNewUsername } = useTaskUsername(Number(defaultData?.userId));
+  const { username, setNewUsername, resetUsername } = useTaskUsername(Number(defaultData?.userId));
   const handleDropdownClick = ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) => {
     setNewTaskManager(Number(currentTarget.id));
     setNewUsername(Number(currentTarget.id));
+    toggleDetail();
+  };
+  const handleDropdownResetClick = () => {
+    setNewTaskManager(null);
+    resetUsername();
     toggleDetail();
   };
   return (
@@ -70,7 +75,9 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
                 click
               </button>
             </div>
-            {!detail && <MemberDropdown setNewTaskManager={handleDropdownClick} />}
+            {!detail && (
+              <MemberDropdown setNewTaskManager={handleDropdownClick} resetTaskManager={handleDropdownResetClick} />
+            )}
           </div>
         </TaskInputLayout>
         <TaskInputLayout

--- a/FE/src/components/backlog/taskForm/TaskForm.tsx
+++ b/FE/src/components/backlog/taskForm/TaskForm.tsx
@@ -85,6 +85,7 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
               id="point"
               name="point"
               defaultValue={defaultData?.point}
+              min={0}
             />
             <p className="font-bold text-starbucks-green">Point</p>
           </div>

--- a/FE/src/components/backlog/taskForm/TaskForm.tsx
+++ b/FE/src/components/backlog/taskForm/TaskForm.tsx
@@ -21,7 +21,7 @@ interface TaskFormProps {
 }
 
 const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData = null }: TaskFormProps) => {
-  const { detail, toggleDetail, detailRef, handleOutsideClick } = useDropdownToggle();
+  const { detail, toggleDetail, detailRef } = useDropdownToggle();
   const { username, setNewUsername, resetUsername } = useTaskUsername(Number(defaultData?.userId));
   const handleDropdownClick = ({ currentTarget }: React.MouseEvent<HTMLButtonElement>) => {
     setNewTaskManager(Number(currentTarget.id));
@@ -33,13 +33,6 @@ const TaskForm = ({ handleSubmit, close, setNewTaskManager, formRef, defaultData
     resetUsername();
     toggleDetail();
   };
-  useEffect(() => {
-    addEventListener('mousedown', handleOutsideClick);
-
-    return () => {
-      removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, []);
 
   return (
     <div className="fixed top-0 left-0 bg-black w-screen h-screen bg-opacity-30 flex justify-center items-center">

--- a/FE/src/components/backlog/taskForm/TaskForm.tsx
+++ b/FE/src/components/backlog/taskForm/TaskForm.tsx
@@ -3,7 +3,6 @@ import TaskInputLayout from './TaskInputLayout';
 import useTaskUsername from '../../../hooks/pages/backlog/useTaskUsername';
 import ChevronUpIcon from '../../../assets/icons/ChevronUpIcon';
 import ChevronDownIcon from '../../../assets/icons/ChevronDownIcon';
-import { useEffect } from 'react';
 import useDropdownToggle from '../../../hooks/pages/backlog/useDropdownToggle';
 
 interface TaskFormProps {

--- a/FE/src/components/sprint/sprintCreate/BacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/BacklogComponent.tsx
@@ -9,6 +9,7 @@ import StoryComponent from '../../backlog/StoryComponent';
 import PostButton from '../../backlog/PostButton';
 import SprintBacklogTask from './SprintBacklogTask';
 import { useSelectedProjectState } from '../../../stores';
+import getStoryPoint from '../../../utils/getStoryPoint';
 
 interface BacklogComponentProps {
   backlog: { epicList: ReadBacklogEpicResponseDto[] };
@@ -26,7 +27,12 @@ const BacklogComponent = ({ backlog }: BacklogComponentProps) => {
               <Droppable droppableId={`${epicIndex} ${storyIndex}`} key={`STORY${story.id}`} isDropDisabled={true}>
                 {(provided) => (
                   <div {...provided.droppableProps} ref={provided.innerRef}>
-                    <StoryComponent title={story.title} id={story.id} sequence={story.sequence}>
+                    <StoryComponent
+                      title={story.title}
+                      id={story.id}
+                      sequence={story.sequence}
+                      point={getStoryPoint(story.taskList)}
+                    >
                       <>
                         {story.taskList.map((task: ReadBacklogTaskResponseDto, index) => (
                           <Draggable draggableId={`${task.id}`} index={index} key={`TASK${task.id}`}>

--- a/FE/src/hooks/pages/backlog/useDropdownToggle.tsx
+++ b/FE/src/hooks/pages/backlog/useDropdownToggle.tsx
@@ -1,0 +1,20 @@
+import { useRef, useState } from 'react';
+
+const useDropdownToggle = () => {
+  const [detail, setDetail] = useState<Boolean>(false);
+  const detailRef = useRef<HTMLDivElement>(null);
+
+  const handleOutsideClick = ({ target }: MouseEvent) => {
+    if (detailRef.current && !detailRef.current.contains(target as Node)) {
+      setDetail(false);
+    }
+  };
+
+  const toggleDetail = () => {
+    setDetail((detail) => !detail);
+  };
+
+  return { detail, toggleDetail, detailRef, handleOutsideClick };
+};
+
+export default useDropdownToggle;

--- a/FE/src/hooks/pages/backlog/useDropdownToggle.tsx
+++ b/FE/src/hooks/pages/backlog/useDropdownToggle.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const useDropdownToggle = () => {
   const [detail, setDetail] = useState<Boolean>(false);
@@ -14,7 +14,15 @@ const useDropdownToggle = () => {
     setDetail((detail) => !detail);
   };
 
-  return { detail, toggleDetail, detailRef, handleOutsideClick };
+  useEffect(() => {
+    addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, []);
+
+  return { detail, toggleDetail, detailRef };
 };
 
 export default useDropdownToggle;

--- a/FE/src/hooks/pages/backlog/useGetUsername.tsx
+++ b/FE/src/hooks/pages/backlog/useGetUsername.tsx
@@ -4,9 +4,9 @@ const useGetUsername = () => {
   const userList = useSelectedProjectState((state) => state.userList);
 
   const getUsernameByUserid = (userId: number | undefined) => {
-    if (!userId) return '';
+    if (!userId) return '미할당';
 
-    return userList.find((user) => user.userId === Number(userId))?.userName ?? '';
+    return userList.find((user) => user.userId === Number(userId))?.userName ?? '미할당';
   };
 
   return { getUsernameByUserid };

--- a/FE/src/hooks/pages/backlog/usePostBacklog.tsx
+++ b/FE/src/hooks/pages/backlog/usePostBacklog.tsx
@@ -15,7 +15,7 @@ const usePostBacklog = (url: string, getBody: () => BacklogPostBody, toggleButto
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['backlogs'] });
     },
   });
 

--- a/FE/src/hooks/pages/backlog/useTaskManager.tsx
+++ b/FE/src/hooks/pages/backlog/useTaskManager.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-const useTaskManager = (initialValue?: number) => {
-  const [taskManagerId, setTaskManagerId] = useState<number | undefined>(initialValue);
+const useTaskManager = (initialValue?: number | null) => {
+  const [taskManagerId, setTaskManagerId] = useState<number | null>(initialValue ?? null);
 
-  useEffect(() => {
-    console.log('changed', taskManagerId);
-  }, [taskManagerId]);
-
-  const setNewTaskManager = (newId: number) => {
+  const setNewTaskManager = (newId: number | null) => {
+    if (!newId) {
+      setTaskManagerId(null);
+      return;
+    }
     setTaskManagerId(newId);
   };
 

--- a/FE/src/hooks/pages/backlog/useTaskUsername.tsx
+++ b/FE/src/hooks/pages/backlog/useTaskUsername.tsx
@@ -3,12 +3,15 @@ import useGetUsername from './useGetUsername';
 
 const useTaskUsername = (initialValue: number) => {
   const { getUsernameByUserid } = useGetUsername();
-  const [username, setUsername] = useState<string>(getUsernameByUserid(initialValue));
+  const [username, setUsername] = useState<string>(getUsernameByUserid(initialValue) ?? '미할당');
   const setNewUsername = (id: number) => {
     setUsername(getUsernameByUserid(id));
   };
+  const resetUsername = () => {
+    setUsername('미할당');
+  };
 
-  return { username, setNewUsername };
+  return { username, setNewUsername, resetUsername };
 };
 
 export default useTaskUsername;

--- a/FE/src/pages/backlog/BacklogPage.tsx
+++ b/FE/src/pages/backlog/BacklogPage.tsx
@@ -14,9 +14,8 @@ import { useSelectedProjectState } from '../../stores';
 import BacklogLandingPage from './BacklogLandingPage';
 
 const BacklogPage = () => {
-  const id = useSelectedProjectState((state) => state.id);
-  const REQUEST_URL = `${API_URL.BACKLOG}/${id}`;
   const projectId = useSelectedProjectState((state) => state.id);
+  const REQUEST_URL = `${API_URL.BACKLOG}/${projectId}`;
   const { data, isLoading } = useQuery({
     queryKey: ['backlogs', projectId],
     queryFn: async () => {
@@ -62,7 +61,7 @@ const BacklogPage = () => {
         placeholder="어떤 기능을 계획할 예정인가요? 예시) 회원 기능"
         color="bg-house-green"
         url="/backlogs/epic"
-        id={Number(id)}
+        id={Number(projectId)}
       />
     </main>
   );

--- a/FE/src/pages/backlog/BacklogPage.tsx
+++ b/FE/src/pages/backlog/BacklogPage.tsx
@@ -12,6 +12,7 @@ import PostButton from '../../components/backlog/PostButton';
 import { API_URL } from '../../constants/constants';
 import { useSelectedProjectState } from '../../stores';
 import BacklogLandingPage from './BacklogLandingPage';
+import getStoryPoint from '../../utils/getStoryPoint';
 
 const BacklogPage = () => {
   const projectId = useSelectedProjectState((state) => state.id);
@@ -45,7 +46,13 @@ const BacklogPage = () => {
         <EpicComponent title={epic.title} id={epic.id} sequence={epic.sequence} key={`EPIC${epic.id}`}>
           <>
             {epic.storyList.map((story: ReadBacklogStoryResponseDto) => (
-              <StoryComponent title={story.title} id={story.id} sequence={story.sequence} key={`STORY${story.id}`}>
+              <StoryComponent
+                title={story.title}
+                id={story.id}
+                sequence={story.sequence}
+                key={`STORY${story.id}`}
+                point={getStoryPoint(story.taskList)}
+              >
                 <>
                   {story.taskList.map((task: ReadBacklogTaskResponseDto) => (
                     <TaskComponent {...task} key={`TASK${task.id}`} />

--- a/FE/src/types/backlog.ts
+++ b/FE/src/types/backlog.ts
@@ -5,7 +5,7 @@ export interface CompositionComponentProps {
 }
 
 export interface ReadBacklogTaskResponseDto {
-  userId: string | number;
+  userId: string | number | null;
   id: number;
   title: string;
   state: string;

--- a/FE/src/utils/getStoryPoint.ts
+++ b/FE/src/utils/getStoryPoint.ts
@@ -1,0 +1,6 @@
+import { ReadBacklogTaskResponseDto } from '../types/backlog';
+
+const getStoryPoint = (taskList: ReadBacklogTaskResponseDto[]) =>
+  taskList.reduce((acc: number, cur: ReadBacklogTaskResponseDto) => acc + cur.point, 0);
+
+export default getStoryPoint;


### PR DESCRIPTION
# 설명
### 1. backlogs 데이터 key값 제한을 통한 fetch 효율 최적화
- invalidQueries의 조건을 모든 데이터에서 실행하던 내역을 'backlogs' key를 가진 query로 제한하여 데이터를 불필요하게 fetch 하는 경우를 제외
### 2. task point 최소값 설정
- task ponint의 최소값을 0으로 설정
### 3. task 담당자를 미할당 할 수 있도록 코드 수정
- task 담당자를 미할당 하는 버튼을 작성하여, 서버에 null을 전달하는 코드를 작성
### 4. 외부를 클릭하면 dropdown을 닫는 코드 작성
- dropdown을 열고 닫는 커스텀 훅을 작성하고, member를 확인하는 dropdown에 적용
### 5. TaskModal 디자인 수정 및 반복 코드 리팩토링
- TaskModal의 디자인을 TaskPostModal과 일부 차이를 주도록 수정
- TaskModal의 반복되는 제목과 설명 부분을 컴포넌트화하여 재사용성을 높임