### PR TITLE
test: 백엔드 e2e 테스트 생성

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from 'src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -12,13 +12,18 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
     await app.init();
   });
 
   it('/ (GET)', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/api')
       .expect(200)
-      .expect('Hello World!');
+      .expect('Hello Lesser!');
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 });

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { DataSource } from 'typeorm';
+
+describe('AuthController (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    dataSource = app.get(DataSource);
+    const entities = dataSource.entityMetadatas;
+    for (const entity of entities) {
+      const repository = dataSource.getRepository(entity.name);
+      await repository.query(`DELETE FROM ${entity.tableName}`);
+    }
+  });
+
+  it('/auth/github/authorization-server (GET)', async () => {
+    const response = await request(app.getHttpServer()).get(
+      '/api/auth/github/authorization-server',
+    );
+    const urlPattern = new RegExp(
+      `^https://github.com/login/oauth/authorize\\?client_id=[\\w]+&scope=[\\w]*$`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.authUrl).toMatch(urlPattern);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## 🎟️ 태스크

[authController E2E 테스트 코드 작성 (github/authorization-server)](https://plastic-toad-cb0.notion.site/authController-E2E-github-authorization-server-8ec828d5ed144e649af7009a9621f0ce)

## ✅ 작업 내용

- [e2e 테스트 파일에서 절대경로 찾을 수 있도록 설정](https://github.com/boostcampwm2023/web10-Lesser/commit/cbf93e73eda8b65375524f303118a21f3792783d)
- [e2e 테스트코드 설정](https://github.com/boostcampwm2023/web10-Lesser/commit/9824be30ad6ab6038cd4fe33a2f0635dcb77ce9e)
- [e2e 테스트 실행시 테스트들이 동기적으로 실행되도록 변경](https://github.com/boostcampwm2023/web10-Lesser/commit/4e843e6ed025050381ec53b4baf7d2b35fbb6394)

## 🖊️ 구체적인 작업

### e2e 테스트 파일에서 절대경로 찾을 수 있도록 설정
- jest-e2e.json

```json
  "moduleNameMapper": {
    "^src/(.*)$": "<rootDir>/../src/$1"
  }
```

### (GET) /auth/github/authorization-server API에 대한 e2e 테스트코드 작성
- supertest의 request를 사용해 HTTP 요청을 생성하고 response 값에 대한 검증을 수행
- beforeEach 함수를 사용하여 테스트 전에 데이터베이스의 모든 테이블 레코드를 삭제
- afterAll 함수를 사용하여 테스트 후 app 종료

### e2e 테스트 실행시 테스트들이 동기적으로 실행되도록 변경
- e2e 테스트 설정에 --runInBand 옵션 추가
```json
  "scripts": {
    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"
  },
```

## 🤔 고민한 것들
자세한 내용은 [E2E 테스트 개발일지](https://plastic-toad-cb0.notion.site/E2E-2f7e2b11a4d247caa163ffe10bd016e1) 참고

### E2E 테스트를 도입한 이유

- 유닛 테스트를 작성해 개발하고도 포스트맨을 사용해 API에 요청해가며 테스트 해보았을때 동작하지 않는 경우가 많았다.
- 이때 문제를 발견해 수정하는 방식으로 진행했으나, 이러한 방식은 테스트 주도개발의 본질인 `테스트 성공시 동작하는 코드라는 확신` 과 `테스트 자동화` 가 지켜지지 않는것이라고 판단해 E2E 테스트를 추가하기로 결정했다.

### E2E 테스트 방식에 대한 논의

- 클라이언트가 사용하는 일련의 절차를 E2E 테스트로 작성한다.
    - 예) 회원가입 → 로그인 → 로그아웃 플로우
- API의 명세를 E2E 테스트로 모두 작성해 동작을 증명한다.
    - 400 에러, 401 에러, 200 OK 등…
- 외부자원을 최대한 실제 환경과 비슷하게 구성해 테스트한다.
    - DB는 실행환경에서 MySQL을 설치하고 테스트를 진행함
    - 깃허브 API는 깃허브 로그인 과정이 필요하기 때문에 모킹하기로 결정함
- DB의 현재 상태와 상관없이 테스트 가능하게 만든다.
    - 로컬에서 데이터가 이미 들어가 있을 경우 Unique같은 속성때문에 결과가 달라지는 것을 방지하기 위해 매 테스트 전에 DB의 데이터를 모두 지우고 테스트한다.
- E2E 테스트들이 서로 영향을 끼치지 않고 독립적으로 테스트 가능하게 만든다.
    - 테스트들을 병렬적으로 실행할 경우 테스트끼리 영향을 줄 수 있다.(데이터 초기화) 그렇기 때문에 테스트를 동기적으로 실행한다.