### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { LesserJwtModule } from './lesser-jwt/lesser-jwt.module';
 import { TempMember } from './auth/entity/tempMember.entity';
 import { MemberModule } from './member/member.module';
 import { Member } from './member/entity/member.entity';
+import { LoginMember } from './auth/entity/loginMember.entity';
 
 @Module({
   imports: [
@@ -29,7 +30,7 @@ import { Member } from './member/entity/member.entity';
         username: ConfigService.get(DATABASE_USER),
         password: ConfigService.get(DATABASE_PASSWORD),
         database: ConfigService.get(DATABASE_NAME),
-        entities: [Member, TempMember],
+        entities: [Member, TempMember, LoginMember],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),
     }),

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,15 +7,17 @@ import { TempMember } from './entity/tempMember.entity';
 import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
 import { TempMemberRepository } from './repository/tempMember.repository';
 import { MemberModule } from 'src/member/member.module';
+import { LoginMember } from './entity/loginMember.entity';
+import { LoginMemberRepository } from './repository/loginMember.repository';
 
 @Module({
   imports: [
     GithubApiModule,
-    TypeOrmModule.forFeature([TempMember]),
+    TypeOrmModule.forFeature([TempMember, LoginMember]),
     LesserJwtModule,
     MemberModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, TempMemberRepository],
+  providers: [AuthService, TempMemberRepository, LoginMemberRepository],
 })
 export class AuthModule {}

--- a/backend/src/auth/entity/loginMember.entity.ts
+++ b/backend/src/auth/entity/loginMember.entity.ts
@@ -1,0 +1,36 @@
+import { Member } from 'src/member/entity/member.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class LoginMember {
+  @PrimaryColumn()
+  member_id: number;
+
+  @OneToOne(() => Member)
+  @JoinColumn({ name: 'member_id' })
+  member: Member;
+
+  @Column()
+  refresh_token: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  static of(memberId: number, refreshToken: string) {
+    const newRefreshToken = new LoginMember();
+    newRefreshToken.member_id = memberId;
+    newRefreshToken.refresh_token = refreshToken;
+    return newRefreshToken;
+  }
+}

--- a/backend/src/auth/repository/loginMember.repository.ts
+++ b/backend/src/auth/repository/loginMember.repository.ts
@@ -7,7 +7,7 @@ import { LoginMember } from '../entity/loginMember.entity';
 @Injectable()
 export class LoginMemberRepository {
   constructor(
-    @InjectRepository(TempMember)
+    @InjectRepository(LoginMember)
     private readonly loginMemberRepository: Repository<LoginMember>,
   ) {}
 

--- a/backend/src/auth/repository/loginMember.repository.ts
+++ b/backend/src/auth/repository/loginMember.repository.ts
@@ -1,0 +1,29 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TempMember } from '../entity/tempMember.entity';
+import { Injectable } from '@nestjs/common';
+import { LoginMember } from '../entity/loginMember.entity';
+
+@Injectable()
+export class LoginMemberRepository {
+  constructor(
+    @InjectRepository(TempMember)
+    private readonly loginMemberRepository: Repository<LoginMember>,
+  ) {}
+
+  async save(loginMember: LoginMember): Promise<number> {
+    const { member_id } = await this.loginMemberRepository.save(loginMember);
+    return member_id;
+  }
+
+  async findByMemberId(memberId: number): Promise<LoginMember> {
+    return this.loginMemberRepository.findOneBy({ member_id: memberId });
+  }
+
+  async deleteByMemberId(memberId: number): Promise<number> {
+    const { affected } = await this.loginMemberRepository.delete({
+      member_id: memberId,
+    });
+    return affected;
+  }
+}


### PR DESCRIPTION
## 🎟️ 태스크

[로그아웃 API 구현 (POST /auth/logout)](https://plastic-toad-cb0.notion.site/API-POST-auth-logout-86dfb24a84754912815a61cd43ed9b53)

## ✅ 작업 내용
- [LoginMember 엔티티, 레포지토리 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/ec552421df643afc05a6e14ba41febbfef1bed47)
- [로그아웃 서비스 로직 및 로그인/회원가입 시 리프레시 토큰을 저장하는 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/721d6bbccc4ec9f26804ed39b6edc89af80a9f2a)
- [로그아웃 컨트롤러 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/e7416d506a2924e61582a038b8e54cbce32a27a3)

## 🖊️ 구체적인 작업

### LoginMember 엔티티, 레포지토리 구현
- 회원의 로그인 상태를 저장하기 위한 엔티티
- member_id, refresh_token 값 저장

### 로그인/회원가입 시 리프레시 토큰을 저장하는 로직 구현
- 기존 로그인/회원가입 서비스에 리프레시 토큰 저장하는 로직 및 테스트 추가

### 로그아웃 서비스 로직 구현
- 로그아웃 서비스 로직 및 테스트 구현

### 로그아웃 컨트롤러 로직 구현
- 로그아웃 서비스에 accessToken 전달
- 로그아웃 서비스 로직 성공시 쿠키에서 refreshToken 삭제하여 응답

## 🤔 고민한 것들
- [LoginMember의 객체 생성 메서드(of)에 외래키의 엔티티인 Member 객체가 꼭 필요할까?](https://plastic-toad-cb0.notion.site/LoginMember-of-Member-7b828997a86442998f68ad6fd8409a8d)
