### PR TITLE
feat: username 사용가능한지 확인(availability)하는 기능 구현

### DIFF
--- a/backend/src/member/controller/member.controller.spec.ts
+++ b/backend/src/member/controller/member.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemberService } from '../service/member.service';
+import { MemberController } from './member.controller';
+
+describe('MemberController', () => {
+  let memberController: MemberController;
+  let memberService: MemberService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemberController],
+      providers: [
+        {
+          provide: MemberService,
+          useValue: {
+            validateUsername: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    memberController = module.get<MemberController>(MemberController);
+    memberService = module.get<MemberService>(MemberService);
+  });
+
+  describe('Member Availability Username', () => {
+    const username = 'username';
+    it('should return true when valid username', async () => {
+      const controllerResponse =
+        await memberController.availabilityUsername(username);
+
+      expect(memberService.validateUsername).toHaveBeenCalledWith(username);
+      expect(controllerResponse.available).toBe(true);
+    });
+
+    it('should return false when duplicate username', async () => {
+      jest
+        .spyOn(memberService, 'validateUsername')
+        .mockRejectedValue(new Error('duplicate username'));
+
+      const controllerResponse =
+        await memberController.availabilityUsername(username);
+
+      expect(memberService.validateUsername).toHaveBeenCalledWith(username);
+      expect(controllerResponse.available).toBe(false);
+      expect(controllerResponse.message).toBe('duplicate username');
+    });
+  });
+});

--- a/backend/src/member/controller/member.controller.spec.ts
+++ b/backend/src/member/controller/member.controller.spec.ts
@@ -1,3 +1,4 @@
+import { Controller, InternalServerErrorException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MemberService } from '../service/member.service';
 import { MemberController } from './member.controller';
@@ -44,6 +45,16 @@ describe('MemberController', () => {
       expect(memberService.validateUsername).toHaveBeenCalledWith(username);
       expect(controllerResponse.available).toBe(false);
       expect(controllerResponse.message).toBe('duplicate username');
+    });
+
+    it('should throw 500 error when unknown error', async () => {
+      jest
+        .spyOn(memberService, 'validateUsername')
+        .mockRejectedValue(new Error());
+
+      expect(
+        async () => await memberController.availabilityUsername(username),
+      ).rejects.toThrow(InternalServerErrorException);
     });
   });
 });

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -1,4 +1,9 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  InternalServerErrorException,
+  Query,
+} from '@nestjs/common';
 import { MemberService } from '../service/member.service';
 
 @Controller('member')
@@ -10,7 +15,9 @@ export class MemberController {
       await this.memberService.validateUsername(username);
       return { available: true };
     } catch (err) {
-      return { available: false, message: err.message };
+      if (err.message === 'duplicate username')
+        return { available: false, message: err.message };
+      throw new InternalServerErrorException(err.message);
     }
   }
 }

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -8,9 +8,9 @@ export class MemberController {
   async availabilityUsername(@Query('username') username) {
     try {
       await this.memberService.validateUsername(username);
+      return { available: true };
     } catch (err) {
       return { available: false, message: err.message };
     }
-    return { available: true };
   }
 }

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { MemberService } from '../service/member.service';
+
+@Controller('member')
+export class MemberController {
+  constructor(private readonly memberService: MemberService) {}
+  @Get('/availability')
+  async availabilityUsername(@Query('username') username) {
+    try {
+      await this.memberService.validateUsername(username);
+    } catch (err) {
+      return { available: false, message: err.message };
+    }
+    return { available: true };
+  }
+}

--- a/backend/src/member/member.module.ts
+++ b/backend/src/member/member.module.ts
@@ -3,10 +3,12 @@ import { MemberService } from './service/member.service';
 import { Member } from './entity/member.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MemberRepository } from './repository/member.repository';
+import { MemberController } from './controller/member.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Member])],
   providers: [MemberService, MemberRepository],
   exports: [MemberService],
+  controllers: [MemberController],
 })
 export class MemberModule {}

--- a/backend/src/member/repository/member.repository.ts
+++ b/backend/src/member/repository/member.repository.ts
@@ -14,6 +14,10 @@ export class MemberRepository {
     return this.memberRepository.findOneBy({ github_id: githubId });
   }
 
+  findByUsername(username: string): Promise<Member> {
+    return this.memberRepository.findOneBy({ username });
+  }
+
   create(member: Member): Promise<Member> {
     return this.memberRepository.save(member);
   }

--- a/backend/src/member/service/member.service.spec.ts
+++ b/backend/src/member/service/member.service.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Member } from '../entity/member.entity';
+import { MemberRepository } from '../repository/member.repository';
+import { MemberService } from './member.service';
+
+describe('LesserJwtService', () => {
+  let memberService: MemberService;
+  let memberRepository: MemberRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemberService,
+        {
+          provide: MemberRepository,
+          useValue: {
+            findByUsername: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    memberService = module.get<MemberService>(MemberService);
+    memberRepository = module.get<MemberRepository>(MemberRepository);
+  });
+
+  describe('Validate Username', () => {
+    it('should return void when valid username', async () => {
+      const username = 'username';
+
+      jest.spyOn(memberRepository, 'findByUsername').mockResolvedValue(null);
+
+      await expect(
+        memberService.validateUsername(username),
+      ).resolves.toBeUndefined();
+      expect(memberRepository.findByUsername).toHaveBeenCalledWith(username);
+    });
+
+    it('should throw duplicate username when username already exist', async () => {
+      const username = 'username';
+
+      jest
+        .spyOn(memberRepository, 'findByUsername')
+        .mockResolvedValue(new Member());
+
+      await expect(
+        async () => await memberService.validateUsername(username),
+      ).rejects.toThrow('duplicate username');
+    });
+  });
+});

--- a/backend/src/member/service/member.service.ts
+++ b/backend/src/member/service/member.service.ts
@@ -29,4 +29,9 @@ export class MemberService {
     );
     return member.id;
   }
+
+  async validateUsername(username: string): Promise<void> {
+    const member = await this.memberRepository.findByUsername(username);
+    if (member !== null) throw new Error('duplicate username');
+  }
 }


### PR DESCRIPTION
## 🎟️ 태스크

[닉네임 사용 가능 여부 확인 API 구현](https://plastic-toad-cb0.notion.site/API-e37a9a0daa044b2e8d19ce434f3a446e?pvs=74)

## ✅ 작업 내용

- Member모듈 username의 유효성검사 서비스
- Member모듈 availability username 컨트롤러

## 🖊️ 구체적인 작업

### Member모듈 username의 유효성검사 서비스

- repository에 username으로 member 검색하는 메소드 추가
- service에 username을 인자로 받아 중복된 username이 있는지 검사하는 메소드 추가
- username 중복시 'duplicate username' throw함

### Member모듈 availability username 컨트롤러

- username 유효성 검사 컨트롤러 구현
- 유효시 {available: true} 반환
- 유효성 검사 실패시 {available: false, massage: 에러 메시지} 반환

## 🤔 고민 및 의논할 거리(선택)
    
- 일반적으로 사용할 수 있도록 서비스의 이름을 validateUsername이라고 지었습니다. 
- 이후 username에 대해 검증할 사항이 늘어났을때 이름 중복검사 뿐만 아니라, 이전에 이야기한 '조ㅇㅇ'같이 자음, 모음이 모두 같추어지지 않은 한글 닉네임도 서비스 로직에서 유효성검사하고 실패시 throw + 적절한 에러메시지를 던지게 일관적으로 구현하면 좋을것같습니다.

- void 반환형을 확인하는 테스트코드입니다. 이전에 사용한 적이 없어 첨부합니다.

```
await expect(
        memberService.validateUsername(username),
      ).resolves.toBeUndefined();
```