### PR TITLE
fix: 미할당 task가 수정 되지 않는 현상 수정

### DIFF
--- a/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
+++ b/FE/src/components/backlog/Modal/TaskUpdateModal.tsx
@@ -8,7 +8,7 @@ import useTaskManager from '../../../hooks/pages/backlog/useTaskManager';
 
 const TaskUpdateModal = ({ close, id, title, userId, point, condition }: TaskModalProps) => {
   const formRef = useRef<HTMLFormElement>(null);
-  const { taskManagerId, setNewTaskManager } = useTaskManager(Number(userId));
+  const { taskManagerId, setNewTaskManager } = useTaskManager(!userId ? null : Number(userId));
   const getBody = () => {
     if (!formRef.current) return { id, title, userId, point, condition };
     return [...formRef.current.querySelectorAll('input'), formRef.current.querySelector('textarea')].reduce(


### PR DESCRIPTION
- task를 업데이트 할 때, 클라이언트 메모리에 저장하는 초기값이 Number(null)로 인해 0으로 저장되는 현상 발생
- 최초 값이 null로 들어오면, null로 그 이외는 Number를 통해 숫자로 저장할 수 있도록 코드를 수정