### PR TITLE
feat: 개발서버 및 프로덕션서버 HTTPS 적용

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,7 @@ services:
   nginx:
     build:
       context: ./nginx
+      dockerfile: Dockerfile.dev
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,12 +6,16 @@ services:
       context: ./nginx
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - backend
       - frontend
+    volumes:
+      - certbot-www:/var/www/certbot/:ro
+      - certbot-conf:/etc/nginx/ssl/:ro
     networks:
       - lesser-net
-  
+
   backend:
     build:
       context: ./backend
@@ -28,7 +32,7 @@ services:
       - db
     networks:
       - lesser-net
-  
+
   frontend:
     build:
       context: ./frontend
@@ -52,3 +56,7 @@ networks:
 
 volumes:
   mysql_data: {}
+  certbot-www:
+    external: true
+  certbot-conf:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,16 @@ services:
       context: ./nginx
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - backend
       - frontend
+    volumes:
+      - certbot-www:/var/www/certbot/:ro
+      - certbot-conf:/etc/nginx/ssl/:ro
     networks:
       - lesser-net
-  
+
   backend:
     build:
       context: ./backend
@@ -26,7 +30,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
     networks:
       - lesser-net
-  
+
   frontend:
     build:
       context: ./frontend
@@ -35,4 +39,10 @@ services:
 
 networks:
   lesser-net:
+    external: true
+
+volumes:
+  certbot-www:
+    external: true
+  certbot-conf:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   nginx:
     build:
       context: ./nginx
+      dockerfile: Dockerfile.prod
     ports:
       - "80:80"
       - "443:443"

--- a/nginx/Dockerfile.dev
+++ b/nginx/Dockerfile.dev
@@ -1,7 +1,5 @@
 FROM nginx
 
-COPY conf/dev.conf /etc/ngix/conf.d
-
-EXPOSE 80
+COPY conf/conf.d/dev.conf /etc/ngix/conf.d
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile.dev
+++ b/nginx/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM nginx
 
-COPY conf/conf.d/dev.conf /etc/ngix/conf.d
+COPY conf/conf.d/dev.conf /etc/nginx/conf.d
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile.dev
+++ b/nginx/Dockerfile.dev
@@ -1,8 +1,6 @@
 FROM nginx
 
-RUN rm -rf /etc/nginx/conf.d
-
-COPY conf /etc/nginx
+COPY conf/dev.conf /etc/ngix/conf.d
 
 EXPOSE 80
 

--- a/nginx/Dockerfile.prod
+++ b/nginx/Dockerfile.prod
@@ -1,0 +1,11 @@
+FROM nginx
+
+RUN rm -rf /etc/nginx/conf.d
+
+RUN mkdir /etc/nginx/conf.d
+
+COPY conf/prod.conf /etc/ngix/conf.d
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile.prod
+++ b/nginx/Dockerfile.prod
@@ -1,11 +1,5 @@
 FROM nginx
 
-RUN rm -rf /etc/nginx/conf.d
-
-RUN mkdir /etc/nginx/conf.d
-
-COPY conf/prod.conf /etc/ngix/conf.d
-
-EXPOSE 80
+COPY conf/conf.d/prod.conf /etc/ngix/conf.d
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile.prod
+++ b/nginx/Dockerfile.prod
@@ -1,5 +1,5 @@
 FROM nginx
 
-COPY conf/conf.d/prod.conf /etc/ngix/conf.d
+COPY conf/conf.d/prod.conf /etc/nginx/conf.d
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/conf/conf.d/default.conf
+++ b/nginx/conf/conf.d/default.conf
@@ -1,6 +1,24 @@
 server {
-	server_name lesser-project.site;
-    listen 80;
+    listen 80 default_server;
+    listen [::]:80;
+
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://lesser-project.site$request_uri;
+    }
+}
+
+server {
+    listen 443 default_server ssl;
+    listen [::]:443 ssl;
+
+    ssl_certificate /etc/nginx/ssl/live/lesser-project.site/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/lesser-project.site/privkey.pem;
 
     location / {
         proxy_pass http://frontend:5000;

--- a/nginx/conf/conf.d/dev.conf
+++ b/nginx/conf/conf.d/dev.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+	server_name dev.lesser-project.site;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://dev.lesser-project.site$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+	server_name dev.lesser-project.site;
+
+    ssl_certificate /etc/nginx/ssl/live/dev.lesser-project.site/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/dev.lesser-project.site/privkey.pem;
+
+    location / {
+        proxy_pass http://frontend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/nginx/conf/conf.d/prod.conf
+++ b/nginx/conf/conf.d/prod.conf
@@ -1,7 +1,8 @@
 server {
-    listen 80 default_server;
+    listen 80;
     listen [::]:80;
 
+	server_name lesser-project.site;
     server_tokens off;
 
     location /.well-known/acme-challenge/ {
@@ -14,8 +15,10 @@ server {
 }
 
 server {
-    listen 443 default_server ssl;
+    listen 443 ssl;
     listen [::]:443 ssl;
+
+	server_name lesser-project.site;
 
     ssl_certificate /etc/nginx/ssl/live/lesser-project.site/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/lesser-project.site/privkey.pem;


### PR DESCRIPTION
## 🎟️ 태스크

[배포서버 nginx에 HTTPS 인증 적용](https://plastic-toad-cb0.notion.site/nginx-HTTPS-b9c1733457a54bdaa4ef46952085da94?pvs=74)
[개발서버 nginx에 HTTPS 인증 적용](https://plastic-toad-cb0.notion.site/nginx-HTTPS-22b25c0c875c43a090cf6870605be94d?pvs=74)

## ✅ 작업 내용

- 배포서버 nginx에 HTTPS 인증 적용
- 개발서버 nginx에 HTTPS 인증 적용

## 🖊️ 구체적인 작업

### HTTPS 포팅 매뉴얼
[링크](https://plastic-toad-cb0.notion.site/HTTPS-57e1b6995d6e463e9350649b117d0d2d?pvs=74)에 상세히 작성해놓았습니다.

## 🤔 고민 및 의논할 거리(선택)
    
- SSL인증서의 만료기한이 3개월인데 만료기한 이후에는 SSL인증서가 유효하지 않게 됩니다. 따라서 자동으로 갱신하는 프로세스를 구축해놓으면 좋을것같습니다.
- 개발서버와 배포서버의 SSL 인증서 경로가 다르기 때문에 nginx conf파일에 차이가 있습니다. nginx의 conf파일에 환경변수 적용이 어려워 nginx conf파일, 이를 불러오는 도커파일이 두개로 쪼개져 최종적으로 두개의 파일이 더 생겨났습니다. 이를 하나로 관리할 방법을 고민해보면 좋을것 같아요👻