### PR TITLE
getStoryPoint 함수가 정상적으로 출력되지 않는 현상 수정

### DIFF
--- a/FE/src/test/utils.test.ts
+++ b/FE/src/test/utils.test.ts
@@ -1,0 +1,74 @@
+import { ReadBacklogTaskResponseDto } from '../types/backlog';
+import getStoryPoint from '../utils/getStoryPoint';
+
+const sampleTaskList1: Array<ReadBacklogTaskResponseDto> = [
+  {
+    id: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    sequence: 1,
+    point: 3,
+    userId: null,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
+  },
+  {
+    id: 3,
+    sequence: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    point: 3,
+    userId: 1,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
+  },
+];
+
+const sampleTaskList2: Array<ReadBacklogTaskResponseDto> = [
+  {
+    id: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    sequence: 1,
+    point: 3,
+    userId: null,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
+  },
+  {
+    id: 3,
+    sequence: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    point: 3,
+    userId: 1,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Done',
+  },
+];
+const sampleTaskList3: Array<ReadBacklogTaskResponseDto> = [
+  {
+    id: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    sequence: 1,
+    point: 3,
+    userId: null,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
+  },
+  {
+    id: 3,
+    sequence: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    point: 3,
+    userId: 1,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'InProgress',
+  },
+];
+
+test('스토리 포인트 계산1', () => {
+  expect(getStoryPoint(sampleTaskList1)).toEqual({ TOTAL: 6, REMAIN: 6 });
+});
+test('스토리 포인트 계산2', () => {
+  expect(getStoryPoint(sampleTaskList2)).toEqual({ TOTAL: 6, REMAIN: 3 });
+});
+test('스토리 포인트 계산3', () => {
+  expect(getStoryPoint(sampleTaskList3)).toEqual({ TOTAL: 6, REMAIN: 6 });
+});

--- a/FE/src/test/utils.test.ts
+++ b/FE/src/test/utils.test.ts
@@ -6,8 +6,17 @@ const sampleTaskList1: Array<ReadBacklogTaskResponseDto> = [
     id: 2,
     title: '[BE]에픽 목록을 화면이 렌더링',
     sequence: 1,
-    point: 3,
+    point: 1,
     userId: null,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
+  },
+  {
+    id: 3,
+    sequence: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    point: 2,
+    userId: 1,
     condition: '인수조건 인수분해 인수합병 인수인계',
     state: 'Todo',
   },
@@ -27,7 +36,7 @@ const sampleTaskList2: Array<ReadBacklogTaskResponseDto> = [
     id: 2,
     title: '[BE]에픽 목록을 화면이 렌더링',
     sequence: 1,
-    point: 3,
+    point: 1,
     userId: null,
     condition: '인수조건 인수분해 인수합병 인수인계',
     state: 'Todo',
@@ -36,10 +45,19 @@ const sampleTaskList2: Array<ReadBacklogTaskResponseDto> = [
     id: 3,
     sequence: 2,
     title: '[BE]에픽 목록을 화면이 렌더링',
-    point: 3,
+    point: 2,
     userId: 1,
     condition: '인수조건 인수분해 인수합병 인수인계',
     state: 'Done',
+  },
+  {
+    id: 3,
+    sequence: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    point: 3,
+    userId: 1,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
   },
 ];
 const sampleTaskList3: Array<ReadBacklogTaskResponseDto> = [
@@ -47,7 +65,7 @@ const sampleTaskList3: Array<ReadBacklogTaskResponseDto> = [
     id: 2,
     title: '[BE]에픽 목록을 화면이 렌더링',
     sequence: 1,
-    point: 3,
+    point: 1,
     userId: null,
     condition: '인수조건 인수분해 인수합병 인수인계',
     state: 'Todo',
@@ -56,10 +74,19 @@ const sampleTaskList3: Array<ReadBacklogTaskResponseDto> = [
     id: 3,
     sequence: 2,
     title: '[BE]에픽 목록을 화면이 렌더링',
-    point: 3,
+    point: 2,
     userId: 1,
     condition: '인수조건 인수분해 인수합병 인수인계',
     state: 'InProgress',
+  },
+  {
+    id: 3,
+    sequence: 2,
+    title: '[BE]에픽 목록을 화면이 렌더링',
+    point: 3,
+    userId: 1,
+    condition: '인수조건 인수분해 인수합병 인수인계',
+    state: 'Todo',
   },
 ];
 
@@ -67,7 +94,7 @@ test('스토리 포인트 계산1', () => {
   expect(getStoryPoint(sampleTaskList1)).toEqual({ TOTAL: 6, REMAIN: 6 });
 });
 test('스토리 포인트 계산2', () => {
-  expect(getStoryPoint(sampleTaskList2)).toEqual({ TOTAL: 6, REMAIN: 3 });
+  expect(getStoryPoint(sampleTaskList2)).toEqual({ TOTAL: 6, REMAIN: 4 });
 });
 test('스토리 포인트 계산3', () => {
   expect(getStoryPoint(sampleTaskList3)).toEqual({ TOTAL: 6, REMAIN: 6 });

--- a/FE/src/utils/getStoryPoint.ts
+++ b/FE/src/utils/getStoryPoint.ts
@@ -3,7 +3,7 @@ import { ReadBacklogTaskResponseDto } from '../types/backlog';
 const getStoryPoint = (taskList: ReadBacklogTaskResponseDto[]) => ({
   TOTAL: taskList.reduce((acc: number, cur: ReadBacklogTaskResponseDto) => acc + cur.point, 0),
   REMAIN: taskList.reduce(
-    (acc: number, cur: ReadBacklogTaskResponseDto) => (acc + cur.state !== 'Done' ? cur.point : 0),
+    (acc: number, cur: ReadBacklogTaskResponseDto) => (cur.state !== 'Done' ? acc + cur.point : acc),
     0,
   ),
 });


### PR DESCRIPTION
# Task 
[Task125] bug fix: 스토리 포인트가 마지막 태스크 포인트만 나오는 상황을 수정한다.

# 설명
### 1. getStoryPoint 코드 수정
- getStoryPoint의 값이 마지막 taskPoint로 출력되는 현상이 발생
- reduce 메서드 내 acc의 값을 반환하는 삼항 조건문으로 인해 마지막 값이 출력되는 현상 발생
- acc의 값 반환하는 삼항 조건문을 수정하여 문제 해결

### 2. getStoryPoint 테스트 코드 작성
1. Todo 3개의 경우 테스트코드 작성 (정상)
2. Todo 2개와 Done 1개의 경우 테스트코드 작성 (정상)
3. Todo 2개와 InProgress 1개의 경우 테스트코드 작성 (정상)