### PR TITLE
feat: 로그인 상황에서 Authentication API가 액세스 토큰과 함께 회원의 공개 정보를 반환하도록 구현

### DIFF
--- a/backend/test/auth/github-authentication.e2e-spec.ts
+++ b/backend/test/auth/github-authentication.e2e-spec.ts
@@ -8,6 +8,25 @@ import {
 } from 'test/setup';
 
 describe('POST /api/auth/github/authentication', () => {
+  it('should return 201', async () => {
+    const { member } = await createMember(memberFixture);
+    
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/authentication')
+      .send({ authCode: 'authCode' });
+
+    expect(response.status).toBe(201);
+    expect(response.body.accessToken).toMatch(jwtTokenPattern);
+    expect(response.body.member).toEqual({
+      username: member.username,
+      imageUrl: member.github_image_url,
+    });
+    const [cookie] = response.headers['set-cookie'];
+    expect(cookie).toBeDefined();
+    const [, refreshToken] = cookie.match(/refreshToken=([^;]+)/);
+    expect(refreshToken).toMatch(jwtTokenPattern);
+  });
+
   it('should return 209', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/auth/github/authentication')
@@ -15,16 +34,6 @@ describe('POST /api/auth/github/authentication', () => {
 
     expect(response.status).toBe(209);
     expect(response.body.tempIdToken).toMatch(jwtTokenPattern);
-  });
-
-  it('should return 201', async () => {
-    await createMember(memberFixture);
-    const response = await request(app.getHttpServer())
-      .post('/api/auth/github/authentication')
-      .send({ authCode: 'authCode' });
-
-    expect(response.status).toBe(201);
-    expect(response.body.accessToken).toMatch(jwtTokenPattern);
   });
 
   it('should return 400', async () => {


### PR DESCRIPTION
## 🎟️ 태스크

- [로그인 상황에서 Authentication API가 액세스 토큰과 함께 회원의 공개 정보를 반환하도록 구현(백엔드)](https://plastic-toad-cb0.notion.site/Authentication-API-0355d7a665b44abd934c0d2811316b25)

## ✅ 작업 내용

- [POST /api/auth/github/authentication에 대한 e2e 테스트 추가](https://github.com/boostcampwm2023/web10-Lesser/commit/7f4446a40d2ecf2e4aba6a4e96370cb1a361b1b5)
- [e2e 테스트 추가된 컨트롤러에 대하여 단위 테스트 삭제](https://github.com/boostcampwm2023/web10-Lesser/commit/f51bc7145cd2c8d85348bb8bd52057dfaac637a9)
- [회원인 사용자가 인증하는 경우 회원의 공개 정보를 body에 반환하는 기능 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/f765c91eae9c24b6c9c0c4f576f324daa6e7eb93)

## 🖊️ 구체적인 작업

### POST /api/auth/github/authentication에 대한 e2e 테스트 추가
- response body가 회원의 공개 정보를 포함하는지 테스트
- response cookie가 refreshToken을 포함하는지 테스트
- refreshToken 값이 jwt 패턴에 매치되는지 테스트
### e2e 테스트 추가된 컨트롤러에 대하여 단위 테스트 삭제
- 컨트롤러에 대한 단위 테스트는 e2e 테스트 추가에 따라 deprecate 하기로 결정
- 컨트롤러는 API 명세와 일치한 응답을 반환하는지 테스트하는 것이 중요한데 이는 e2e 테스트를 통해 테스트할 수 있음
- 컨트롤러에 대한 단위 테스트는 e2e 테스트와 많은 중복이 발생하므로 e2e 테스트로 갈음
### 회원인 사용자가 인증하는 경우 회원의 공개 정보를 body에 반환하는 기능 구현
- 기존에 response body에 access token만 반환하던 것에 더하여 username, imageUrl을 포함하는 회원 정보를 추가로 담아서 반환

## 🤔 고민 및 의논할 거리
- authService의 githubAuthentication 함수를 통해 회원가입 여부에 따라 액세스 토큰과 리프레시 토큰을 받아오거나, 임시회원 가입을 위한 토큰을 받아옵니다. 반환 받은 타입에 따라 컨트롤러에서 다른 로직을 실행하고 싶은데 타입 검사 로직을 isMember라는 함수로 분리하고자 하였던 과정을 [개발일지](https://plastic-toad-cb0.notion.site/isMember-0bab639ec4c64706837a9bb400f6412b)에 기록했습니다.