### PR TITLE
feat: auth controller에서 에러 메시지를 로그하도록 변경

### DIFF
--- a/backend/src/auth/controller/auth.controller.spec.ts
+++ b/backend/src/auth/controller/auth.controller.spec.ts
@@ -109,10 +109,7 @@ describe('Auth Controller Unit Test', () => {
         );
       } catch (error) {
         expect(error).toBeInstanceOf(UnauthorizedException);
-        expect(error.response).toEqual({
-          statusCode: 401,
-          message: 'Unauthorized',
-        });
+        expect(error.response.statusCode).toEqual(401);
       }
     });
 
@@ -128,10 +125,7 @@ describe('Auth Controller Unit Test', () => {
         );
       } catch (error) {
         expect(error).toBeInstanceOf(UnauthorizedException);
-        expect(error.response).toEqual({
-          statusCode: 401,
-          message: 'Unauthorized',
-        });
+        expect(error.response.statusCode).toEqual(401);
       }
     });
 
@@ -147,10 +141,7 @@ describe('Auth Controller Unit Test', () => {
         );
       } catch (error) {
         expect(error).toBeInstanceOf(InternalServerErrorException);
-        expect(error.response).toEqual({
-          statusCode: 500,
-          message: 'Internal Server Error',
-        });
+        expect(error.response.statusCode).toEqual(500);
       }
     });
   });

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -27,7 +27,6 @@ export class AuthController {
       const result = await this.authService.githubAuthentication(body.authCode);
       if ('tempIdToken' in result) {
         const responseBody = { tempIdToken: result.tempIdToken };
-		console.log(responseBody);
         return response.status(209).send(responseBody);
       } else {
         const responseBody = { accessToken: result.accessToken };
@@ -46,9 +45,9 @@ export class AuthController {
         err.message === 'Cannot retrieve access token' ||
         err.message === 'Cannot retrieve github user'
       ) {
-        throw new UnauthorizedException();
+        throw new UnauthorizedException(err.message);
       }
-      throw new InternalServerErrorException();
+      throw new InternalServerErrorException(err.message);
     }
   }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- API 테스트시 에러 메시지를 확인할 수 있도록 auth controller에서 에러 메시지를 로그하도록 변경