### PR TITLE
로그인 화면 크기 조정, 스프린트 페이지 오류 수정

### DIFF
--- a/FE/src/components/common/Loading.tsx
+++ b/FE/src/components/common/Loading.tsx
@@ -1,7 +1,7 @@
 import LoadingLesser from '../../assets/images/loading-image.png';
 
 const Loading = () => (
-  <div className="flex items-center justify-center h-full">
+  <div className="flex items-center justify-center w-full h-full">
     <img className="w-[7%] animate-[bounce_0.9s_ease-in-out_infinite]" src={LoadingLesser} alt="레서 판다" />
     <img className="w-[7%] animate-[bounce_0.9s_ease-in-out_0.1s_infinite]" src={LoadingLesser} alt="레서 판다" />
     <img className="w-[7%] animate-[bounce_0.9s_ease-in-out_0.3s_infinite]" src={LoadingLesser} alt="레서 판다" />

--- a/FE/src/pages/LoginPage.tsx
+++ b/FE/src/pages/LoginPage.tsx
@@ -8,13 +8,13 @@ const LoginPage = () => {
   const { code, handleLoginButtonClick } = useLogin();
 
   return (
-    <div className="flex h-screen min-w-[95rem] w-screen">
+    <div className="flex h-screen min-w-[76rem] w-screen">
       {code ? (
         <Loading />
       ) : (
         <>
           <div className="flex items-center justify-center w-1/2 bg-true-white">
-            <img className="w-[38rem] h-[38rem]" src={loginImage} alt="로그인하는 레서" />
+            <img className="w-[32rem] h-[32rem]" src={loginImage} alt="로그인하는 레서" />
           </div>
           <div className="flex flex-col items-center justify-center w-1/2 bg-cool-neutral">
             <LesserTextLogo width={272} height={72} color="#006241" />

--- a/FE/src/pages/SprintPage.tsx
+++ b/FE/src/pages/SprintPage.tsx
@@ -98,9 +98,9 @@ const SprintPage = () => {
   };
 
   const [todoNumber, inProgressNumber, doneNumber] = useMemo(() => {
-    const todoNumber = data?.taskList.filter(({ state }) => state === 'ToDo').length;
-    const inProgressNumber = data?.taskList.filter(({ state }) => state === 'InProgress').length;
-    const doneNumber = data?.taskList.filter(({ state }) => state === 'Done').length;
+    const todoNumber = data?.taskList?.filter(({ state }) => state === 'ToDo').length;
+    const inProgressNumber = data?.taskList?.filter(({ state }) => state === 'InProgress').length;
+    const doneNumber = data?.taskList?.filter(({ state }) => state === 'Done').length;
 
     return [todoNumber, inProgressNumber, doneNumber];
   }, [data]);


### PR DESCRIPTION
## 설명

- 로그인 화면의 크기를 다른 화면들과 같도록 조정했습니다.
- 칸반보드에서 태스크 리스트가 없을 때(스프린트가 시작되지 않았거나 끝났을 때) 오류가 나 페이지가 보이지 않던 문제를 수정했습니다.
- 로딩 컴포넌트의 가로 정렬을 추가했습니다.