### PR TITLE
필터링, 태스크 설정 기능 수정

### DIFF
--- a/FE/src/components/common/SideNavigationBar.tsx
+++ b/FE/src/components/common/SideNavigationBar.tsx
@@ -30,10 +30,10 @@ const SideNavigationBar = () => {
 
   return (
     <nav className="flex flex-col items-center px-6 py-8 top-[32px] rounded-lg w-52 bg-house-green gap-2.5 mr-10 min-w-[13.125rem] min-h-[calc(100vh-64px)] max-h-[calc(100vh-64px)] sticky">
-      <div className="mb-5">
+      <Link to={'/projects'} className="mb-5">
         <img src={lesserLogo} alt="로고" />
         <p className="text-xs font-medium text-center text-true-white">적고 쉽고 애자일하게 일하자</p>
-      </div>
+      </Link>
       <hr className="w-full h-px bg-true-white" />
       <ul>
         {navigationInformation.map(({ pageName, description, pageURI }) => (

--- a/FE/src/components/sprint/FilterDropdown.tsx
+++ b/FE/src/components/sprint/FilterDropdown.tsx
@@ -1,8 +1,10 @@
-import { ProjectUser } from '../../types/project';
 import { UserFilter, TaskGroup } from '../../types/sprint';
 
 interface FilterDropdownProps {
-  userList: ProjectUser[];
+  userList: {
+    userId: number | null;
+    userName: string;
+  }[];
   userToFilter: UserFilter;
   taskGroup: TaskGroup;
   onUserFilterButtonClick: (user: UserFilter, group: TaskGroup) => void;

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -13,7 +13,7 @@ const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBa
   <Droppable droppableId={SPRINT_BACKLOG_DROP_ID}>
     {(provided) => (
       <div
-        className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7"
+        className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7 overflow-y-scroll overflow-x-hidden"
         {...provided.droppableProps}
         ref={provided.innerRef}
       >
@@ -28,7 +28,7 @@ const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBa
               <Draggable draggableId={JSON.stringify(task)} index={index} key={task.id}>
                 {(provided) => (
                   <div
-                    className="flex items-center justify-between"
+                    className="flex items-center justify-between bg-true-white"
                     {...provided.dragHandleProps}
                     {...provided.draggableProps}
                     ref={provided.innerRef}

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogComponent.tsx
@@ -13,7 +13,7 @@ const SprintBacklogComponent = ({ sprintBacklog, deleteSprintBacklog }: SprintBa
   <Droppable droppableId={SPRINT_BACKLOG_DROP_ID}>
     {(provided) => (
       <div
-        className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7 overflow-y-scroll overflow-x-hidden"
+        className="h-[31.75rem] border rounded-md bg-cool-neutral border-house-green flex flex-col items-center p-7 overflow-y-auto overflow-x-hidden"
         {...provided.droppableProps}
         ref={provided.innerRef}
       >

--- a/FE/src/components/sprint/sprintCreate/SprintBacklogTask.tsx
+++ b/FE/src/components/sprint/sprintCreate/SprintBacklogTask.tsx
@@ -14,7 +14,7 @@ const SprintBacklogTask = (props: ReadBacklogTaskResponseDto) => {
       <div className="flex items-center justify-between border-t py-[0.563rem] pl-2.5 pr-[0.438rem] bg-white text-house-green text-r whitespace-nowrap">
         <div className="flex items-center gap-2.5 w-[80%]">
           <span className="w-16 font-bold">Task{sequence}</span>
-          <span>{title}</span>
+          <span className="max-w-[16rem] truncate">{title}</span>
         </div>
         <span className="w-[5rem] truncate">{getUserNameById(!userId ? undefined : Number(userId))}</span>
         <button

--- a/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
+++ b/FE/src/hooks/queries/sprint/useGetProgressSprint.ts
@@ -1,15 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../../../apis/api';
-import { ReturnedSprint, Sprint } from '../../../types/sprint';
+import { ReturnedSprint, Sprint, TaskGroup, UserFilter } from '../../../types/sprint';
 import structureTaskList from '../../../utils/structureTaskList';
 import { AxiosError } from 'axios';
 
-const useGetProgressSprint = (projectId: number) =>
+interface UseGetProgressSprintParams {
+  projectId: number;
+  userToFilter: UserFilter;
+  taskGroup: TaskGroup;
+}
+
+const useGetProgressSprint = ({ projectId, userToFilter, taskGroup }: UseGetProgressSprintParams) =>
   useQuery<Sprint, AxiosError, ReturnedSprint>({
     queryKey: ['sprint'],
     queryFn: async () => {
       const response = await api.get(`/projects/${projectId}/sprints/progress`);
-      const data = { ...response.data, boardTask: structureTaskList(response.data.taskList) };
+      const data = { ...response.data, boardTask: structureTaskList(response.data.taskList, userToFilter, taskGroup) };
       return data;
     },
     refetchOnWindowFocus: false,

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -26,7 +26,10 @@ const SprintPage = () => {
   const { mutateAsync } = usePatchTaskState();
   const endModal = useModal();
   const navigate = useNavigate();
-  const userFilterList = useMemo(() => [{ userId: -1, userName: '전체' }, ...userList], [userList]);
+  const userFilterList = useMemo(
+    () => [{ userId: -1, userName: '전체' }, ...userList, { userId: null, userName: '미할당' }],
+    [userList],
+  );
   const queryClient = useQueryClient();
 
   const handleGroupButtonClick = (user: UserFilter, taskGroup: TaskGroup): void => {

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -21,7 +21,7 @@ import useFilterState from '../stores/useFilterState';
 const SprintPage = () => {
   const { userToFilter, taskGroup, changeTaskGroup, changeUserToFilter } = useFilterState();
   const [dropdownOpend, setDropdownOpend] = useState<boolean>(false);
-  const { id: projectId, userList } = useSelectedProjectState();
+  const { id: projectId, userList, getUserNameById } = useSelectedProjectState();
   const { data, isLoading, isError } = useGetProgressSprint({ projectId, userToFilter, taskGroup });
   const { mutateAsync } = usePatchTaskState();
   const endModal = useModal();
@@ -171,7 +171,7 @@ const SprintPage = () => {
                 onClick={handleFilterButtonClick}
                 className="bg-starbucks-green text-true-white rounded py-1.5 px-4 font-bold text-xs"
               >
-                필터
+                {userToFilter === -1 ? '필터' : getUserNameById(userToFilter)}
               </button>
               {dropdownOpend && (
                 <FilterDropdown

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -16,13 +16,13 @@ import { useModal } from '../modal/useModal';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import structureTaskList from '../utils/structureTaskList';
+import useFilterState from '../stores/useFilterState';
 
 const SprintPage = () => {
-  const [taskGroup, setTaskGroup] = useState<TaskGroup>('all');
-  const [userToFilter, setUserToFilter] = useState<UserFilter>(-1);
+  const { userToFilter, taskGroup, changeTaskGroup, changeUserToFilter } = useFilterState();
   const [dropdownOpend, setDropdownOpend] = useState<boolean>(false);
   const { id: projectId, userList } = useSelectedProjectState();
-  const { data, isLoading, isError } = useGetProgressSprint(projectId);
+  const { data, isLoading, isError } = useGetProgressSprint({ projectId, userToFilter, taskGroup });
   const { mutateAsync } = usePatchTaskState();
   const endModal = useModal();
   const navigate = useNavigate();
@@ -38,7 +38,7 @@ const SprintPage = () => {
       return { ...prevSprintData, boardTask };
     });
 
-    setTaskGroup(taskGroup);
+    changeTaskGroup(taskGroup);
     setDropdownOpend(false);
   };
 
@@ -48,7 +48,7 @@ const SprintPage = () => {
       return { ...prevSprintData, boardTask };
     });
 
-    setUserToFilter(user);
+    changeUserToFilter(user);
     setDropdownOpend(false);
   };
 

--- a/FE/src/stores/useFilterState.ts
+++ b/FE/src/stores/useFilterState.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { TaskGroup, UserFilter } from '../types/sprint';
+
+interface InitialFilterState {
+  userToFilter: UserFilter;
+  taskGroup: TaskGroup;
+}
+
+interface FilterState extends InitialFilterState {
+  changeUserToFilter: (userToFilter: UserFilter) => void;
+  changeTaskGroup: (taskGroup: TaskGroup) => void;
+}
+
+const initialState: InitialFilterState = { userToFilter: -1, taskGroup: 'all' };
+
+const useFilterState = create<FilterState>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        ...initialState,
+        changeUserToFilter: (userToFilter: UserFilter) => {
+          const { taskGroup } = get();
+          set(() => ({ userToFilter, taskGroup }));
+        },
+        changeTaskGroup: (taskGroup: TaskGroup) => {
+          const { userToFilter } = get();
+          set(() => ({ userToFilter, taskGroup }));
+        },
+      }),
+      { name: 'filterState' },
+    ),
+  ),
+);
+
+export default useFilterState;

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -2,7 +2,7 @@ import { ReadBacklogEpicResponseDto, ReadBacklogStoryResponseDto, ReadBacklogTas
 
 export type TaskGroup = 'all' | 'story';
 
-export type UserFilter = number;
+export type UserFilter = number | null;
 
 export type TaskState = 'ToDo' | 'InProgress' | 'Done' | string;
 

--- a/FE/src/types/sprint.ts
+++ b/FE/src/types/sprint.ts
@@ -2,7 +2,7 @@ import { ReadBacklogEpicResponseDto, ReadBacklogStoryResponseDto, ReadBacklogTas
 
 export type TaskGroup = 'all' | 'story';
 
-export type UserFilter = number | null;
+export type UserFilter = number | undefined;
 
 export type TaskState = 'ToDo' | 'InProgress' | 'Done' | string;
 


### PR DESCRIPTION
## 설명
### 필터링
- 필터링 옵션에 미할당을 추가했습니다.
- 필터링 시 필터링 되는 대상의 이름을 필터 버튼에서 확인할 수 있도록 했습니다.
  - 전체 태스크인 경우 그대로 필터로 표시, 특정 유저(미할당 포함)일 경우 해당 유저 이름 표시
- 스토어를 추가해 전역으로 필터링 상태를 관리하여 다른 페이지에 갔다 오거나, 새로고침을 해도 필터링 상태가 유지되도록 했습니다.
### 태스크 설정
- 태스크 제목의 길이를 고정하고 말줄임표를 넣어 제거 아이콘이 태스크 밖으로 벗어나지 않도록 했습니다.
- 스프린트 태스크 박스에서 태스크 개수가 박스 크기를 넘어가면 내부 스크롤을 할 수 있도록 했습니다.
![녹화_2023_12_12_13_46_10_294](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/5cdd825b-123b-468b-a65a-e47f0fbd0d6d)

- 네비게이션 바에서 로고를 누르면 프로젝트 목록 페이지로 이동하도록 했습니다.
