### PR TITLE
feat: 깃허브 유저네임 반환하는 API 구현

### DIFF
--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -153,4 +153,32 @@ export class AuthController {
       throw new InternalServerErrorException(err.message);
     }
   }
+
+  @Post('/github/username')
+  async getGithubUsername(
+    @Req() request: Request & { headers: CustomHeaders },
+  ) {
+    const authHeader = request.headers.authorization;
+    if (!authHeader) {
+      throw new UnauthorizedException('Authorization header is missing');
+    }
+    const [bearer, tempIdToken] = authHeader.split(' ');
+    if (bearer !== 'Bearer' || !tempIdToken) {
+      throw new UnauthorizedException('Invalid authorization header format');
+    }
+
+    try {
+      const githubUsername =
+        await this.authService.getGithubUsernameByTempIdToken(tempIdToken);
+      return { githubUsername };
+    } catch (err) {
+      if (
+        err.message === 'Failed to verify token' ||
+        err.message === 'tempIdToken does not match'
+      ) {
+        throw new UnauthorizedException('Expired:tempIdToken');
+      }
+      throw new InternalServerErrorException(err.message);
+    }
+  }
 }

--- a/backend/src/auth/service/auth.service.spec.ts
+++ b/backend/src/auth/service/auth.service.spec.ts
@@ -44,6 +44,7 @@ describe('Auth Service Unit Test', () => {
             findByGithubId: jest.fn(),
             updateTempIdToken: jest.fn(),
             findByUuid: jest.fn(),
+            findByTempIdToken: jest.fn(),
           },
         },
         {
@@ -469,6 +470,28 @@ describe('Auth Service Unit Test', () => {
         async () =>
           await authService.refreshAccessTokenAndRefreshToken(oldRefreshToken),
       ).rejects.toThrow('No matching refresh token');
+    });
+  });
+
+  describe('Get github username by temp id token', () => {
+    const tempIdToken = 'tempIdToken';
+
+    it('should return github username when given valid temp id token', async () => {
+      const githubUsername = 'githubUsername';
+      const tempMember = TempMember.of(
+        'uuid',
+        tempIdToken,
+        0,
+        githubUsername,
+        'image_url',
+      );
+      jest.spyOn(authService, 'getTempMember').mockResolvedValue(tempMember);
+
+      const response =
+        await authService.getGithubUsernameByTempIdToken(tempIdToken);
+
+      expect(authService.getTempMember).toHaveBeenCalledWith(tempIdToken);
+      expect(response).toBe(githubUsername);
     });
   });
 });

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -177,4 +177,9 @@ export class AuthService {
       await this.lesserJwtService.createAccessToken(memberId);
     return { accessToken: newAccessToken, refreshToken: newRefreshToken };
   }
+
+  async getGithubUsernameByTempIdToken(tempIdToken: string) {
+    const tempMember = await this.getTempMember(tempIdToken);
+    return tempMember.username;
+  }
 }


### PR DESCRIPTION
## 🎟️ 태스크

[temp id token으로 깃허브 닉네임 반환하는 API 구현](https://plastic-toad-cb0.notion.site/temp-id-token-API-ef849b302cf6442bac18c70438ce3ead)

## ✅ 작업 내용

- [tempIdToken으로 깃허브 유저네임을 찾는 서비스 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/db3859593288a63b0a15ff8fc732fbba2785483b)
- [tempIdToken을 받아 깃허브 유저네임을 반환하는 컨트롤러 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/226b34475a90410b7d3cd6c9379a50c6b1cd3974)

## 🖊️ 구체적인 작업

### tempIdToken으로 깃허브 유저네임을 찾는 서비스 로직 구현

- 기존에 구현되어 있는 getTempMember 서비스를 재사용하여 tempIdToken에 대응하는 임시회원 정보를 가져오고, 그중 깃허브 유저네임에 해당하는 username 속성을 반환하도록 구현

### tempIdToken을 받아 깃허브 유저네임을 반환하는 컨트롤러 로직 구현

- 요청 헤더에서 Authorization Bearer 형식으로 tempIdToken을 받아서 이에 대응하는 임시회원의 깃허브 유저네임을 반환하도록 구현

## 🤔 고민 및 의논할 거리

- tempIdToken으로 임시회원을 조회하는 새로운 서비스 로직을 도입하는 것을 고려했지만, 기존 getTempMember 로직에서 이미 토큰의 유효성 검증 등 필요한 로직이 구현되어 있었기 때문에 이를 재사용하기로 결정했습니다. 
- 또한, getTempMember 서비스는 임시회원 테이블의 pk인 uuid 값으로 조회하므로, tempIdToken을 사용하여 조회하는 것보다 비용이 적게 든다고 판단했습니다.
