### PR TITLE
test: 깃허브 유저네임 API, 닉네임 사용 가능 여부 확인 API에 대한 e2e 테스트

### DIFF
--- a/backend/src/member/controller/member.controller.spec.ts
+++ b/backend/src/member/controller/member.controller.spec.ts
@@ -31,7 +31,7 @@ describe('MemberController', () => {
     const username = 'username';
     it('should return true when valid username', async () => {
       const controllerResponse =
-        await memberController.availabilityUsername(username);
+        await memberController.getUsernameAvailability(username);
 
       expect(memberService.validateUsername).toHaveBeenCalledWith(username);
       expect(controllerResponse.available).toBe(true);
@@ -43,7 +43,7 @@ describe('MemberController', () => {
         .mockRejectedValue(new Error('duplicate username'));
 
       const controllerResponse =
-        await memberController.availabilityUsername(username);
+        await memberController.getUsernameAvailability(username);
 
       expect(memberService.validateUsername).toHaveBeenCalledWith(username);
       expect(controllerResponse.available).toBe(false);
@@ -52,13 +52,13 @@ describe('MemberController', () => {
 
     it('should throw 400 error when username is missing', async () => {
       expect(
-        async () => await memberController.availabilityUsername(''),
+        async () => await memberController.getUsernameAvailability(''),
       ).rejects.toThrow(new BadRequestException('username is missing'));
       expect(
-        async () => await memberController.availabilityUsername(undefined),
+        async () => await memberController.getUsernameAvailability(undefined),
       ).rejects.toThrow(new BadRequestException('username is missing'));
       expect(
-        async () => await memberController.availabilityUsername(null),
+        async () => await memberController.getUsernameAvailability(null),
       ).rejects.toThrow(new BadRequestException('username is missing'));
     });
 
@@ -68,7 +68,7 @@ describe('MemberController', () => {
         .mockRejectedValue(new Error());
 
       expect(
-        async () => await memberController.availabilityUsername(username),
+        async () => await memberController.getUsernameAvailability(username),
       ).rejects.toThrow(InternalServerErrorException);
     });
   });

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -14,7 +14,7 @@ import { MemberService } from '../service/member.service';
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
   @Get('/availability')
-  async availabilityUsername(@Query('username') username: string) {
+  async getUsernameAvailability(@Query('username') username: string) {
     if (!username) throw new BadRequestException('username is missing');
     try {
       await this.memberService.validateUsername(username);

--- a/backend/test/auth/get-github-username.e2e-spec.ts
+++ b/backend/test/auth/get-github-username.e2e-spec.ts
@@ -1,0 +1,45 @@
+import * as request from 'supertest';
+import { app, githubUserFixture } from 'test/setup';
+
+describe('GET /api/auth/github/username', () => {
+  it('should return 200 when given valid tempIdToken', async () => {
+    const authenticationResponse = await request(app.getHttpServer())
+      .post('/api/auth/github/authentication')
+      .send({ authCode: 'authCode' });
+    const tempIdToken = authenticationResponse.body.tempIdToken;
+
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/github/username')
+      .set('Authorization', `Bearer ${tempIdToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.githubUsername).toBe(githubUserFixture.login);
+  });
+
+  it('should return 401 (Authorization header is missing)', async () => {
+    const response = await request(app.getHttpServer()).get(
+      '/api/auth/github/username',
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Authorization header is missing');
+  });
+
+  it('should return 401 (Invalid authorization header format)', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/github/username')
+      .set('Authorization', 'accessToken');
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid authorization header format');
+  });
+
+  it('should return 401 (Expired:tempIdToken)', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/github/username')
+      .set('Authorization', 'Bearer tempIdToken');
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:tempIdToken');
+  });
+});

--- a/backend/test/member/get-member.e2e-spec.ts
+++ b/backend/test/member/get-member.e2e-spec.ts
@@ -23,16 +23,16 @@ describe('GET /api/member', () => {
   it('should return 401 (Invalid authorization header format)', async () => {
     const response = await request(app.getHttpServer())
       .get('/api/member')
-      .set('Authorization', `accessToken`);
+      .set('Authorization', 'accessToken');
 
     expect(response.status).toBe(401);
     expect(response.body.message).toBe('Invalid authorization header format');
   });
 
-  it('should return 401 Expired:accessToken', async () => {
+  it('should return 401 (Expired:accessToken)', async () => {
     const response = await request(app.getHttpServer())
       .get('/api/member')
-      .set('Authorization', `Bearer accessToken`);
+      .set('Authorization', 'Bearer accessToken');
 
     expect(response.status).toBe(401);
     expect(response.body.message).toBe('Expired:accessToken');

--- a/backend/test/member/get-username-availability.e2e-spec.ts
+++ b/backend/test/member/get-username-availability.e2e-spec.ts
@@ -1,0 +1,32 @@
+import * as request from 'supertest';
+import { app, createMember, memberFixture } from 'test/setup';
+
+describe('GET /api/member/availability', () => {
+  it('should return 200 { available: true } when input username is available', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/member/availability')
+      .query({ username: 'availableUsername' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.available).toBe(true);
+  });
+
+  it('should return 200 { available: false } when input username is not available', async () => {
+    await createMember(memberFixture, app);
+
+    const response = await request(app.getHttpServer())
+      .get('/api/member/availability')
+      .query({ username: memberFixture.username });
+
+    expect(response.status).toBe(200);
+    expect(response.body.available).toBe(false);
+  });
+
+  it('should throw 400 when given bad request', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/member/availability')
+      .query({});
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -25,6 +25,12 @@ export const memberFixture = {
   tech_stack: { stacks: ['js', 'ts'] },
 };
 
+export const githubUserFixture = {
+  id: '123',
+  login: 'username',
+  avatar_url: 'avatar_url',
+};
+
 export const createMember = async (newMember, app: INestApplication) => {
   const authenticationResponse = await request(app.getHttpServer())
     .post('/api/auth/github/authentication')
@@ -51,11 +57,7 @@ beforeAll(async () => {
       fetchAccessToken: jest
         .fn()
         .mockResolvedValue({ access_token: 'github.access.token' }),
-      fetchGithubUser: jest.fn().mockResolvedValue({
-        id: '123',
-        login: 'username',
-        avatar_url: 'avatar_url',
-      }),
+      fetchGithubUser: jest.fn().mockResolvedValue(githubUserFixture),
     })
     .compile();
   githubApiService = moduleFixture.get<GithubApiService>(GithubApiService);


### PR DESCRIPTION
## 🎟️ 태스크
- [(GET) /api/auth/github/username](https://plastic-toad-cb0.notion.site/GET-api-auth-github-username-6caf5cb8dffe4820a154fb34c1a12ee7?pvs=74)
- [(GET) /api/member/availability?username={닉네임}](https://plastic-toad-cb0.notion.site/GET-api-member-availability-username-24ba2aaac792451d81a25ad37867f684?pvs=74)

## ✅ 작업 내용

- [임시회원의 깃허브 유저네임을 반환하는 API에 대한 e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/b294e14408ccf389261ac31b6f7143c5034227ec)
- [닉네임 사용 가능 여부 확인 API에 대한 e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/77dfa62af79ca280e1ab8c863732090535860beb)

## 🖊️ 구체적인 작업

### 임시회원의 깃허브 유저네임을 반환하는 API에 대한 e2e 테스트 작성

- e2e 테스트의 setup.ts에 githubUserFixture 추가했습니다.
- 테스트 목록
  - GET /api/auth/github/username 요청시 githubFixture의 유저네임과 동일한 값을 반환하는지 테스트
  - authorization 헤더가 없을때 401 에러 반환
  - authorization 헤더의 포맷이 적절하지 않을때 401 에러 반환
  - tempIdToken이 유효하지 않을때 401 에러 반환

### 닉네임 사용 가능 여부 확인 API에 대한 e2e 테스트 작성
- 닉네임 사용 가능 여부 확인하는 컨트롤러 함수명을 `availabilityUsername` -> `getUsernameAvailability`로 변경하였습니다. 다른 함수명과의 통일성을 고려했습니다.
- 테스트 목록
  - 요청한 닉네임이 사용 가능하면 body의 available 속성을 true로 반환
  - 요청한 닉네임이 이미 사용중인 닉네임이면 body의 available 속성을 false로 반환
  - 요청 형식이 잘못됐으면 400 반환