### PR TITLE
칸반보드 필터링 오류 수정, 미할당 유저 이름 표기 수정

### DIFF
--- a/FE/src/components/sprint/TaskCard.tsx
+++ b/FE/src/components/sprint/TaskCard.tsx
@@ -20,8 +20,7 @@ const TaskCard = (props: TaskCardProps) => {
   const handleTaskClick = () => {
     open(<TaskModal {...props} close={close} />);
   };
-  const { userList } = useSelectedProjectState();
-  const userName = userList.find(({ userId }) => userId === Number(taskUserId))?.userName;
+  const getUserNameById = useSelectedProjectState((state) => state.getUserNameById);
 
   return (
     <Draggable draggableId={String(id)} index={index}>
@@ -38,7 +37,7 @@ const TaskCard = (props: TaskCardProps) => {
           <p className="font-medium">{title}</p>
           <p className="flex justify-between text-starbucks-green">
             <span className="font-bold">{id}</span>
-            <span>{userName}</span>
+            <span>{getUserNameById(Number(taskUserId))}</span>
             <span>{point} point</span>
           </p>
         </div>

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -31,8 +31,8 @@ const SprintPage = () => {
 
   const handleGroupButtonClick = (user: UserFilter, taskGroup: TaskGroup): void => {
     queryClient.setQueryData(['sprint'], (prevSprintData: ReturnedSprint) => {
-      const boardTaskList = structureTaskList(prevSprintData.taskList, user, taskGroup);
-      return { ...prevSprintData, boardTaskList };
+      const boardTask = structureTaskList(prevSprintData.taskList, user, taskGroup);
+      return { ...prevSprintData, boardTask };
     });
 
     setTaskGroup(taskGroup);
@@ -41,8 +41,8 @@ const SprintPage = () => {
 
   const handleUserFilterButtonClick = (user: UserFilter, taskGroup: TaskGroup): void => {
     queryClient.setQueryData(['sprint'], (prevSprintData: ReturnedSprint) => {
-      const boardTaskList = structureTaskList(prevSprintData.taskList, user, taskGroup);
-      return { ...prevSprintData, boardTaskList };
+      const boardTask = structureTaskList(prevSprintData.taskList, user, taskGroup);
+      return { ...prevSprintData, boardTask };
     });
 
     setUserToFilter(user);


### PR DESCRIPTION
## 설명
- 칸반보드에서 유저별, 스토리별 필터링과 그룹화가 되지 않는 문제를 수정했습니다.
- 미할당 유저 이름이 표기되지 않는 문제를 수정했습니다.