### PR TITLE
칸반보드 패이지 수정, 스프린트 백로그 설정 기능 수정

### DIFF
--- a/FE/src/components/sprint/FilterDropdown.tsx
+++ b/FE/src/components/sprint/FilterDropdown.tsx
@@ -5,8 +5,8 @@ interface FilterDropdownProps {
   userList: ProjectUser[];
   userToFilter: UserFilter;
   taskGroup: TaskGroup;
-  onUserFilterButtonClick: (user: UserFilter) => void;
-  onGroupFilterButtonClick: (group: TaskGroup) => void;
+  onUserFilterButtonClick: (user: UserFilter, group: TaskGroup) => void;
+  onGroupFilterButtonClick: (user: UserFilter, group: TaskGroup) => void;
 }
 
 const FilterDropdown = (props: FilterDropdownProps) => {
@@ -24,7 +24,7 @@ const FilterDropdown = (props: FilterDropdownProps) => {
           className={`text-center text-xs hover:cursor-pointer ${
             userId === userToFilter ? activeMenuClass : inactiveMenuClass
           }`}
-          onClick={() => onUserFilterButtonClick(userId)}
+          onClick={() => onUserFilterButtonClick(userId, taskGroup)}
         >
           {userName}
         </p>
@@ -35,7 +35,7 @@ const FilterDropdown = (props: FilterDropdownProps) => {
         className={`text-center text-xs hover:cursor-pointer ${
           taskGroup === 'all' ? activeMenuClass : inactiveMenuClass
         }`}
-        onClick={() => onGroupFilterButtonClick('all')}
+        onClick={() => onGroupFilterButtonClick(userToFilter, 'all')}
       >
         전체 태스크
       </p>
@@ -43,7 +43,7 @@ const FilterDropdown = (props: FilterDropdownProps) => {
         className={`text-center text-xs hover:cursor-pointer ${
           taskGroup === 'story' ? activeMenuClass : inactiveMenuClass
         }`}
-        onClick={() => onGroupFilterButtonClick('story')}
+        onClick={() => onGroupFilterButtonClick(userToFilter, 'story')}
       >
         스토리 그룹
       </p>

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -1,12 +1,12 @@
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import ClosedIcon from '../../../assets/icons/ClosedIcon';
-import { SprintBacklog } from '../../../types/sprint';
+import { SprintBacklogTask as SprintBacklogTaskType } from '../../../types/sprint';
 import SprintBacklogTask from './SprintBacklogTask';
 import { SPRINT_BACKLOG_DROP_ID } from '../../../constants/constants';
 
 interface SprintBacklogComponentProps {
-  sprintBacklog: SprintBacklog[];
-  deleteSprintBacklog: (task: SprintBacklog, index: number) => void;
+  sprintBacklog: SprintBacklogTaskType[];
+  deleteSprintBacklog: (task: SprintBacklogTaskType, index: number) => void;
 }
 
 const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBacklogComponentProps) => (

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -6,7 +6,7 @@ import { SPRINT_BACKLOG_DROP_ID } from '../../../constants/constants';
 
 interface SprintBacklogComponentProps {
   sprintBacklog: SprintBacklogTaskType[];
-  deleteSprintBacklog: (task: SprintBacklogTaskType, index: number) => void;
+  deleteSprintBacklog: (index: number) => void;
 }
 
 const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBacklogComponentProps) => (
@@ -36,7 +36,7 @@ const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBa
                     <div className="w-full">
                       <SprintBacklogTask {...task} />
                     </div>
-                    <button className="pr-2" onClick={() => deleteSprintBacklog(task, index)}>
+                    <button className="pr-2" onClick={() => deleteSprintBacklog(index)}>
                       <ClosedIcon color="text-error-red" />
                     </button>
                   </div>

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogSetting.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogSetting.tsx
@@ -4,33 +4,21 @@ import { ReadBacklogEpicResponseDto } from '../../../types/backlog';
 import BacklogComponent from './BacklogComponent';
 import SprintBacklogComponent from './SprintBacklogComponent';
 import { useQueryClient } from '@tanstack/react-query';
-import { SprintBacklog } from '../../../types/sprint';
+import { SprintBacklogTask, SprintBacklogEpic } from '../../../types/sprint';
 import { SPRINT_BACKLOG_DROP_ID } from '../../../constants/constants';
 
 interface SprintBacklogSettingProps {
-  backlog: { epicList: ReadBacklogEpicResponseDto[] };
-  sprintBacklog: SprintBacklog[];
-  setSprintBacklog: React.Dispatch<React.SetStateAction<SprintBacklog[]>>;
+  backlog: { epicList: SprintBacklogEpic[] };
+  sprintBacklog: SprintBacklogTask[];
+  setSprintBacklog: React.Dispatch<React.SetStateAction<SprintBacklogTask[]>>;
   onCreateButtonClick: () => void;
   projectId: number;
 }
 
 const SprintBacklogSetting = (props: SprintBacklogSettingProps) => {
-  const { backlog, sprintBacklog, setSprintBacklog, onCreateButtonClick, projectId } = props;
-  const queryClient = useQueryClient();
+  const { backlog, sprintBacklog, setSprintBacklog, onCreateButtonClick } = props;
 
-  const deleteSprintBacklog = (task: SprintBacklog, index: number) => {
-    const { epicIndex, storyIndex, taskIndex } = task;
-
-    queryClient.setQueryData(
-      ['backlogs', projectId, 'sprint'],
-      (prevBacklog: { epicList: ReadBacklogEpicResponseDto[] }) => {
-        const newBacklogData = structuredClone(prevBacklog);
-        newBacklogData.epicList[epicIndex].storyList[storyIndex].taskList.splice(taskIndex, 0, { ...task });
-        return newBacklogData;
-      },
-    );
-
+  const deleteSprintBacklog = (index: number) => {
     setSprintBacklog((prevSprintBacklog) => {
       const newSprintBacklog = structuredClone(prevSprintBacklog);
       newSprintBacklog.splice(index, 1);
@@ -39,12 +27,11 @@ const SprintBacklogSetting = (props: SprintBacklogSettingProps) => {
   };
 
   const onDragEnd = (result: DropResult) => {
-    const { destination, source, draggableId } = result;
+    const { destination, source } = result;
 
     if (!destination) {
       if (source.droppableId === SPRINT_BACKLOG_DROP_ID) {
-        const task = JSON.parse(draggableId);
-        deleteSprintBacklog(task, source.index);
+        deleteSprintBacklog(source.index);
       }
 
       return;
@@ -63,21 +50,11 @@ const SprintBacklogSetting = (props: SprintBacklogSettingProps) => {
 
     const [epicIndex, storyIndex] = source.droppableId.split(' ').map((id) => Number(id));
 
-    const targetTask: SprintBacklog = {
+    const targetTask: SprintBacklogTask = {
       ...backlog.epicList[epicIndex].storyList[storyIndex].taskList[source.index],
       epicIndex,
       storyIndex,
-      taskIndex: source.index,
     };
-
-    queryClient.setQueryData(
-      ['backlogs', projectId, 'sprint'],
-      (prevBacklog: { epicList: ReadBacklogEpicResponseDto[] }) => {
-        const newBacklogData = structuredClone(prevBacklog);
-        newBacklogData.epicList[epicIndex].storyList[storyIndex].taskList.splice(source.index, 1);
-        return newBacklogData;
-      },
-    );
 
     setSprintBacklog((prevSprintBacklog) => {
       const newSprintBacklog = structuredClone(prevSprintBacklog);

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogSetting.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogSetting.tsx
@@ -1,9 +1,7 @@
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import RightBracketIcon from '../../../assets/icons/RightBracketIcon';
-import { ReadBacklogEpicResponseDto } from '../../../types/backlog';
 import BacklogComponent from './BacklogComponent';
 import SprintBacklogComponent from './SprintBacklogComponent';
-import { useQueryClient } from '@tanstack/react-query';
 import { SprintBacklogTask, SprintBacklogEpic } from '../../../types/sprint';
 import { SPRINT_BACKLOG_DROP_ID } from '../../../constants/constants';
 

--- a/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
+++ b/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
@@ -1,25 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../../../apis/api';
-import { Task } from '../../../types/sprint';
-
-interface Sprint {
-  sprintId: number;
-  sprintTitle: string;
-  sprintGoal: string;
-  sprintStartDate: string;
-  sprintEndDate: string;
-  sprintEnd: boolean;
-  sprintModal: boolean;
-  taskList: Task[];
-}
+import { ReturnedSprint, Sprint } from '../../../types/sprint';
+import structureTaskList from '../../../utils/structureTaskList';
+import { AxiosError } from 'axios';
 
 const useGetProgressSprint = (projectId: number) =>
-  useQuery<Sprint>({
+  useQuery<Sprint, AxiosError, ReturnedSprint>({
     queryKey: ['sprint'],
     queryFn: async () => {
       const response = await api.get(`/projects/${projectId}/sprints/progress`);
-      return response.data;
+      const data = { ...response.data, boardTask: structureTaskList(response.data.taskList) };
+      return data;
     },
+    refetchOnWindowFocus: false,
+    retry: 0,
   });
 
 export default useGetProgressSprint;

--- a/FE/src/hooks/queries/sprint/usePatchTaskState.ts
+++ b/FE/src/hooks/queries/sprint/usePatchTaskState.ts
@@ -7,7 +7,8 @@ const usePatchTaskState = () => {
   return useMutation({
     mutationFn: async ({ id, state }: { id: number; state: string }) =>
       await api.patch('/backlogs/task', { id, state }),
-    onSuccess: () => {
+    onError: () => {
+      alert('오류가 발생해 상태를 업데이트하지 못했습니다.');
       queryClient.invalidateQueries({ queryKey: ['sprint'] });
     },
   });

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -1,4 +1,4 @@
-import { ReadBacklogTaskResponseDto } from './backlog';
+import { ReadBacklogEpicResponseDto, ReadBacklogStoryResponseDto, ReadBacklogTaskResponseDto } from './backlog';
 
 export type TaskGroup = 'all' | 'story';
 
@@ -19,7 +19,15 @@ export interface Task {
   condition: string;
 }
 
-export interface SprintBacklog extends ReadBacklogTaskResponseDto {
+export interface SprintBacklogEpic extends ReadBacklogEpicResponseDto {
+  storyList: SprintBacklogStory[];
+}
+
+export interface SprintBacklogStory extends ReadBacklogStoryResponseDto {
+  taskList: SprintBacklogTask[];
+}
+
+export interface SprintBacklogTask extends ReadBacklogTaskResponseDto {
   epicIndex: number;
   storyIndex: number;
   taskIndex: number;

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -33,3 +33,29 @@ export interface SprintCreateBody {
   endDate: string;
   title: string;
 }
+
+export interface BoardTaskObject {
+  storyId?: number;
+  storySequence?: number;
+  storyTitle?: string;
+  ToDo: Task[];
+  InProgress: Task[];
+  Done: Task[];
+}
+
+export type TaskGroupedByStory = Record<number, BoardTaskObject>;
+
+export interface Sprint {
+  sprintId: number;
+  sprintTitle: string;
+  sprintGoal: string;
+  sprintStartDate: string;
+  sprintEndDate: string;
+  sprintEnd: boolean;
+  sprintModal: boolean;
+  taskList: Task[];
+}
+
+export interface ReturnedSprint extends Sprint {
+  boardTask: Record<number, BoardTaskObject>;
+}

--- a/FE/src/utils/structureTaskList.ts
+++ b/FE/src/utils/structureTaskList.ts
@@ -1,0 +1,36 @@
+import { Task, TaskGroup, TaskGroupedByStory, UserFilter } from '../types/sprint';
+
+const structureTaskList = (data: Task[], user: UserFilter = -1, group: TaskGroup = 'all') => {
+  const copiedData = structuredClone(data);
+
+  const currentTaskList = user === -1 ? copiedData : copiedData.filter(({ userId }) => userId === user);
+
+  if (group === 'all') {
+    const ToDo = currentTaskList?.filter(({ state }: Task) => state === 'ToDo');
+    const InProgress = currentTaskList?.filter(({ state }: Task) => state === 'InProgress');
+    const Done = currentTaskList?.filter(({ state }: Task) => state === 'Done');
+    const newBoardTask = { 0: { ToDo, InProgress, Done, storyId: 0 } };
+    return newBoardTask;
+  }
+
+  const taskList = currentTaskList?.reduce((acc: TaskGroupedByStory, current: Task) => {
+    const { storyId, storySequence, storyTitle } = current;
+    acc[storyId] = acc[storyId] ?? {
+      storySequence,
+      storyId,
+      storyTitle,
+      ToDo: [],
+      InProgress: [],
+      Done: [],
+    };
+
+    const taskState = current.state;
+    acc[storyId][taskState as 'ToDo' | 'InProgress' | 'Done'].push(current);
+
+    return acc;
+  }, {});
+
+  return taskList;
+};
+
+export default structureTaskList;


### PR DESCRIPTION
## 설명
- 칸반보드 페이지에서 드롭하면 보드의 맨 마지막에 태스크가 추가되던 것을,  낙관적 업데이트를 사용해서 사용자가 지정한 순서대로 태스크가 보여질 수 있도록 수정했습니다.
- 스프린트 백로그를 설정할 때 태스크를 새로 추가하면 이미 스프린트 백로그에 넣어놓은 것까지 백로그에 생기던 문제를 해결했습니다.
![녹화_2023_12_09_22_57_00_119](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/b5af1ec3-2b29-4f00-9631-9ddd5919ca47)
```typescript
const backlog = useMemo(() => {
    const newData = structuredClone(data);

    if (!sprintBacklog.length) {
      return newData;
    }

    sprintBacklog.forEach((sprintBacklogItem: SprintBacklogTask) => {
      const { epicIndex, storyIndex, taskIndex } = sprintBacklogItem;
      newData.epicList[epicIndex].storyList[storyIndex].taskList[taskIndex] = undefined;
    });

    newData.epicList.forEach((epic: ReadBacklogEpicResponseDto) => {
      epic.storyList.forEach((story) => {
        story.taskList = story.taskList.filter((task) => !!task);
      });
    });

    return newData;
  }, [data, sprintBacklog]);
```
  - 이렇게 백로그 데이터를 불러올 때, 스프린트 백로그를 설정할 때 가져온 데이터에서 스프린트 백로그에 있는 것을 제거하고 이를 백로그 데이터로 사용하는 방식으로 수정했습니다. 다만 태스크가 많아질 경우 계산에 걸리는 시간이 길어져서 비효율적일 수 있을 것 같습니다.
  - 이런 방식으로 변경하니 스프린트 백로그에서 태스크를 제거할 때, 백로그에 원래 있었던 자리로 태스크가 돌아가지 않는 문제도 자연스럽게 해결됐습니다.

