### PR TITLE
fix: GitHub OAuth URL 반환하는 컨트롤러가 URL 값을 JSON 형식으로 반환하도록 변경

### DIFF
--- a/backend/src/auth/controller/auth.controller.spec.ts
+++ b/backend/src/auth/controller/auth.controller.spec.ts
@@ -26,7 +26,7 @@ describe('Controller getGithubAuthServerUrl Unit Test', () => {
   it('should return data from the service', async () => {
     const controllerResponse = controller.getGithubAuthServerUrl();
     const serviceResponse = authService.getGithubAuthUrl();
-    expect(controllerResponse).toEqual(serviceResponse);
+    expect(controllerResponse.authUrl).toEqual(serviceResponse);
     expect(authService.getGithubAuthUrl).toHaveBeenCalled();
   });
 });

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -5,7 +5,7 @@ import { AuthService } from '../service/auth.service';
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
   @Get('github/authorization-server')
-  getGithubAuthServerUrl(): string {
-    return this.authService.getGithubAuthUrl();
+  getGithubAuthServerUrl() {
+    return { authUrl: this.authService.getGithubAuthUrl() };
   }
 }


### PR DESCRIPTION
## ✅ 작업 내용

- 컨트롤러에서 URL 값을 단순 string이 아닌 다음과 같은 형식으로 반환하도록 수정
```
{
  authUrl: "https://github...."
}
```
