### PR TITLE
fix: naviagation bar 버튼 활성화 로직 수정

### DIFF
--- a/FE/src/components/common/NavigationButton.tsx
+++ b/FE/src/components/common/NavigationButton.tsx
@@ -9,19 +9,10 @@ interface NavigationButtonProps extends NavigationInformation {
 const NavigationButton = ({ pageName, description, pageURI, currentURI }: NavigationButtonProps) => {
   const { id } = useSelectedProjectState();
   const isSameURL = () => {
-    const currentUriList = currentURI.split('/');
-    const pageUriList = pageURI(id).split('/');
+    const currentUriList = currentURI.split('/').splice(1, 3);
+    const pageUriList = pageURI(id).split('/').splice(1, 3);
 
-    const currentUriLength = currentUriList.length;
-    const pageUriLength = pageUriList.length;
-
-    if (currentUriLength === pageUriLength && currentUriList[currentUriLength - 1] === pageUriList[pageUriLength - 1]) {
-      return true;
-    }
-
-    if (currentUriList[currentUriLength - 2] === pageUriList[pageUriLength - 2]) {
-      return true;
-    }
+    if (JSON.stringify(currentUriList) === JSON.stringify(pageUriList)) return true;
 
     return false;
   };


### PR DESCRIPTION
- navigation bar 버튼의 url의 조건 설정에 오류로 인한 backlog와 sprint 버튼이 동시에 활성화
- 현재 url과 버튼에 주어진 url을 특정 기준에 맞추어 나누고, 해당 배열의 값을 string화 하여 비교하는 로직으로 수정하여, 검사를 더 간단하고 명확하게 수행할 수 있도록 수정