### PR TITLE
feat: 프로젝트 목록 더미데이터 API 구현

### DIFF
--- a/backend/fixtures/project-fixtures.ts
+++ b/backend/fixtures/project-fixtures.ts
@@ -1,0 +1,56 @@
+export const projectFixtures = [
+  {
+    id: 1,
+    title: 'Lesser',
+    createdAt: '2024-03-01T12:00:00Z',
+    currentSprint: {
+      title: '스프린트 1',
+      startDate: '2024-03-14T12:00:00Z',
+      endDate: '2024-03-21T12:00:00Z',
+      progressPercentage: 80,
+      myTasksLeft: 5,
+    },
+  },
+  {
+    id: 2,
+    title: 'Chikorita',
+    createdAt: '2024-03-02T12:00:00Z',
+    currentSprint: null,
+  },
+  {
+    id: 3,
+    title: 'Charmander',
+    createdAt: '2024-03-03T12:00:00Z',
+    currentSprint: {
+      title: '스프린트 1',
+      startDate: '2024-03-14T12:00:00Z',
+      endDate: '2024-03-21T12:00:00Z',
+      progressPercentage: 100,
+      myTasksLeft: 0,
+    },
+  },
+  {
+    id: 4,
+    title: 'Bulbasaur',
+    createdAt: '2024-03-04T12:00:00Z',
+    currentSprint: {
+      title: '스프린트 1',
+      startDate: '2024-03-14T12:00:00Z',
+      endDate: '2024-03-21T12:00:00Z',
+      progressPercentage: 15,
+      myTasksLeft: 36,
+    },
+  },
+  {
+    id: 5,
+    title: 'Squirtle',
+    createdAt: '2024-03-05T12:00:00Z',
+    currentSprint: {
+      title: '스프린트 1',
+      startDate: '2024-03-14T12:00:00Z',
+      endDate: '2024-03-21T12:00:00Z',
+      progressPercentage: 0,
+      myTasksLeft: 17,
+    },
+  },
+];

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { TempMember } from './auth/entity/tempMember.entity';
 import { MemberModule } from './member/member.module';
 import { Member } from './member/entity/member.entity';
 import { LoginMember } from './auth/entity/loginMember.entity';
+import { ProjectModule } from './project/project.module';
 import * as cookieParser from 'cookie-parser';
 
 @Module({
@@ -40,6 +41,7 @@ import * as cookieParser from 'cookie-parser';
     GithubApiModule,
     LesserJwtModule,
     MemberModule,
+    ProjectModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  Get,
+  Req,
+  UnauthorizedException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { projectFixtures } from 'fixtures/project-fixtures';
+
+import { CustomHeaders } from 'src/auth/controller/auth.controller';
+import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
+
+@Controller('project')
+export class ProjectController {
+  constructor(private readonly lesserJwtService: LesserJwtService) {}
+  @Get('/')
+  async getProjectList(@Req() request: Request & { headers: CustomHeaders }) {
+    const authHeader = request.headers.authorization;
+    if (!authHeader) {
+      throw new UnauthorizedException('Authorization header is missing');
+    }
+    const [bearer, accessToken] = authHeader.split(' ');
+    if (bearer !== 'Bearer' || !accessToken) {
+      throw new UnauthorizedException('Invalid authorization header format');
+    }
+
+    try {
+      // access token 검증을 위한 임시 로직
+      await this.lesserJwtService.getPayload(accessToken, 'access');
+    } catch (err) {
+      if (err.message === 'Failed to verify token')
+        throw new UnauthorizedException('Expired:accessToken');
+      throw new InternalServerErrorException(err.message);
+    }
+    return { projects: projectFixtures };
+  }
+}

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProjectController } from './project.controller';
+import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
+
+@Module({
+  imports: [LesserJwtModule],
+  controllers: [ProjectController],
+})
+export class ProjectModule {}

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -8,7 +8,8 @@
   },
   "moduleNameMapper": {
     "^src/(.*)$": "<rootDir>/../src/$1",
-    "^test/(.*)$": "<rootDir>/../test/$1"
+    "^test/(.*)$": "<rootDir>/../test/$1",
+    "^fixtures/(.*)$": "<rootDir>/../fixtures/$1"
   },
   "setupFilesAfterEnv": ["<rootDir>/setup.ts"]
 }

--- a/backend/test/project/get-project.e2e-spec.ts
+++ b/backend/test/project/get-project.e2e-spec.ts
@@ -1,0 +1,41 @@
+import * as request from 'supertest';
+import { app, createMember, memberFixture } from 'test/setup';
+import { projectFixtures } from 'fixtures/project-fixtures';
+
+describe('GET /api/project', () => {
+  it('should return 200', async () => {
+    const { accessToken } = await createMember(memberFixture);
+
+    const response = await request(app.getHttpServer())
+      .get('/api/project')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.projects).toEqual(projectFixtures);
+  });
+
+  it('should return 401 (Authorization header is missing)', async () => {
+    const response = await request(app.getHttpServer()).get('/api/project');
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Authorization header is missing');
+  });
+
+  it('should return 401 (Invalid authorization header format)', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/project')
+      .set('Authorization', `accessToken`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid authorization header format');
+  });
+
+  it('should return 401 Expired:accessToken', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/project')
+      .set('Authorization', `Bearer accessToken`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:accessToken');
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[백엔드 프로젝트 목록 더미데이터 API 구현](https://plastic-toad-cb0.notion.site/API-ca349f4cdbfb47b9807679ad76165b72?pvs=74)

## ✅ 작업 내용
- [내 프로젝트 목록 요청시 더미데이터 반환하는 API에 대한 e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/e4977ec1137f40ef72cf60df54470e412b4b1317)
- [프로젝트 더미데이터 리스트를 반환하는 GET /api/project API 컨트롤러 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/c5e047b77e37f859aba5aa5f50885f973aa70f1f)
## 🖊️ 구체적인 작업

### 내 프로젝트 목록 요청시 더미데이터 반환하는 API에 대한 e2e 테스트 작성
- projectFixtures 생성
- GET /api/project 요청시 projectFixtures와 동일한 값을 반환하는지 테스트
- access token이 유효하지 않으면 401 에러 반환하는지 테스트

### 프로젝트 더미데이터 리스트를 반환하는 GET /api/project API 컨트롤러 구현
- 현재는 fixture에 있는 프로젝트 더미데이터를 그대로 반환
- 서비스 로직은 추후 개발 예정

## 🤔 고민 및 의논할 거리
    
- jest 테스트코드에서 객체를 비교할 때 toBe와 toEqual의 차이점에 대해 알아보았다.
- 개발일지: [객체를 toBe로 비교해도 될까?](https://plastic-toad-cb0.notion.site/toBe-91b21a6b1d2949669f753ae880f9b585)