### PR TITLE
task state가 완료가 될 시 사용자 UI 변경

### DIFF
--- a/FE/src/components/backlog/StoryComponent.tsx
+++ b/FE/src/components/backlog/StoryComponent.tsx
@@ -12,7 +12,7 @@ interface StoryComponentProps {
   id: number;
   children: ReactElement;
   sequence: number;
-  point: number;
+  point: { TOTAL: number; REMAIN: number };
 }
 
 const StoryComponent = ({ title, id, children, sequence, point }: StoryComponentProps) => {
@@ -27,7 +27,10 @@ const StoryComponent = ({ title, id, children, sequence, point }: StoryComponent
           <p className="text-starbucks-green">Story{sequence}</p>
           <BacklogTitle title={title} id={id} url="/story" />
           <div className="flex gap-1 text-starbucks-green font-bold">
-            <p>{point}</p>
+            <p>{point.REMAIN}</p>
+            {/* <p>POINT</p> */}
+            <p>/</p>
+            <p>{point.TOTAL}</p>
             <p>POINT</p>
           </div>
         </div>

--- a/FE/src/components/backlog/TaskComponent.tsx
+++ b/FE/src/components/backlog/TaskComponent.tsx
@@ -6,17 +6,21 @@ import TaskModal from './Modal/TaskModal';
 
 const TaskComponent = (props: ReadBacklogTaskResponseDto) => {
   const { open, close } = useModal();
-  const { sequence, title, userId, point } = props;
+  const { sequence, title, userId, point, state } = props;
   const { getUsernameByUserid } = useGetUsername();
   return (
     <>
       <div className="flex items-center justify-between border-t py-[0.563rem] pl-2.5 pr-[0.438rem] bg-white text-house-green text-r whitespace-nowrap">
         <div className="flex items-center gap-2.5">
-          <span className="w-16 font-bold">Task{sequence}</span>
+          <span
+            className={`w-16 font-bold ${state === 'Done' ? 'line-through text-light-gray' : 'text-starbucks-green'}`}
+          >
+            Task{sequence}
+          </span>
           <span className="w-[33.75rem]">{title}</span>
         </div>
         <span className="w-[6.25rem] truncate">{getUsernameByUserid(Number(userId))}</span>
-        <span className="w-[5rem] truncate">{point} POINT</span>
+        <span className={`w-[5rem] truncate ${state === 'Done' && 'line-through text-light-gray'}`}>{point} POINT</span>
         <button
           className="flex items-center hover:underline hover:font-bold"
           onClick={() => {

--- a/FE/src/pages/MainPage.tsx
+++ b/FE/src/pages/MainPage.tsx
@@ -3,7 +3,7 @@ import SideNavigationBar from '../components/common/SideNavigationBar';
 const MainPage = () => (
   <div className="flex p-8 justify-center min-w-[76rem]">
     <SideNavigationBar />
-    <div>
+    <div className="min-w-[60.25rem]">
       <Outlet />
     </div>
   </div>

--- a/FE/src/pages/backlog/BacklogPage.tsx
+++ b/FE/src/pages/backlog/BacklogPage.tsx
@@ -35,6 +35,7 @@ const BacklogPage = () => {
   if (isLoading) return <></>;
 
   if (data?.status !== 200) return <BacklogLandingPage />;
+  console.log(data.data.epicList);
 
   return (
     <main className="flex flex-col gap-4 min-w-[60.25rem] font-pretendard select-none">

--- a/FE/src/pages/backlog/BacklogPage.tsx
+++ b/FE/src/pages/backlog/BacklogPage.tsx
@@ -35,7 +35,6 @@ const BacklogPage = () => {
   if (isLoading) return <></>;
 
   if (data?.status !== 200) return <BacklogLandingPage />;
-  console.log(data.data.epicList);
 
   return (
     <main className="flex flex-col gap-4 min-w-[60.25rem] font-pretendard select-none">

--- a/FE/src/types/backlog.ts
+++ b/FE/src/types/backlog.ts
@@ -11,6 +11,7 @@ export interface ReadBacklogTaskResponseDto {
   point: number;
   condition: string;
   sequence: number;
+  state: 'Todo' | 'InProgress' | 'Done';
 }
 
 export interface ReadBacklogStoryResponseDto {

--- a/FE/src/utils/getStoryPoint.ts
+++ b/FE/src/utils/getStoryPoint.ts
@@ -1,6 +1,11 @@
 import { ReadBacklogTaskResponseDto } from '../types/backlog';
 
-const getStoryPoint = (taskList: ReadBacklogTaskResponseDto[]) =>
-  taskList.reduce((acc: number, cur: ReadBacklogTaskResponseDto) => acc + cur.point, 0);
+const getStoryPoint = (taskList: ReadBacklogTaskResponseDto[]) => ({
+  TOTAL: taskList.reduce((acc: number, cur: ReadBacklogTaskResponseDto) => acc + cur.point, 0),
+  REMAIN: taskList.reduce(
+    (acc: number, cur: ReadBacklogTaskResponseDto) => (acc + cur.state !== 'Done' ? cur.point : 0),
+    0,
+  ),
+});
 
 export default getStoryPoint;


### PR DESCRIPTION
# 설명
### 1. task state가 완료가 될 시 사용자 UI 변경
- 완료된 task의 경우 story point 및 task sequence에 그음줄 및 text 색상변경
- story point 표시의 경우 (미완료 task) / (완료 task) 로 표현 변경
![image](https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/7c0d5c88-b637-4624-b4c2-6a2351f3d073)


### 2. main 페이지 w 길이 고정을 통해 navigation bar 위치를 고정
- main 페이지의 가로 길이를 고정하여, 데이터를 fetching, loading하는 기간 동안 navigation bar가 중앙으로 이동하던 현상을 막음