### PR TITLE
feat: refresh API 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.1",
+        "cookie-parser": "^1.4.6",
         "mysql2": "^3.9.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
@@ -3727,6 +3728,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.1",
+    "cookie-parser": "^1.4.6",
     "mysql2": "^3.9.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -18,6 +18,7 @@ import { TempMember } from './auth/entity/tempMember.entity';
 import { MemberModule } from './member/member.module';
 import { Member } from './member/entity/member.entity';
 import { LoginMember } from './auth/entity/loginMember.entity';
+import * as cookieParser from 'cookie-parser';
 
 @Module({
   imports: [
@@ -43,4 +44,8 @@ import { LoginMember } from './auth/entity/loginMember.entity';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(cookieParser()).forRoutes('*');
+  }
+}

--- a/backend/src/auth/controller/auth.controller.spec.ts
+++ b/backend/src/auth/controller/auth.controller.spec.ts
@@ -95,7 +95,7 @@ describe('Auth Controller Unit Test', () => {
         {
           httpOnly: true,
           secure: false,
-          path: '/auth/',
+          path: '/api/auth/',
           sameSite: 'strict',
         },
       );
@@ -213,7 +213,7 @@ describe('Auth Controller Unit Test', () => {
         {
           httpOnly: true,
           secure: false,
-          path: '/auth/',
+          path: '/api/auth/',
           sameSite: 'strict',
         },
       );
@@ -289,7 +289,7 @@ describe('Auth Controller Unit Test', () => {
       expect(mockResponse.clearCookie).toHaveBeenCalledWith('refreshToken', {
         httpOnly: true,
         secure: false,
-        path: '/auth/',
+        path: '/api/auth/',
         sameSite: 'strict',
       });
       expect(mockResponse.status).toHaveBeenCalledWith(200);
@@ -381,7 +381,7 @@ describe('Auth Controller Unit Test', () => {
         {
           httpOnly: true,
           secure: false,
-          path: '/auth/',
+          path: '/api/auth/',
           sameSite: 'strict',
         },
       );

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -21,7 +21,7 @@ export class AuthController {
   private cookieOptions: CookieOptions = {
     httpOnly: true,
     secure: false, // HTTPS 적용시 true로 변경
-    path: '/auth/',
+    path: '/api/auth/',
     sameSite: 'strict',
   };
 

--- a/backend/src/auth/repository/loginMember.repository.ts
+++ b/backend/src/auth/repository/loginMember.repository.ts
@@ -26,4 +26,16 @@ export class LoginMemberRepository {
     });
     return affected;
   }
+
+  async updateRefreshToken(
+    memberId: number,
+    refreshToken: string,
+    newRefreshToken: string,
+  ) {
+    const { affected } = await this.loginMemberRepository.update(
+      { member_id: memberId, refresh_token: refreshToken },
+      { refresh_token: newRefreshToken },
+    );
+    return affected;
+  }
 }

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -158,4 +158,23 @@ export class AuthService {
       await this.loginMemberRepository.deleteByMemberId(memberId);
     if (deletedCount === 0) throw new Error('Not a logged in member');
   }
+
+  async refreshAccessTokenAndRefreshToken(refreshToken: string) {
+    const { sub } = await this.lesserJwtService.getPayload(
+      refreshToken,
+      'refresh',
+    );
+    const memberId = sub.id;
+    const newRefreshToken =
+      await this.lesserJwtService.createRefreshToken(memberId);
+    const updatedCount = await this.loginMemberRepository.updateRefreshToken(
+      memberId,
+      refreshToken,
+      newRefreshToken,
+    );
+    if (updatedCount === 0) throw new Error('No matching refresh token');
+    const newAccessToken =
+      await this.lesserJwtService.createAccessToken(memberId);
+    return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+  }
 }


### PR DESCRIPTION
[토큰 리프레시 API 구현 (POST /auth/refresh)](https://plastic-toad-cb0.notion.site/API-POST-auth-refresh-dfbe487791564fd590607d90e5737420?pvs=74)

## ✅ 작업 내용

- loginMember의 리프레시토큰을 업데이트하는 메서드 추가
- refresh토큰을 받아 새로운 refresh토큰과 access토큰을 반환하는 서비스 구현
- 리프레시 컨트롤러 로직 구현
- 쿠키 누락된 설정 추가

## 🖊️ 구체적인 작업

### loginMember의 리프레시토큰을 업데이트하는 메서드 추가

### refresh토큰을 받아 새로운 refresh토큰과 access토큰을 반환하는 서비스 구현
- 리프레시토큰을 교체하고, 새로운 엑세스 토큰과 리프레시 토큰을 반환
기존의 리프레시 토큰이 유효한지 확인
리프레시 토큰으로 식별된 회원이 로그인 상태이며 DB에 저장된 리프레시토큰이 일치하는지 확인
유효하다면 새로운 리프레시토큰과 엑세스토큰을 반환
- DB에 회원의 로그인 상태가 아니거나 저장된 리프레시토큰이 일치하지 않으면 에러를 반환

### 리프레시 컨트롤러 로직 구현
- 유효한 리프레시토큰일때 바디로 새로운 엑세스토큰을 반환하고, 쿠키로 새로운 리프레시 토큰을 반환
- 리프레시토큰이 없거나 유효하지 않은 리프레시토큰이면 401 반환

### 쿠키 누락된 설정 추가
- request.cookies['refreshToken']를 사용하기 위해 쿠키파서 설치
- /auth/였던 쿠키 경로를 /api/auth/로 변경

## 🤔 고민 및 의논할 거리(선택)
- 레포지토리 업데이트 메서드의 매개변수로 객체를 사용할지, 프로퍼티를 사용할지 고민하고 프로퍼티를 사용하기로 결정했습니다.
[매개변수에 대한 고민](https://plastic-toad-cb0.notion.site/143c40cbb3f748e3b789005d0f3e6148)
