### PR TITLE
feat: auth controller 401 에러 메시지 변경

### DIFF
--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -52,7 +52,7 @@ export class AuthController {
         err.message === 'Cannot retrieve access token' ||
         err.message === 'Cannot retrieve github user'
       ) {
-        throw new UnauthorizedException(err.message);
+        throw new UnauthorizedException('Invalid authorization code');
       }
       throw new InternalServerErrorException(err.message);
     }
@@ -90,7 +90,7 @@ export class AuthController {
         err.message === 'Failed to verify token' ||
         err.message === 'tempIdToken does not match'
       ) {
-        throw new UnauthorizedException(err.message);
+        throw new UnauthorizedException('Expired:tempIdToken');
       }
       throw new InternalServerErrorException(err.message);
     }
@@ -113,11 +113,11 @@ export class AuthController {
     try {
       await this.authService.logout(accessToken);
     } catch (err) {
-      if (
-        err.message === 'Not a logged in member' ||
-        err.message === 'Failed to verify token'
-      ) {
-        throw new UnauthorizedException(err.message);
+      if (err.message === 'Not a logged in member') {
+        throw new UnauthorizedException('Not a logged in member');
+      }
+      if (err.message === 'Failed to verify token') {
+        throw new UnauthorizedException('Expired:accessToken');
       }
       throw new InternalServerErrorException(err.message);
     }
@@ -148,7 +148,7 @@ export class AuthController {
         err.message === 'No matching refresh token' ||
         err.message === 'Failed to verify token'
       ) {
-        throw new UnauthorizedException(err.message);
+        throw new UnauthorizedException('Expired:refreshToken');
       }
       throw new InternalServerErrorException(err.message);
     }


### PR DESCRIPTION
## 🎟️ 태스크

[HTTP 응답 코드 정리](https://plastic-toad-cb0.notion.site/HTTP-0f2bb22935e943f5802504f8dd70f129?pvs=74)

## ✅ 작업 내용

1. JWT 토큰 종류에 따른 에러 메시지 분리 1-1. tempIdToken 만료: 'Expired:tempIdToken'
1-2. accessToken 만료: 'Expired:accessToken'
1-3. refreshToken 만료: 'Expired:refreshToken'
2. 로그아웃 컨트롤러에서 로그인 상태의 회원이 아닌 경우를 따로 분리하여 에러 응답 2-1. 액세스 토큰 만료가 아닌, 로그인 회원이 아닌 경우에는 'Not a logged in member' 에러 메시지 반환
3. auth controller 테스트코드 작성

## 구체적인 작업 내용

401 에러가 발생하면 인증에 실패한 것이므로, 기본적으로 로그인 페이지로 리다이렉트 해야한다.

다만 토큰 만료에 따른 401 에러 발생시 예외적으로 다른 로직을 수행해야하므로, 이런 상황에 분기하여 다른 로직을 수행할 수 있도록 에러 메시지로 3가지 토큰 만료 상태를 구분할 수 있도록 변경하였다.

### 액세스 토큰 만료

- 에러 메시지: `Expired:accessToken`
- 후속 조치: 리프레시 토큰 이용하여 리프레시 로직 수행

### 리프레시 토큰 만료

- 에러 메시지: `Expired:refreshToken`
- 후속 조치: 로그인 페이지로 리다이렉트

### 임시ID토큰 만료 (회원가입할 때 필요)

- 에러 메시지: `Expired:tempIdToken`
- 후속 조치: 깃허브 인증 다시 수행

### 그외 401 에러 발생시

- 회원 인증에 실패한 것이기 때문에 로그인 페이지로 리다이렉트

## 🤔 고민 및 의논할 거리

### 문제상황

- 기존의 API 명세서는 각 에러상황에서 에러코드에 대한 설명만 작성되어있었음. 
- 예를들면 로그아웃 API에서 Authorization 헤더가 없는 상황, accessToken이 유효하지 않은상황, accessToken의 유저가 로그인 되어있지 않은 상황 모두 401을 반환한다 정도로 작성되어있었음.
- 그러나 클라이언트입장에서 401 등의 에러시, 에러상황을 구분할 방법이 없어 적절한 분기처리가 어렵기 때문에 에러 구분을 요청했다. 
이때 에러를 구분하는 방법으로 여러가지 방법이 떠올라서 고민해보았다.

### 방안
1. 에러 각각을 `에러코드`로 구분
2. 에러 각각을 상황에 맞는 에러코드를 사용하고 `에러 메시지`로 구분

### 결론
- `에러 메시지`로 구분하는게 맞다고 생각함
- 에러코드로 구분하려고하면 에러의 종류가 많아짐에 따라 커스텀 에러코드를 많이 사용해야 할것이다.
- 커스텀 에러코드가 많아지면 에러의 가독성이 떨어짐
- 에러코드는 항상 상황에 맞게 사용하고, 클라이언트는 에러코드와 에러 메시지를 모두 이용해 분기처리
- [API 명세서](https://plastic-toad-cb0.notion.site/API-5929e1755c864279b8239f1c9186fe0a)에서 에러상황과 에러 메시지를 디테일하게 작성
