### PR TITLE
feat: Member 엔티티 제약조건 설정

### DIFF
--- a/backend/src/member/entity/member.entity.ts
+++ b/backend/src/member/entity/member.entity.ts
@@ -1,34 +1,35 @@
 import {
-  BaseEntity,
   Column,
-  CreateDateColumn,
   Entity,
-  PrimaryColumn,
   PrimaryGeneratedColumn,
+  CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 
 @Entity()
-export class Member extends BaseEntity {
-  @PrimaryGeneratedColumn()
+export class Member {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
 
-  @Column()
+  @Index()
+  @Column({ type: 'int', unique: true, nullable: false })
   github_id: number;
 
-  @Column()
+  @Column({ type: 'varchar', length: 39, nullable: false })
   github_username: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 256, nullable: false })
   github_image_url: string;
 
-  @Column()
+  @Index()
+  @Column({ type: 'varchar', length: 39, unique: true, nullable: false })
   username: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 20, nullable: false })
   position: string;
 
-  @Column('json')
+  @Column({ type: 'json', nullable: false })
   tech_stack: object;
 
   @CreateDateColumn({ type: 'timestamp' })


### PR DESCRIPTION
## 🎟️ 태스크

[DB 회원 테이블 제약조건 설정](https://plastic-toad-cb0.notion.site/DB-93beea0011ca45fa87cd5b05cdf6455b)

## ✅ 작업 내용

- Data Mapper 패턴을 채택하여 불필요한 BaseEntity 확장 제거
- 칼럼별 type, length, nullable 제약조건 설정
- github_id, username 칼럼에 unique 제약조건 설정
- github_id, username 칼럼에 index 설정

## 🖊️ 구체적인 작업

### 칼럼별 type, length, nullable 제약조건 설정
- github_username의 최대길이가 39자이기 때문에 제약조건을 39자로 둠

### github_id, username 칼럼에 index 제약조건 설정
- github_id와 username은 unique 제약조건이 걸려있고, 특히 username컬럼은 닉네임 중복검사 API를 통해 자주 조회될것이 예상돼 index를 걸어 놓았음

## 🤔 고민 및 의논할 거리
    
position과 tech_stack의 nullable처리를 현재는 false로 해 놓았는데, 추후에 nullable하게 변경해야합니다. member Entity 클래스의 정적메서드 중 of에서 현재는 모든 컬럼을 인자로 받아 인스턴스로 생성하는데, nullable한 컬럼이 있을때 어떻게 처리해야할지 고민해보면 좋을것 같아요!

## member 테이블 스키마
```
mysql> desc member;
+------------------+--------------+------+-----+----------------------+--------------------------------------------------+
| Field            | Type         | Null | Key | Default              | Extra                                            |
+------------------+--------------+------+-----+----------------------+--------------------------------------------------+
| id               | int          | NO   | PRI | NULL                 | auto_increment                                   |
| github_id        | int          | NO   | UNI | NULL                 |                                                  |
| tech_stack       | json         | NO   |     | NULL                 |                                                  |
| created_at       | timestamp(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED                                |
| updated_at       | timestamp(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6) |
| github_username  | varchar(39)  | NO   |     | NULL                 |                                                  |
| github_image_url | varchar(256) | NO   |     | NULL                 |                                                  |
| username         | varchar(39)  | NO   | UNI | NULL                 |                                                  |
| position         | varchar(20)  | NO   |     | NULL                 |                                                  |
+------------------+--------------+------+-----+----------------------+--------------------------------------------------+
```
## member 테이블 인덱스
```
mysql> show index from member;
+--------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
| Table  | Non_unique | Key_name                       | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Visible | Expression |
+--------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
| member |          0 | PRIMARY                        |            1 | id          | A         |           0 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
| member |          0 | IDX_f29502fbd8f92518bfc2544125 |            1 | github_id   | A         |           0 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
| member |          0 | IDX_1945f9202fcfbce1b439b47b77 |            1 | username    | A         |           0 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
+--------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
```