### PR TITLE
fix: tempId 토큰을 보내는 상태코드를 204에서 209로 변경

### DIFF
--- a/backend/src/auth/controller/auth.controller.spec.ts
+++ b/backend/src/auth/controller/auth.controller.spec.ts
@@ -64,7 +64,7 @@ describe('Auth Controller Unit Test', () => {
       expect(mockResponse.send).toHaveBeenCalledWith({
         tempIdToken: 'tempIdToken',
       });
-      expect(mockResponse.status).toHaveBeenCalledWith(204);
+      expect(mockResponse.status).toHaveBeenCalledWith(209);
       expect(authService.githubAuthentication).toHaveBeenCalled();
     });
 

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -27,7 +27,8 @@ export class AuthController {
       const result = await this.authService.githubAuthentication(body.authCode);
       if ('tempIdToken' in result) {
         const responseBody = { tempIdToken: result.tempIdToken };
-        return response.status(204).send(responseBody);
+		console.log(responseBody);
+        return response.status(209).send(responseBody);
       } else {
         const responseBody = { accessToken: result.accessToken };
         return response


### PR DESCRIPTION
## ✅ 작업 내용

- tempId 토큰을 보내는 상태코드를 204에서 209로 변경

## 🖊️ 구체적인 작업

- 204 상태코드에서 정상적으로 리턴했음에도 상태코드의 특성으로 인해 body가 클라이언트로 전달되지 않아 209로 변경함.
