### PR TITLE
[feat] error boundary 적용하기

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-router-dom": "^6.22.1",
     "reusify": "^1.0.4"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
 import { ModalProvider } from "./hooks/common/modal/ModalProvider";
 import AppRouter from "./AppRouter";
+import GlobalErrorBoundary from "./GlobalErrorBoundary";
 
 const App = () => {
   return (
-    <ModalProvider>
-      <AppRouter />
-    </ModalProvider>
+    <GlobalErrorBoundary>
+      <ModalProvider>
+        <AppRouter />
+      </ModalProvider>
+    </GlobalErrorBoundary>
   );
 };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,11 @@
 import { ModalProvider } from "./hooks/common/modal/ModalProvider";
 import AppRouter from "./AppRouter";
-import GlobalErrorBoundary from "./GlobalErrorBoundary";
 
 const App = () => {
   return (
-    <GlobalErrorBoundary>
-      <ModalProvider>
-        <AppRouter />
-      </ModalProvider>
-    </GlobalErrorBoundary>
+    <ModalProvider>
+      <AppRouter />
+    </ModalProvider>
   );
 };
 

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -1,28 +1,44 @@
-import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { Outlet, RouterProvider, createBrowserRouter } from "react-router-dom";
 import { LoginPage, SignupPage, AuthPage, TempHomepage } from "./pages";
 import { ROUTER_URL } from "./constants/path";
 import ProjectsPage from "./pages/projects/ProjectsPage";
+import ErrorThrowPage from "./pages/ErrorThrowPage";
+import GlobalErrorBoundary from "./GlobalErrorBoundary";
 
 const router = createBrowserRouter([
   {
-    path: ROUTER_URL.TEMP,
-    element: <TempHomepage />,
-  },
-  {
-    path: ROUTER_URL.LOGIN,
-    element: <LoginPage />,
-  },
-  {
-    path: ROUTER_URL.SIGNUP,
-    element: <SignupPage />,
-  },
-  {
-    path: ROUTER_URL.AUTH,
-    element: <AuthPage />,
-  },
-  {
-    path: ROUTER_URL.PROJECTS,
-    element: <ProjectsPage />,
+    path: ROUTER_URL.ROOT,
+    element: (
+      <GlobalErrorBoundary>
+        <Outlet />
+      </GlobalErrorBoundary>
+    ),
+    children: [
+      {
+        index: true,
+        element: <TempHomepage />,
+      },
+      {
+        path: ROUTER_URL.LOGIN,
+        element: <LoginPage />,
+      },
+      {
+        path: ROUTER_URL.SIGNUP,
+        element: <SignupPage />,
+      },
+      {
+        path: ROUTER_URL.AUTH,
+        element: <AuthPage />,
+      },
+      {
+        path: ROUTER_URL.PROJECTS,
+        element: <ProjectsPage />,
+      },
+      {
+        path: "/throw-error",
+        element: <ErrorThrowPage />,
+      },
+    ],
   },
 ]);
 

--- a/frontend/src/GlobalErrorBoundary.tsx
+++ b/frontend/src/GlobalErrorBoundary.tsx
@@ -6,7 +6,6 @@ const GlobalErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   return (
     <div>
       <ErrorPage {...{ error, resetErrorBoundary }} />
-      <button onClick={resetErrorBoundary}>Try again</button>
     </div>
   );
 };

--- a/frontend/src/GlobalErrorBoundary.tsx
+++ b/frontend/src/GlobalErrorBoundary.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from "react";
+import { ErrorBoundary, FallbackProps } from "react-error-boundary";
+import ErrorPage from "./pages/error/ErrorPage";
+
+const GlobalErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return (
+    <div>
+      <ErrorPage {...{ error, resetErrorBoundary }} />
+      <button onClick={resetErrorBoundary}>Try again</button>
+    </div>
+  );
+};
+
+const GlobalErrorBoundary: React.FC<PropsWithChildren> = ({ children }) => {
+  return <ErrorBoundary FallbackComponent={GlobalErrorFallback}>{children}</ErrorBoundary>;
+};
+
+export default GlobalErrorBoundary;

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -9,9 +9,11 @@ export const API_URL = {
 };
 
 export const ROUTER_URL = {
-  TEMP: "/",
+  ROOT: "/",
+  TEMP: "/temp",
   LOGIN: "/login",
   SIGNUP: "/signup",
   AUTH: "/auth/github/callback",
   PROJECTS: "/projects",
+  ERROR: "/error",
 };

--- a/frontend/src/pages/ErrorThrowPage.tsx
+++ b/frontend/src/pages/ErrorThrowPage.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+const ErrorThrowPage = () => {
+  useEffect(() => {
+    throw Error("임시 에러입니다!");
+  });
+
+  return (
+    <div>
+      <p>Error Throwing!</p>
+      <p>Error Page로 이동해야 합니다!</p>
+    </div>
+  );
+};
+
+export default ErrorThrowPage;

--- a/frontend/src/pages/TempHomepage.tsx
+++ b/frontend/src/pages/TempHomepage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import React from "react";
+import { ROUTER_URL } from "../constants/path";
 
 const TempHomepage = () => {
   console.log("실행중");
@@ -16,21 +17,21 @@ const TempHomepage = () => {
       </div>
       <ul>
         <li>
-          <Link to={"/login"} className="hover:underline">
+          <Link to={ROUTER_URL.LOGIN} className="hover:underline">
             Log in
           </Link>
         </li>
         <li>
-          <Link to={"/signup"} className="hover:underline">
+          <Link to={ROUTER_URL.SIGNUP} className="hover:underline">
             Sign up
           </Link>
         </li>
+        <li>
+          <Link to={"/throw-error"} className="hover:underline">
+            에러를 던져봅시다!
+          </Link>
+        </li>
       </ul>
-      <div className="w-screen border-4 border-black">
-        <p className="text-xl font-bold">Typing 애니메이션 테스트</p>
-        <p>애니메이션 문구 : abcdefg</p>
-        <p>테스트 결과 :</p>
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/error/ErrorPage.tsx
+++ b/frontend/src/pages/error/ErrorPage.tsx
@@ -1,0 +1,13 @@
+import { FallbackProps } from "react-error-boundary";
+
+const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return (
+    <div>
+      <p>Error 발생</p>
+      <p>error : {error.message}</p>
+      <button onClick={resetErrorBoundary}>Try again</button>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -2,3 +2,4 @@ export { default as TempHomepage } from "./TempHomepage";
 export { default as LoginPage } from "./login/LoginPage";
 export { default as SignupPage } from "./account/SignupPage";
 export { default as AuthPage } from "./login/AuthPage";
+export { default as ErrorPage } from "./error/ErrorPage";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4688,6 +4688,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.13.tgz#80386b7b27b1131c5fbb7368b8c0d983354c7947"
+  integrity sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"


### PR DESCRIPTION
## 🎟️ 태스크

[태스크 이름](해당 태스크 노션 링크)

## ✅ 작업 내용

- react-error-boundary 적용
- react-error-boundary가 에러를 잡아내지 못하는 문제 해결

## 🖊️ 구체적인 작업

### react-error-boundary 적용기
- 지난 버전1의 LESSER에는 에러를 잡아내는 기능이 전무했습니다. 그저 Auth가 있는지 확인하고 이를 직접 명령적 코드를 통해 redirect 시키는 코드가 전부였습니다. 이러한 형식의 문제점은, 우리의 프로젝트에 특정 문제가 발생했을 때 사용자에게 문제가 발생했다는 것을 알려주지 못하고, 동시에 에러사항의 화면을 그대로 보여준다는 점이었습니다. 사용자에게 네트워크 문제가 발생했다고 가정했을 경우, 사용자는 아무런 조치도 못한채 텅빈 화면만을 봐야 한다는 것이었습니다.
- 이러한 문제를 해결하기 위해, Error Boundary를 도입하기로 결정했습니다. Error Boundary는 몇가지 기능을 제공하지만 그중 핵심 기능은, 에러가 발생했을 경우 자동으로 우리가 커스텀한 에러 페이지를 화면에 대신 띄워줄 수 있다는 점입니다.
- 또 강력한 기능은, 에러 로깅을 위한 개발자 툴을 사용하기에 용이하다는 점입니다. Error Boundary의 prop중 onError에 sentry와 같은 에러 로그 툴을 호출할 수 있도록 기능이 설계되어 있어 추후 프로젝트의 운영 간 발생하는 사용자의 클라이언트 로그를 쉽게 확인하고 문제분석에 더 높은 효율성을 제공할 수 있을 것입니다.
- react-error-boundary를 화면에 적용한 후, 임시 화면에서 error를 일부러 던지는 화면으로 이동할 경우, 정상적으로 (임시로 작성한) 에러페이지가 뜨는 것을 확인할 수 있습니다.

### react-error-boundary에서 에러를 잡아내지 못하는 에러~

- react-error-boundary에서 우리가 설정한 Fallback 화면을 잡아내기 위해서는 throw로 에러를 던지는 것을 감지할 수 있는 위치에 두어야 합니다.
- 저는 App.tsx에서 제가 만든 Error Boundary를 설정했었습니다. 하지만 Error는 AppRouter 내에서만 throw 되었기 때문에, 제가 커스텀한 GlobalErrorBoundary에서는 해당 던진 에러를 인식할 수가 없었습니다.
```typescript
const App = () => {
  return (
    <GlobalErrorBoundary>
      <ModalProvider>
        <AppRouter />
      </ModalProvider>
    </GlobalErrorBoundary>
  );
};
```
- 그렇기 때문에 AppRouter의 내부 요소의 최외각에 ErrorBoundary를 감싸주는 방식으로 코드를 수정했고 정상적으로, 제가 작성한 에러 페이지가 뜨는 것을 확인했습니다.
```typescript
// createBrowserRouter 파라미터의 일부 요소
    path: ROUTER_URL.ROOT,
    element: (
      <GlobalErrorBoundary>
        <Outlet />
      </GlobalErrorBoundary>
    ),
...
```