### PR TITLE
test: auth API(회원가입, 리프레시, 로그아웃) e2e 테스트 작성

### DIFF
--- a/backend/test/auth/github-signup.e2e-spec.ts
+++ b/backend/test/auth/github-signup.e2e-spec.ts
@@ -1,0 +1,71 @@
+import * as request from 'supertest';
+import { app, jwtTokenPattern, memberFixture } from 'test/setup';
+
+describe('POST /api/auth/github/signup', () => {
+  const memberSignupPayload = {
+    username: memberFixture.username,
+    position: memberFixture.position,
+    techStack: memberFixture.tech_stack.stacks,
+  };
+  it('should return 201', async () => {
+    const authenticationResponse = await request(app.getHttpServer())
+      .post('/api/auth/github/authentication')
+      .send({ authCode: 'authCode' });
+
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/signup')
+      .set('Authorization', `Bearer ${authenticationResponse.body.tempIdToken}`)
+      .send(memberSignupPayload);
+
+    expect(response.status).toBe(201);
+    expect(response.body.accessToken).toMatch(jwtTokenPattern);
+    // 추후 적용
+    // expect(response.body.member).toEqual({
+    //   username: memberFixture.username,
+    //   imageUrl: memberFixture.github_image_url,
+    // });
+    const [cookie] = response.headers['set-cookie'];
+    expect(cookie).toBeDefined();
+    const [, refreshToken] = cookie.match(/refreshToken=([^;]+)/);
+    expect(refreshToken).toMatch(jwtTokenPattern);
+  });
+
+  it('should return 400', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/signup')
+      .send({
+        invalidProperty: 'invalidProperty',
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 401 (Authorization header is missing)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/signup')
+      .send(memberSignupPayload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Authorization header is missing');
+  });
+
+  it('should return 401 (Invalid authorization header format)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/signup')
+      .set('Authorization', `No Bearer tempIdToken`)
+      .send(memberSignupPayload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid authorization header format');
+  });
+
+  it('should return 401 (Expired:tempIdToken)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/signup')
+      .set('Authorization', `Bearer invalidToken`)
+      .send(memberSignupPayload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:tempIdToken');
+  });
+});

--- a/backend/test/auth/logout.e2e-spec.ts
+++ b/backend/test/auth/logout.e2e-spec.ts
@@ -11,6 +11,13 @@ describe('POST /api/auth/logout', () => {
       .send();
 
     expect(response.status).toBe(200);
+
+    const [cookie] = response.headers['set-cookie'];
+    expect(cookie).toBeDefined();
+    expect(cookie.includes('refreshToken=;')).toBeTruthy();
+    expect(
+      cookie.includes('Expires=Thu, 01 Jan 1970 00:00:00 GMT;'),
+    ).toBeTruthy();
   });
 
   it('should return 401 (Not a logged in member)', async () => {

--- a/backend/test/auth/logout.e2e-spec.ts
+++ b/backend/test/auth/logout.e2e-spec.ts
@@ -1,0 +1,59 @@
+import * as request from 'supertest';
+import { app, createMember, memberFixture } from 'test/setup';
+
+describe('POST /api/auth/logout', () => {
+  it('should return 200', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send();
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should return 401 (Not a logged in member)', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+
+    let response;
+    for (let i = 0; i < 2; i++) {
+      response = await request(app.getHttpServer())
+        .post('/api/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send();
+    }
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Not a logged in member');
+  });
+
+  it('should return 401 (Authorization header is missing)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/logout')
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Authorization header is missing');
+  });
+
+  it('should return 401 (Invalid authorization header format)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/logout')
+      .set('Authorization', `accessToken`)
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid authorization header format');
+  });
+
+  it('should return 401 (Expired:accessToken)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer invalidToken`)
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:accessToken');
+  });
+});

--- a/backend/test/auth/refresh.e2e-spec.ts
+++ b/backend/test/auth/refresh.e2e-spec.ts
@@ -1,0 +1,61 @@
+import * as request from 'supertest';
+import { app, createMember, jwtTokenPattern, memberFixture } from 'test/setup';
+
+describe('POST /api/auth/refresh', () => {
+  it('should return 201', async () => {
+    const { refreshToken: oldRefreshToken } = await createMember(
+      memberFixture,
+      app,
+    );
+
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${oldRefreshToken}`)
+      .send();
+
+    expect(response.status).toBe(201);
+    expect(response.body.accessToken).toMatch(jwtTokenPattern);
+    const [cookie] = response.headers['set-cookie'];
+    expect(cookie).toBeDefined();
+    const [, refreshToken] = cookie.match(/refreshToken=([^;]+)/);
+    expect(refreshToken).toMatch(jwtTokenPattern);
+  });
+
+  it('should return 401 (Refresh Token is missing)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/refresh')
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Refresh Token is missing');
+  });
+
+  it('should return 401 (Expired:refreshToken) when already logout member', async () => {
+    const { accessToken, refreshToken } = await createMember(
+      memberFixture,
+      app,
+    );
+    await request(app.getHttpServer())
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send();
+
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${refreshToken}`)
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:refreshToken');
+  });
+
+  it('should return 401 (Expired:refreshToken) when invalid refresh token', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=invalidAccessToken`)
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:refreshToken');
+  });
+});

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -1,13 +1,10 @@
 import * as request from 'supertest';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from 'src/app.module';
 import { GithubApiService } from 'src/github-api/github-api.service';
 import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
-import { Member } from 'src/member/entity/member.entity';
 import { DataSource } from 'typeorm';
-import { response } from 'express';
 
 export let app: INestApplication;
 export let githubApiService: GithubApiService;


### PR DESCRIPTION
## 🎟️ 태스크

- [(POST) /api/auth/github/signup](https://plastic-toad-cb0.notion.site/POST-api-auth-github-signup-2822735b13424dd084446bac58463580?pvs=74)
- [(POST) /api/auth/logout](https://plastic-toad-cb0.notion.site/POST-api-auth-logout-a11f434485e5416abe3ceb7d5e77ca0a?pvs=74)
- [(POST) /api/auth/refresh](https://plastic-toad-cb0.notion.site/POST-api-auth-refresh-8b0d01b9b79044b4b36baa1c71557dea?pvs=74)

## ✅ 작업 내용

- [POST /api/auth/logout 에 대한 e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/90c4167fe8675fef1c614a1f18f811f7f9afa6c5)
- [POST /api/auth/github/signup 에 대한 e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/9b3c15c9f4c3cdd6616c025d99cda4f98b3a59a6)
- [POST /api/auth/refresh 에 대한 e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/05388f663212c5674d353595ff57d3fd4fd6ee5b)

## 🖊️ 구체적인 작업

### POST /api/auth/logout 에 대한 e2e 테스트 작성
- 유효한 엑세스 토큰일때 성공적으로 로그아웃
- 이미 로그아웃한 회원이 다시 로그아웃 할 경우 401에러를 반환
- authorization 헤더가 없을때 401에러를 반환
- authorization 헤더의 포맷이 적절하지 않을때 401에러를 반환
- 엑세스토큰의 유효하지 않을때 401에러를 반환

### POST /api/auth/github/signup 에 대한 e2e 테스트 작성
- 유효한 tempId토큰이고 body의 데이터 형식이 적절할때 성공적으로 회원가입
- body의 데이터 형식이 적절하지 않을때 400에러를 반환
- authorization 헤더가 없을때 401에러를 반환
- authorization 헤더의 포맷이 적절하지 않을때 401에러를 반환
- tempId토큰이 유효하지 않을때 401에러를 반환

### POST /api/auth/refresh 에 대한 e2e 테스트 작성
- 유효한 refresh 토큰일때 성공적으로 새로운 refresh 토큰, access토큰 반환
- authorization 헤더가 없을때 401에러를 반환
- 이미 로그아웃 한 회원이 호출했을때 401에러를 반환
- refresh 토큰의 유효하지 않을때 401에러를 반환

## 🤔 고민 및 의논할 거리
- 회원가입 성공 테스트에서 주석을 쳐놓은 부분이 있습니다. 이 부분에 대해 설명 해드리겠습니다.
- 회원가입 API 에서 성공시 응답으로 멤버의 공개된 정보를 줘야하는데 아직 구현이 안되어있어 e2e테스트에서도 테스트를 하지 않았습니다. 이 부분을 잊어버릴 수 있을것같아 주석을 쳐놓았습니다.
  - 구현하는 작업이 백로그에 있으니까, 구현할때 e2e 테스트에서 주석을 해제해 사용하면 편할것같습니다~
  ```ts
  it('should return 201', async () => {
    const authenticationResponse = await request(app.getHttpServer())
      .post('/api/auth/github/authentication')
      .send({ authCode: 'authCode' });

    const response = await request(app.getHttpServer())
      .post('/api/auth/github/signup')
      .set('Authorization', `Bearer ${authenticationResponse.body.tempIdToken}`)
      .send(memberSignupPayload);

    expect(response.status).toBe(201);
    expect(response.body.accessToken).toMatch(jwtTokenPattern);
    // 추후 적용
    // expect(response.body.member).toEqual({
    //   username: memberFixture.username,
    //   imageUrl: memberFixture.github_image_url,
    // });
    const [cookie] = response.headers['set-cookie'];
    expect(cookie).toBeDefined();
    const [, refreshToken] = cookie.match(/refreshToken=([^;]+)/);
    expect(refreshToken).toMatch(jwtTokenPattern);
  });
  ```