### PR TITLE
feat: 회원의 공개된 정보를 반환하는 /api/member API 구현

### DIFF
--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -13,7 +13,7 @@ import { CookieOptions, Response, Request } from 'express';
 import { GithubAuthenticationRequestDto } from './dto/GithubAuthenticationRequest.dto';
 import { GithubSignupRequestDto } from './dto/GithubSignupRequest.dto';
 
-interface CustomHeaders {
+export interface CustomHeaders {
   authorization: string;
 }
 

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -4,7 +4,10 @@ import {
   Query,
   BadRequestException,
   InternalServerErrorException,
+  Req,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { CustomHeaders } from 'src/auth/controller/auth.controller';
 import { MemberService } from '../service/member.service';
 
 @Controller('member')
@@ -12,13 +15,33 @@ export class MemberController {
   constructor(private readonly memberService: MemberService) {}
   @Get('/availability')
   async availabilityUsername(@Query('username') username: string) {
-    if (!username) throw new BadRequestException('username is missing')
+    if (!username) throw new BadRequestException('username is missing');
     try {
       await this.memberService.validateUsername(username);
       return { available: true };
     } catch (err) {
       if (err.message === 'duplicate username')
         return { available: false, message: err.message };
+      throw new InternalServerErrorException(err.message);
+    }
+  }
+  @Get('/')
+  async getMember(@Req() request: Request & { headers: CustomHeaders }) {
+    const authHeader = request.headers.authorization;
+    if (!authHeader) {
+      throw new UnauthorizedException('Authorization header is missing');
+    }
+    const [bearer, accessToken] = authHeader.split(' ');
+    if (bearer !== 'Bearer' || !accessToken) {
+      throw new UnauthorizedException('Invalid authorization header format');
+    }
+    try {
+      const { username, githubImageUrl } =
+        await this.memberService.getMemberPublicInfo(accessToken);
+      return { username, imageUrl: githubImageUrl };
+    } catch (err) {
+      if (err.message === 'Failed to verify token')
+        throw new UnauthorizedException('Expired:accessToken');
       throw new InternalServerErrorException(err.message);
     }
   }

--- a/backend/src/member/member.module.ts
+++ b/backend/src/member/member.module.ts
@@ -4,9 +4,10 @@ import { Member } from './entity/member.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MemberRepository } from './repository/member.repository';
 import { MemberController } from './controller/member.controller';
+import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Member])],
+  imports: [LesserJwtModule, TypeOrmModule.forFeature([Member])],
   providers: [MemberService, MemberRepository],
   exports: [MemberService],
   controllers: [MemberController],

--- a/backend/src/member/repository/member.repository.ts
+++ b/backend/src/member/repository/member.repository.ts
@@ -10,6 +10,10 @@ export class MemberRepository {
     private readonly memberRepository: Repository<Member>,
   ) {}
 
+  findById(id: number): Promise<Member> {
+    return this.memberRepository.findOneBy({ id });
+  }
+
   findByGithubId(githubId: number): Promise<Member> {
     return this.memberRepository.findOneBy({ github_id: githubId });
   }

--- a/backend/src/member/service/member.service.ts
+++ b/backend/src/member/service/member.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
 import { Member } from '../entity/member.entity';
 import { MemberRepository } from '../repository/member.repository';
 
 @Injectable()
 export class MemberService {
-  constructor(private readonly memberRepository: MemberRepository) {}
+  constructor(
+    private readonly memberRepository: MemberRepository,
+    private readonly lesserJwtService: LesserJwtService,
+  ) {}
   findByGithubId(githubId: number): Promise<Member> {
     return this.memberRepository.findByGithubId(githubId);
   }
@@ -33,5 +37,19 @@ export class MemberService {
   async validateUsername(username: string): Promise<void> {
     const member = await this.memberRepository.findByUsername(username);
     if (member !== null) throw new Error('duplicate username');
+  }
+
+  async getMemberPublicInfo(
+    accessToken: string,
+  ): Promise<{ username: string; githubImageUrl: string }> {
+    const {
+      sub: { id },
+    } = await this.lesserJwtService.getPayload(accessToken, 'access');
+    const member = await this.memberRepository.findById(id);
+    if (!member) throw new Error('assert: member must be found from database');
+    return {
+      username: member.username,
+      githubImageUrl: member.github_image_url,
+    };
   }
 }

--- a/backend/test/auth/github-authentication.e2e-spec.ts
+++ b/backend/test/auth/github-authentication.e2e-spec.ts
@@ -3,7 +3,8 @@ import {
   app,
   githubApiService,
   jwtTokenPattern,
-  saveMemberToDatabase,
+  createMember,
+  memberFixture,
 } from 'test/setup';
 
 describe('POST /api/auth/github/authentication', () => {
@@ -17,7 +18,7 @@ describe('POST /api/auth/github/authentication', () => {
   });
 
   it('should return 201', async () => {
-    await saveMemberToDatabase();
+    await createMember(memberFixture);
     const response = await request(app.getHttpServer())
       .post('/api/auth/github/authentication')
       .send({ authCode: 'authCode' });

--- a/backend/test/member/get-member.e2e-spec.ts
+++ b/backend/test/member/get-member.e2e-spec.ts
@@ -1,0 +1,40 @@
+import * as request from 'supertest';
+import { app, githubApiService, createMember, memberFixture } from 'test/setup';
+
+describe('GET /api/member', () => {
+  it('should return 200', async () => {
+    const { accessToken, member } = await createMember(memberFixture);
+    const response = await request(app.getHttpServer())
+      .get('/api/member')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe(member.username);
+    expect(response.body.imageUrl).toBe(member.github_image_url);
+  });
+
+  it('should return 401 (Authorization header is missing)', async () => {
+    const response = await request(app.getHttpServer()).get('/api/member');
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Authorization header is missing');
+  });
+
+  it('should return 401 (Invalid authorization header format)', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/member')
+      .set('Authorization', `accessToken`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid authorization header format');
+  });
+
+  it('should return 401 Expired:accessToken', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/member')
+      .set('Authorization', `Bearer accessToken`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:accessToken');
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[회원의 공개 정보를 응답하는 API 구현(백엔드)](https://plastic-toad-cb0.notion.site/c71cd40eb7234c549a9673bca3de1be2?pvs=74)

## ✅ 작업 내용

[test: GET /api/member API에 대한 E2E 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/d1cca18420795a7aef905c54d6ca2339185ca023)
[feat: 회원 정보 가져오는 컨트롤러 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/f36006e5804258fb50f5d5691afbc336d8819b77)
[feat: 엑세스토큰으로 회원의 공개된 정보를 반환하는 서비스 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/d8fc96a96f906099f0f6a71367baa26b6f5c2c2a)

## 🖊️ 구체적인 작업

### GET /api/member API에 대한 E2E 테스트 작성
- 유효한 엑세스 토큰일때 회원의 username과 imageUrl을 반환
- authorization 헤더가 없을때 401에러를 반환
- authorization 헤더의 포맷이 적절하지 않을때 401에러를 반환
- 엑세스토큰의 유효하지 않을때 401에러를 반환

### 회원 정보 가져오는 컨트롤러 로직 구현
- 엑세스토큰이 유효할때 회원정보를 가져와 반환
- 헤더의 포맷이 유효하지 않으면 401에러 반환

### 엑세스토큰으로 회원의 공개된 정보를 반환하는 서비스 구현
- id를 통해 회원의 정보를 조회하는 레포지토리 구현
- 엑세스토큰의 id로 회원의 정보를 조회해 공개된 정보를 반환하는 서비스 구현

## 🤔 고민 및 의논할 거리
- 레포지토리의 findByID에서 조회에 실패할 경우 null이 나옵니다. 
- 하지만 id를 유효한 JWT토큰에서 뽑아냈기 때문에 논리적으로는 항상 성공합니다. 
- assert라고 생각한 상황에 대해 `assert:문제상황`으로 로깅해 관리하기로 결정했습니다.
[assert에 대한 고민](https://plastic-toad-cb0.notion.site/assert-55e2cec65a534e1cb50fb7e26f750648)

## 📸 결과 화면(선택)