### PR TITLE
feat: 프로젝트 목록 페이지 구현

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -3,4 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   setupFilesAfterEnv: ["<rootDir>/src/setupTest.ts"],
+  transform: {
+    "^.+\\.svg$": "<rootDir>/svgTransformer.cjs",
+  },
 };

--- a/frontend/src/apis/api/loginAPI.ts
+++ b/frontend/src/apis/api/loginAPI.ts
@@ -7,16 +7,20 @@ import {
   TempIdTokenResponse,
 } from "../../types/authDTO";
 import { useNavigate } from "react-router-dom";
-import { setAccessToken } from "../utils/authAPI";
+import { authAPI, setAccessToken } from "../utils/authAPI";
 
 export const getLoginURL = async () => {
-  const response = await baseAPI.get<GithubOauthUrlDTO>(API_URL.GITHUB_OAUTH_URL);
+  const response = await baseAPI.get<GithubOauthUrlDTO>(
+    API_URL.GITHUB_OAUTH_URL
+  );
   return response.data.authUrl;
 };
 
 export const postAuthCode = async (authCode: string) => {
   const navigate = useNavigate();
-  const response = await baseAPI.post<AuthenticationDTO>(API_URL.AUTH, { authCode });
+  const response = await baseAPI.post<AuthenticationDTO>(API_URL.AUTH, {
+    authCode,
+  });
   if (response.status === 201) {
     const body = response.data as AccessTokenResponse;
     setAccessToken(body.accessToken);
@@ -27,5 +31,14 @@ export const postAuthCode = async (authCode: string) => {
     const body = response.data as TempIdTokenResponse;
     navigate(ROUTER_URL.SIGNUP, { state: { tempIdToken: body.tempIdToken } });
     return;
+  }
+};
+
+export const postLogout = async () => {
+  const response = await authAPI.post(API_URL.LOG_OUT);
+
+  if (response.status === 200) {
+    setAccessToken(undefined);
+    return response;
   }
 };

--- a/frontend/src/apis/api/projectAPI.ts
+++ b/frontend/src/apis/api/projectAPI.ts
@@ -1,0 +1,10 @@
+import { API_URL } from "../../constants/path";
+import { authAPI } from "../utils/authAPI";
+
+export const getProjects = async () => {
+  const response = await authAPI.get(API_URL.PROJECT);
+
+  if (response.status === 200) {
+    return response.data.projects;
+  }
+};

--- a/frontend/src/apis/api/signupAPI.ts
+++ b/frontend/src/apis/api/signupAPI.ts
@@ -1,5 +1,4 @@
-import axios from "axios";
-import { API_URL, BASE_URL } from "../../constants/path";
+import { API_URL } from "../../constants/path";
 import { baseAPI } from "../utils";
 import { SignupDTO } from "../../types/authDTO";
 import { setAccessToken } from "../utils/authAPI";
@@ -9,7 +8,8 @@ interface SignupParams extends SignupDTO {
 }
 
 export const getNicknameAvailability = async (nickname: string) => {
-  const response = await axios(BASE_URL + API_URL.NICKNAME_AVAILABLILITY, {
+  const response = await baseAPI.get(API_URL.NICKNAME_AVAILABLILITY, {
+    withCredentials: false,
     params: { username: nickname },
   });
   return response.data.available;

--- a/frontend/src/apis/utils/authAPI.ts
+++ b/frontend/src/apis/utils/authAPI.ts
@@ -4,7 +4,7 @@ import { AccessTokenResponse } from "../../types/authDTO";
 
 let accessToken: string | undefined;
 
-const setAccessToken = (newAccessToken: string) => {
+const setAccessToken = (newAccessToken: string | undefined) => {
   accessToken = newAccessToken;
 };
 

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,49 @@
+import { ProjectDTO } from "../../types/projectDTO";
+
+interface ProjectCardProps {
+  project: ProjectDTO;
+}
+
+const ProjectCard = ({ project }: ProjectCardProps) => {
+  const { title, currentSprint } = project;
+  return (
+    <div className="w-[21.25rem] p-9 bg-gradient-to-bl from-white-transparent to-90% bg-light-green shadow-box">
+      <p className="mb-[1.125rem] text-xl font-bold text-white">{title}</p>
+      <p className="mb-2.5 text-xs font-bold text-white">
+        {currentSprint && currentSprint.title}
+      </p>
+      <p className="text-xs text-white">
+        {currentSprint &&
+          `${currentSprint.startDate} - ${currentSprint.endDate}`}
+      </p>
+      <div className="flex items-center mt-[1.125rem] px-9 py-6 gap-12 bg-white">
+        {currentSprint ? (
+          <>
+            <div className="flex-col items-center gap-3 font-bold text-middle-green">
+              <p className="text-m">
+                <span className="text-[2.25rem]">
+                  {currentSprint.progressPercentage}
+                </span>{" "}
+                %
+              </p>
+              <p className="">진행률</p>
+            </div>
+            <div className="flex-col items-center gap-3 font-bold text-middle-green">
+              <p className="text-m">
+                <span className="text-[2.25rem]">
+                  {currentSprint.myTasksLeft}
+                </span>{" "}
+                건
+              </p>
+              <p className="">내 업무</p>
+            </div>
+          </>
+        ) : (
+          <p>진행중인 스프린트가 없습니다</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCard;

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { ProjectDTO } from "../../types/projectDTO";
+import formatDate from "../../utils/formatDate";
 
 interface ProjectCardProps {
   project: ProjectDTO;
@@ -9,14 +10,18 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
   return (
     <div className="w-[21.25rem] p-9 bg-gradient-to-bl from-white-transparent to-90% bg-light-green shadow-box">
       <p className="mb-[1.125rem] text-xl font-bold text-white">{title}</p>
-      <p className="mb-2.5 text-xs font-bold text-white">
-        {currentSprint && currentSprint.title}
-      </p>
-      <p className="text-xs text-white">
-        {currentSprint &&
-          `${currentSprint.startDate} - ${currentSprint.endDate}`}
-      </p>
-      <div className="flex items-center mt-[1.125rem] px-9 py-6 gap-12 bg-white">
+      <div className="h-[3.9rem]">
+        <p className="mb-2.5 text-xs font-bold text-white">
+          {currentSprint && currentSprint.title}
+        </p>
+        <p className="text-xs text-white">
+          {currentSprint &&
+            `${formatDate(currentSprint.startDate)} - ${formatDate(
+              currentSprint.endDate
+            )}`}
+        </p>
+      </div>
+      <div className="flex items-center min-h-[7.625rem] mt-[1.125rem] px-9 py-6 gap-12 bg-white">
         {currentSprint ? (
           <>
             <div className="flex-col items-center gap-3 font-bold text-middle-green">
@@ -39,7 +44,10 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
             </div>
           </>
         ) : (
-          <p>진행중인 스프린트가 없습니다</p>
+          <div className="flex-col items-center h-[4.875rem]">
+            <p>진행중인 스프린트가</p>
+            <p>없습니다</p>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -35,7 +35,7 @@ const ProjectList = () => {
       }
     };
 
-    return structuredClone(projects).sort(sortByOption).reverse();
+    return structuredClone(projects).sort(sortByOption);
   }, [projects, selectedOption]);
 
   useEffect(() => {
@@ -46,7 +46,7 @@ const ProjectList = () => {
   }, []);
 
   return (
-    <section className="w-[75rem] min-w-[46.1rem] min-h-[40.5rem]">
+    <section className="w-[720px] min-w-[46.1rem] min-h-[40.5rem]">
       <div className="flex justify-between mb-5 w-[100%]">
         <p className="font-bold text-m text-middle-green">| 프로젝트 목록</p>
         <div className="flex items-center gap-6">

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -9,28 +9,29 @@ import { getProjects } from "../../apis/api/projectAPI";
 const ProjectList = () => {
   const [projects, setProjects] = useState<ProjectDTO[]>([]);
   const { Dropdown, selectedOption } = useDropdown({
-    placeholder: "업데이트 순",
+    placeholder: "",
     options: PROJECT_LIST_OPTION,
+    defaultOption: PROJECT_LIST_OPTION[0],
   });
 
-  const projectList = useMemo<ProjectDTO[]>(
-    () =>
-      structuredClone(projects).sort((a, b) => {
-        if (selectedOption === PROJECT_LIST_OPTION[0]) {
-          const aStartDate = a.currentSprint
-            ? new Date(a.currentSprint?.startDate)
-            : new Date();
-          const bStartDate = b.currentSprint
-            ? new Date(b.currentSprint?.startDate)
-            : new Date();
+  const projectList = useMemo<ProjectDTO[]>(() => {
+    const sortByOption = (a: ProjectDTO, b: ProjectDTO) => {
+      if (selectedOption === PROJECT_LIST_OPTION[0]) {
+        const aStartDate = a.currentSprint
+          ? new Date(a.currentSprint?.startDate)
+          : new Date();
+        const bStartDate = b.currentSprint
+          ? new Date(b.currentSprint?.startDate)
+          : new Date();
 
-          return Number(aStartDate) - Number(bStartDate);
-        } else {
-          return Number(new Date(a.createdAt)) - Number(new Date(b.createdAt));
-        }
-      }),
-    [projects, selectedOption]
-  );
+        return Number(aStartDate) - Number(bStartDate);
+      } else {
+        return Number(new Date(a.createdAt)) - Number(new Date(b.createdAt));
+      }
+    };
+
+    return structuredClone(projects).sort(sortByOption);
+  }, [projects, selectedOption]);
 
   useEffect(() => {
     (async () => {
@@ -40,21 +41,25 @@ const ProjectList = () => {
   }, []);
 
   return (
-    <section className="w-[75rem] min-h-[40.5rem]">
-      <div className="flex justify-between">
+    <section className="w-[75rem] min-w-[46.1rem] min-h-[40.5rem]">
+      <div className="flex justify-between mb-5 w-[100%]">
         <p className="font-bold text-m text-middle-green">| 프로젝트 목록</p>
         <div className="flex items-center gap-6">
-          <Dropdown buttonClassName="flex items-center w-[10rem] h-[2.5rem] py-2 pl-9 text-white text-xs bg-middle-green pr-3 rounded-[0.375rem] shadow-box" />
+          <Dropdown
+            buttonClassName="flex justify-between items-center min-w-[11.625rem] h-[2.5rem] py-2 pl-9 text-white text-xs bg-middle-green pr-3 rounded-[0.375rem] shadow-box"
+            containerClassName="min-w-[11.625rem] overflow-y-auto shadow-box bg-white rounded-b-lg"
+            itemClassName="text-xs font-bold py-3 px-9 hover:bg-middle-green hover:text-white hover:font-bold"
+          />
           <button
             type="button"
-            className="flex items-center w-[10rem] h-[2.5rem] py-2 pl-3 pr-9 text-white text-xs bg-middle-green gap-3 rounded-[0.375rem] shadow-box"
+            className="flex items-center w-[10.45rem] h-[2.5rem] py-2 pl-3 pr-9 text-white text-xs bg-middle-green gap-3 rounded-[0.375rem] shadow-box"
           >
             <img src={plus} alt="더하기" className="w-7" />
             추가하기
           </button>
         </div>
       </div>
-      <div className="">
+      <div className="flex flex-wrap gap-10 w-[100%] max-h-[38.75rem] overflow-y-auto">
         {projectList.map((project: ProjectDTO) => (
           <ProjectCard key={project.id} project={project} />
         ))}

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -1,0 +1,58 @@
+import { useMemo, useState } from "react";
+import useDropdown from "../../hooks/common/dropdown/useDropdown";
+import { ProjectCard } from ".";
+import { PROJECT_LIST_OPTION } from "../../constants/projects";
+import plus from "../../assets/icons/plus.svg";
+import { ProjectDTO } from "../../types/projectDTO";
+
+const ProjectList = () => {
+  const [projects] = useState<ProjectDTO[]>([]);
+  const { Dropdown, selectedOption } = useDropdown({
+    placeholder: "업데이트 순",
+    options: PROJECT_LIST_OPTION,
+  });
+
+  const projectList = useMemo<ProjectDTO[]>(
+    () =>
+      structuredClone(projects).sort((a, b) => {
+        if (selectedOption === PROJECT_LIST_OPTION[0]) {
+          const aStartDate = a.currentSprint
+            ? new Date(a.currentSprint?.startDate)
+            : new Date();
+          const bStartDate = b.currentSprint
+            ? new Date(b.currentSprint?.startDate)
+            : new Date();
+
+          return Number(aStartDate) - Number(bStartDate);
+        } else {
+          return Number(new Date(a.createdAt)) - Number(new Date(b.createdAt));
+        }
+      }),
+    [projects, selectedOption]
+  );
+
+  return (
+    <section className="w-[75rem] min-h-[40.5rem]">
+      <div className="flex justify-between">
+        <p className="font-bold text-m text-middle-green">| 프로젝트 목록</p>
+        <div className="flex items-center gap-6">
+          <Dropdown buttonClassName="flex items-center w-[10rem] h-[2.5rem] py-2 pl-9 text-white text-xs bg-middle-green pr-3 rounded-[0.375rem] shadow-box" />
+          <button
+            type="button"
+            className="flex items-center w-[10rem] h-[2.5rem] py-2 pl-3 pr-9 text-white text-xs bg-middle-green gap-3 rounded-[0.375rem] shadow-box"
+          >
+            <img src={plus} alt="더하기" className="w-7" />
+            추가하기
+          </button>
+        </div>
+      </div>
+      <div className="">
+        {projectList.map((project: ProjectDTO) => (
+          <ProjectCard key={project.id} project={project} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProjectList;

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -15,22 +15,27 @@ const ProjectList = () => {
   });
 
   const projectList = useMemo<ProjectDTO[]>(() => {
+    const now = -new Date();
     const sortByOption = (a: ProjectDTO, b: ProjectDTO) => {
       if (selectedOption === PROJECT_LIST_OPTION[0]) {
         const aStartDate = a.currentSprint
           ? new Date(a.currentSprint?.startDate)
-          : new Date();
+          : now;
         const bStartDate = b.currentSprint
           ? new Date(b.currentSprint?.startDate)
-          : new Date();
+          : now;
 
-        return Number(aStartDate) - Number(bStartDate);
+        if (aStartDate === bStartDate) {
+          return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
+        }
+
+        return Number(bStartDate) - Number(aStartDate);
       } else {
-        return Number(new Date(a.createdAt)) - Number(new Date(b.createdAt));
+        return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
       }
     };
 
-    return structuredClone(projects).sort(sortByOption);
+    return structuredClone(projects).sort(sortByOption).reverse();
   }, [projects, selectedOption]);
 
   useEffect(() => {

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -1,12 +1,13 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useDropdown from "../../hooks/common/dropdown/useDropdown";
 import { ProjectCard } from ".";
 import { PROJECT_LIST_OPTION } from "../../constants/projects";
 import plus from "../../assets/icons/plus.svg";
 import { ProjectDTO } from "../../types/projectDTO";
+import { getProjects } from "../../apis/api/projectAPI";
 
 const ProjectList = () => {
-  const [projects] = useState<ProjectDTO[]>([]);
+  const [projects, setProjects] = useState<ProjectDTO[]>([]);
   const { Dropdown, selectedOption } = useDropdown({
     placeholder: "업데이트 순",
     options: PROJECT_LIST_OPTION,
@@ -30,6 +31,13 @@ const ProjectList = () => {
       }),
     [projects, selectedOption]
   );
+
+  useEffect(() => {
+    (async () => {
+      const projectList = await getProjects();
+      setProjects(projectList);
+    })();
+  }, []);
 
   return (
     <section className="w-[75rem] min-h-[40.5rem]">

--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -1,41 +1,31 @@
 import { useEffect, useMemo, useState } from "react";
 import useDropdown from "../../hooks/common/dropdown/useDropdown";
 import { ProjectCard } from ".";
-import { PROJECT_LIST_OPTION } from "../../constants/projects";
+import { PROJECT_SORT_OPTION } from "../../constants/projects";
 import plus from "../../assets/icons/plus.svg";
 import { ProjectDTO } from "../../types/projectDTO";
 import { getProjects } from "../../apis/api/projectAPI";
+import projectSortByOption from "../../utils/projectSortByOption";
 
 const ProjectList = () => {
   const [projects, setProjects] = useState<ProjectDTO[]>([]);
   const { Dropdown, selectedOption } = useDropdown({
     placeholder: "",
-    options: PROJECT_LIST_OPTION,
-    defaultOption: PROJECT_LIST_OPTION[0],
+    options: [PROJECT_SORT_OPTION.UPDATE, PROJECT_SORT_OPTION.RECENT],
+    defaultOption: PROJECT_SORT_OPTION.UPDATE,
   });
 
   const projectList = useMemo<ProjectDTO[]>(() => {
-    const now = -new Date();
-    const sortByOption = (a: ProjectDTO, b: ProjectDTO) => {
-      if (selectedOption === PROJECT_LIST_OPTION[0]) {
-        const aStartDate = a.currentSprint
-          ? new Date(a.currentSprint?.startDate)
-          : now;
-        const bStartDate = b.currentSprint
-          ? new Date(b.currentSprint?.startDate)
-          : now;
+    const earliest = -new Date();
 
-        if (aStartDate === bStartDate) {
-          return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
-        }
-
-        return Number(bStartDate) - Number(aStartDate);
-      } else {
-        return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
-      }
-    };
-
-    return structuredClone(projects).sort(sortByOption);
+    return structuredClone(projects).sort((projectA, projectB) =>
+      projectSortByOption({
+        projectA,
+        projectB,
+        option: selectedOption,
+        earliest,
+      })
+    );
   }, [projects, selectedOption]);
 
   useEffect(() => {

--- a/frontend/src/components/projects/ProjectsSideBar.tsx
+++ b/frontend/src/components/projects/ProjectsSideBar.tsx
@@ -1,28 +1,48 @@
-const ProjectsSideBar = () => (
-  <aside className="pt-16 pb-10 ml-6 w-fit px-9 shadow-box">
-    <h1 className="mb-16 text-5xl font-bold text-middle-green">내 프로젝트</h1>
-    <p className="mb-8 font-semibold text-m text-dark-gray">
-      프로젝트를 생성하고
-    </p>
-    <p className="mb-8 font-semibold text-m text-dark-gray">관리하고</p>
-    <p className="mb-[9.625rem] font-semibold text-m text-dark-gray">
-      확인해 보세요
-    </p>
-    <div className="w-[23.375rem] py-6 px-[1.875rem] flex items-center gap-6 bg-gradient-to-bl from-white-transparent to-90% bg-light-green rounded-[1.125rem] text-white">
-      <img src="" alt="프로필 사진" />
-      <div className="">
-        <p className="font-semibold text-m">사용자 닉네임</p>
-        <div className="flex gap-6 text-xs">
-          <button type="button" className="">
-            Logout
-          </button>
-          <button type="button" className="">
-            My Page
-          </button>
+import { useNavigate } from "react-router-dom";
+import { postLogout } from "../../apis/api/loginAPI";
+import { ROUTER_URL } from "../../constants/path";
+
+const ProjectsSideBar = () => {
+  const navigate = useNavigate();
+  const handleLogoutButtonClick = async () => {
+    const response = await postLogout();
+    if (response?.status === 200) {
+      navigate(ROUTER_URL.ROOT);
+    }
+  };
+
+  return (
+    <aside className="pt-16 pb-10 ml-6 w-fit px-9 shadow-box">
+      <h1 className="mb-16 text-5xl font-bold text-middle-green">
+        내 프로젝트
+      </h1>
+      <p className="mb-8 font-semibold text-m text-dark-gray">
+        프로젝트를 생성하고
+      </p>
+      <p className="mb-8 font-semibold text-m text-dark-gray">관리하고</p>
+      <p className="mb-[9.625rem] font-semibold text-m text-dark-gray">
+        확인해 보세요
+      </p>
+      <div className="w-[23.375rem] py-6 px-[1.875rem] flex items-center gap-6 bg-gradient-to-bl from-white-transparent to-90% bg-light-green rounded-[1.125rem] text-white">
+        <img src="" alt="프로필 사진" />
+        <div className="">
+          <p className="font-semibold text-m">사용자 닉네임</p>
+          <div className="flex gap-6 text-xs">
+            <button
+              type="button"
+              className=""
+              onClick={handleLogoutButtonClick}
+            >
+              Logout
+            </button>
+            <button type="button" className="">
+              My Page
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  </aside>
-);
+    </aside>
+  );
+};
 
 export default ProjectsSideBar;

--- a/frontend/src/components/projects/ProjectsSideBar.tsx
+++ b/frontend/src/components/projects/ProjectsSideBar.tsx
@@ -1,0 +1,28 @@
+const ProjectsSideBar = () => (
+  <aside className="pt-16 pb-10 w-fit px-9 shadow-box">
+    <h1 className="mb-16 text-5xl font-bold text-middle-green">내 프로젝트</h1>
+    <p className="mb-8 font-semibold text-m text-dark-gray">
+      프로젝트를 생성하고
+    </p>
+    <p className="mb-8 font-semibold text-m text-dark-gray">관리하고</p>
+    <p className="mb-[9.625rem] font-semibold text-m text-dark-gray">
+      확인해 보세요
+    </p>
+    <div className="w-[23.375rem] py-6 px-[1.875rem] flex items-center gap-6 bg-gradient-to-bl from-white-transparent to-90% bg-light-green rounded-[1.125rem] text-white">
+      <img src="" alt="프로필 사진" />
+      <div className="">
+        <p className="font-semibold text-m">사용자 닉네임</p>
+        <div className="flex gap-6 text-xs">
+          <button type="button" className="">
+            Logout
+          </button>
+          <button type="button" className="">
+            My Page
+          </button>
+        </div>
+      </div>
+    </div>
+  </aside>
+);
+
+export default ProjectsSideBar;

--- a/frontend/src/components/projects/ProjectsSideBar.tsx
+++ b/frontend/src/components/projects/ProjectsSideBar.tsx
@@ -1,5 +1,5 @@
 const ProjectsSideBar = () => (
-  <aside className="pt-16 pb-10 w-fit px-9 shadow-box">
+  <aside className="pt-16 pb-10 ml-6 w-fit px-9 shadow-box">
     <h1 className="mb-16 text-5xl font-bold text-middle-green">내 프로젝트</h1>
     <p className="mb-8 font-semibold text-m text-dark-gray">
       프로젝트를 생성하고

--- a/frontend/src/components/projects/index.ts
+++ b/frontend/src/components/projects/index.ts
@@ -1,0 +1,3 @@
+export { default as ProjectsSideBar } from "./ProjectsSideBar";
+export { default as ProjectList } from "./ProjectList";
+export { default as ProjectCard } from "./ProjectCard";

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -6,6 +6,9 @@ export const API_URL = {
   SIGN_UP: "/auth/github/signup",
   LOG_OUT: "/auth/logout",
   REFRESH: "/auth/refresh",
+  NICKNAME_AVAILABLILITY: "/member/availability",
+  GITHUB_USERNAME: "/auth/github/username",
+  PROJECT: "/project",
 };
 
 export const ROUTER_URL = {

--- a/frontend/src/constants/projects.ts
+++ b/frontend/src/constants/projects.ts
@@ -1,0 +1,1 @@
+export const PROJECT_LIST_OPTION = ["업데이트 순", "최신 순"];

--- a/frontend/src/constants/projects.ts
+++ b/frontend/src/constants/projects.ts
@@ -1,1 +1,1 @@
-export const PROJECT_LIST_OPTION = ["업데이트 순", "최신 순"];
+export const PROJECT_SORT_OPTION = { UPDATE: "업데이트 순", RECENT: "최신 순" };

--- a/frontend/src/hooks/common/dropdown/useDropdown.tsx
+++ b/frontend/src/hooks/common/dropdown/useDropdown.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from "react";
+import chevron from "../../../assets/icons/chevron-down.svg";
 
 interface useDropdownParams {
   placeholder: string;
   options: string[];
+  defaultOption?: string;
 }
 
 interface DropdownProps {
@@ -11,8 +13,14 @@ interface DropdownProps {
   itemClassName?: string;
 }
 
-const useDropdown = ({ placeholder, options }: useDropdownParams) => {
-  const [selectedOption, setSelectedOption] = useState<string>("");
+const useDropdown = ({
+  placeholder,
+  options,
+  defaultOption,
+}: useDropdownParams) => {
+  const [selectedOption, setSelectedOption] = useState<string>(
+    defaultOption ? defaultOption : ""
+  );
   const dropdownRef = useRef<HTMLButtonElement>(null);
 
   const Dropdown = ({
@@ -56,6 +64,7 @@ const useDropdown = ({ placeholder, options }: useDropdownParams) => {
           className={buttonClassName}
         >
           {selectedOption || placeholder}
+          <img src={chevron} className="w-7" alt="드롭다운 화살표" />
         </button>
         {open && (
           <ul className={`${containerClassName} absolute`}>
@@ -63,7 +72,11 @@ const useDropdown = ({ placeholder, options }: useDropdownParams) => {
               <li
                 key={index}
                 onMouseDown={() => handleOptionClick(option)}
-                className={`${itemClassName} hover:cursor-pointer`}
+                className={`${
+                  selectedOption === option
+                    ? "text-middle-green"
+                    : "text-text-gray"
+                } ${itemClassName} hover:cursor-pointer`}
               >
                 {option}
               </li>

--- a/frontend/src/pages/projects/ProjectsPage.tsx
+++ b/frontend/src/pages/projects/ProjectsPage.tsx
@@ -1,7 +1,7 @@
 import { ProjectList, ProjectsSideBar } from "../../components/projects";
 
 const ProjectsPage = () => (
-  <main className="flex items-center min-w-[76rem] h-[100vh] gap-10">
+  <main className="flex justify-center items-center min-w-[76rem] h-[100vh] gap-10">
     <ProjectsSideBar />
     <ProjectList />
   </main>

--- a/frontend/src/pages/projects/ProjectsPage.tsx
+++ b/frontend/src/pages/projects/ProjectsPage.tsx
@@ -1,13 +1,10 @@
-import { Link } from "react-router-dom";
-import { ROUTER_URL } from "../../constants/path";
+import { ProjectList, ProjectsSideBar } from "../../components/projects";
 
-const ProjectsPage = () => {
-  return (
-    <div>
-      this is ProjectsPage
-      <Link to={ROUTER_URL.TEMP} />
-    </div>
-  );
-};
+const ProjectsPage = () => (
+  <main className="flex items-center min-w-[76rem] h-[100vh]">
+    <ProjectsSideBar />
+    <ProjectList />
+  </main>
+);
 
 export default ProjectsPage;

--- a/frontend/src/pages/projects/ProjectsPage.tsx
+++ b/frontend/src/pages/projects/ProjectsPage.tsx
@@ -1,7 +1,7 @@
 import { ProjectList, ProjectsSideBar } from "../../components/projects";
 
 const ProjectsPage = () => (
-  <main className="flex items-center min-w-[76rem] h-[100vh]">
+  <main className="flex items-center min-w-[76rem] h-[100vh] gap-10">
     <ProjectsSideBar />
     <ProjectList />
   </main>

--- a/frontend/src/test/projectSortingTest.test.tsx
+++ b/frontend/src/test/projectSortingTest.test.tsx
@@ -1,70 +1,85 @@
-import { PROJECT_LIST_OPTION } from "../constants/projects";
+import { PROJECT_SORT_OPTION } from "../constants/projects";
+import { ProjectDTO } from "../types/projectDTO";
+import projectSortByOption from "../utils/projectSortByOption";
 
-interface Project {
-  id: number;
-  currentSprint?: { startDate: string };
-  createdAt: string;
-}
-const mockProjectListData: Project[] = [
+const mockProjectListData: ProjectDTO[] = [
   {
     id: 1,
-    currentSprint: { startDate: "2024-03-11T12:00:00Z" },
+    title: "",
+    currentSprint: {
+      title: "",
+      startDate: "2024-03-11T12:00:00Z",
+      endDate: "",
+      progressPercentage: 0,
+      myTasksLeft: 0,
+    },
     createdAt: "2024-03-01T12:00:00Z",
   },
   {
     id: 2,
-    currentSprint: { startDate: "2024-03-06T12:00:00Z" },
+    title: "",
+    currentSprint: {
+      title: "",
+      startDate: "2024-03-06T12:00:00Z",
+      endDate: "",
+      progressPercentage: 0,
+      myTasksLeft: 0,
+    },
     createdAt: "2024-03-02T12:00:00Z",
   },
   {
     id: 3,
+    title: "",
+    currentSprint: null,
     createdAt: "2024-03-05T12:00:00Z",
   },
   {
     id: 4,
+    title: "",
+    currentSprint: null,
     createdAt: "2024-03-01T12:00:00Z",
   },
   {
     id: 5,
-    currentSprint: { startDate: "2024-03-12T12:00:00Z" },
+    title: "",
+    currentSprint: {
+      title: "",
+      startDate: "2024-03-12T12:00:00Z",
+      endDate: "",
+      progressPercentage: 0,
+      myTasksLeft: 0,
+    },
     createdAt: "2024-03-10T12:00:00Z",
   },
 ];
 
 describe("프로젝트 목록 정렬 함수", () => {
-  let selectedOption: string;
-  const now = -new Date();
-  const sortingFunction = (a: Project, b: Project) => {
-    if (selectedOption === PROJECT_LIST_OPTION[0]) {
-      const aStartDate = a.currentSprint
-        ? new Date(a.currentSprint?.startDate)
-        : now;
-      const bStartDate = b.currentSprint
-        ? new Date(b.currentSprint?.startDate)
-        : now;
-
-      if (aStartDate === bStartDate) {
-        return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
-      }
-
-      return Number(bStartDate) - Number(aStartDate);
-    } else {
-      return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
-    }
-  };
+  const earliest = -new Date();
 
   it("옵션이 업데이트 순일 때", () => {
-    [selectedOption] = PROJECT_LIST_OPTION;
     const sortingResult = structuredClone(mockProjectListData)
-      .sort(sortingFunction)
+      .sort((projectA, projectB) =>
+        projectSortByOption({
+          projectA,
+          projectB,
+          option: PROJECT_SORT_OPTION.UPDATE,
+          earliest,
+        })
+      )
       .map((project) => project.id);
     expect(sortingResult).toEqual([5, 1, 2, 3, 4]);
   });
 
   it("옵션이 최신 순일 때", () => {
-    [, selectedOption] = PROJECT_LIST_OPTION;
     const sortingResult = structuredClone(mockProjectListData)
-      .sort(sortingFunction)
+      .sort((projectA, projectB) =>
+        projectSortByOption({
+          projectA,
+          projectB,
+          option: PROJECT_SORT_OPTION.RECENT,
+          earliest,
+        })
+      )
       .map((project) => project.id);
     expect(sortingResult).toEqual([5, 3, 2, 1, 4]);
   });

--- a/frontend/src/test/projectSortingTest.test.tsx
+++ b/frontend/src/test/projectSortingTest.test.tsx
@@ -1,0 +1,71 @@
+import { PROJECT_LIST_OPTION } from "../constants/projects";
+
+interface Project {
+  id: number;
+  currentSprint?: { startDate: string };
+  createdAt: string;
+}
+const mockProjectListData: Project[] = [
+  {
+    id: 1,
+    currentSprint: { startDate: "2024-03-11T12:00:00Z" },
+    createdAt: "2024-03-01T12:00:00Z",
+  },
+  {
+    id: 2,
+    currentSprint: { startDate: "2024-03-06T12:00:00Z" },
+    createdAt: "2024-03-02T12:00:00Z",
+  },
+  {
+    id: 3,
+    createdAt: "2024-03-05T12:00:00Z",
+  },
+  {
+    id: 4,
+    createdAt: "2024-03-01T12:00:00Z",
+  },
+  {
+    id: 5,
+    currentSprint: { startDate: "2024-03-12T12:00:00Z" },
+    createdAt: "2024-03-10T12:00:00Z",
+  },
+];
+
+describe("프로젝트 목록 정렬 함수", () => {
+  let selectedOption: string;
+  const now = -new Date();
+  const sortingFunction = (a: Project, b: Project) => {
+    if (selectedOption === PROJECT_LIST_OPTION[0]) {
+      const aStartDate = a.currentSprint
+        ? new Date(a.currentSprint?.startDate)
+        : now;
+      const bStartDate = b.currentSprint
+        ? new Date(b.currentSprint?.startDate)
+        : now;
+
+      if (aStartDate === bStartDate) {
+        return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
+      }
+
+      return Number(bStartDate) - Number(aStartDate);
+    } else {
+      return Number(new Date(b.createdAt)) - Number(new Date(a.createdAt));
+    }
+  };
+
+  it("옵션이 업데이트 순일 때", () => {
+    [selectedOption] = PROJECT_LIST_OPTION;
+    const sortingResult = structuredClone(mockProjectListData)
+      .sort(sortingFunction)
+      .map((project) => project.id);
+    expect(sortingResult).toEqual([5, 1, 2, 3, 4]);
+  });
+
+  it("옵션이 최신 순일 때", () => {
+    [, selectedOption] = PROJECT_LIST_OPTION;
+    const sortingResult = structuredClone(mockProjectListData)
+      .sort(sortingFunction)
+      .map((project) => project.id);
+    expect(sortingResult).toEqual([5, 3, 2, 1, 4]);
+  });
+});

--- a/frontend/src/types/projectDTO.ts
+++ b/frontend/src/types/projectDTO.ts
@@ -1,0 +1,12 @@
+export interface ProjectDTO {
+  id: number;
+  title: string;
+  createdAt: string;
+  currentSprint: null | {
+    title: string;
+    startDate: string;
+    endDate: string;
+    progressPercentage: number;
+    myTasksLeft: number;
+  };
+}

--- a/frontend/src/utils/formatDate.ts
+++ b/frontend/src/utils/formatDate.ts
@@ -1,0 +1,10 @@
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}.${String(date.getDate()).padStart(2, "0")}`;
+};
+
+export default formatDate;

--- a/frontend/src/utils/projectSortByOption.ts
+++ b/frontend/src/utils/projectSortByOption.ts
@@ -1,0 +1,41 @@
+import { PROJECT_SORT_OPTION } from "../constants/projects";
+import { ProjectDTO } from "../types/projectDTO";
+
+interface ProjectSortByOptionParams {
+  projectA: ProjectDTO;
+  projectB: ProjectDTO;
+  option: string;
+  earliest: number;
+}
+
+const projectSortByOption = ({
+  projectA,
+  projectB,
+  option,
+  earliest,
+}: ProjectSortByOptionParams) => {
+  if (option === PROJECT_SORT_OPTION.UPDATE) {
+    const projectASprintStart = projectA.currentSprint
+      ? new Date(projectA.currentSprint?.startDate)
+      : earliest;
+    const projectBSprintStart = projectB.currentSprint
+      ? new Date(projectB.currentSprint?.startDate)
+      : earliest;
+
+    if (projectASprintStart === projectBSprintStart) {
+      return (
+        Number(new Date(projectB.createdAt)) -
+        Number(new Date(projectA.createdAt))
+      );
+    }
+
+    return Number(projectBSprintStart) - Number(projectASprintStart);
+  } else {
+    return (
+      Number(new Date(projectB.createdAt)) -
+      Number(new Date(projectA.createdAt))
+    );
+  }
+};
+
+export default projectSortByOption;

--- a/frontend/svgTransformer.cjs
+++ b/frontend/svgTransformer.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  process() {
+    return { code: "module.exports = {};" };
+  },
+};


### PR DESCRIPTION
## 🎟️ 태스크

- [(프로젝트 목록) 프론트엔드 화면구성](https://plastic-toad-cb0.notion.site/b98a985ea67c4d51b5048aab886f4461)
- [(프로젝트 목록) API 연결(협업)](https://plastic-toad-cb0.notion.site/API-f360093273ed4a19bfc64f25711cc470)
- [필터 함수 만들기](https://plastic-toad-cb0.notion.site/9c14249732664134b0e581d917674bfd)
- [로그아웃 API 연결(백, 프론트)](https://plastic-toad-cb0.notion.site/API-6a1c0a83e1ce455189fa1f56ffe2ae04)

## ✅ 작업 내용

- 프로젝트 목록 화면 구현
- 프로젝트 목록 API 연결
- 프로젝트 목록 필터 함수(정렬 함수) 적용
- 로그아웃 API 연결

## 🖊️ 구체적인 작업

### 프로젝트 목록 화면

- 디자인에 맞춰 화면을 구현했으며, 스프린트 데이터가 없는 경우에는 일단 스프린트 제목, 날짜 데이터를 보여주지 않고 흰 박스에 "스프린트 데이터가 없습니다"라는 문구가 뜨도록 했습니다.
- 피그마에 적힌 수치대로 하니 가로 화면이 남게 되어 우선 가운데에 정렬되도록 했습니다. 

### 프로젝트 목록 필터 함수(정렬 함수)

- 업데이트 순으로 정렬 시 스프린트 시작 날짜가 기준이 되는데, 스프린트 데이터가 없을 경우 해당 데이터가 없는 프로젝트들은 생성일 기준 최신 순으로 정렬되도록 했습니다.

## 🤔 고민 및 의논할 거리
   
- 필터 함수는 utils에 따로 정의하지 않고 컴포넌트 내부에서 정의해서 사용했습니다. 이렇게 한 이유는 utils에 있는 함수는 여러 군데에서 재사용 할 수 있어야 한다고 생각했기 때문입니다. 프로젝트 목록을 정렬할 때 사용하는 함수는 프로젝트 목록 데이터의 형식과 밀접하게 연관되어 있어서 재사용하기 힘들다고 판단했습니다. 그래서 따로 파일을 생성하지 않고 컴포넌트 내부에서 정의했습니다. 해당 함수를 테스트할 때 컴포넌트 전체를 렌더링하면 테스트가 커지고 비효율적으로 될 것 같아서 함수만 따로 테스트를 진행했습니다. 그런데 함수가 컴포넌트 내부에 정의되어있다 보니 import를 할 수가 없어서 동일한 함수를 test 파일에도 정의하고 사용했습니다.
- 이렇게 했을 때 문제점은 정렬 함수가 변경되었을 때 테스트에 있는 함수도 동일하게 변경해줘야 하는 것입니다. 실제 함수가 변경될 일이 거의 없다고 하더라도 한 번 변경되면 두 군데 모두에 반영해야 한다는 점이 번거롭고 오류가 발생할 가능성이 높다고 생각합니다. 이런 경우에는 utils로 함수를 옮기는 게 좋을까요? 아니면 컴포넌트를 렌더링하는 방식으로 테스트를 진행하는 게 맞을까요? 개인적으로는 전체적인 UI가 아니라 정렬 로직만 테스트하면 되는 것이기 때문에 파일을 따로 빼는 게 좋을 것 같지만 테스트의 용이성만을 위해 분리를 하는 게 괜찮을지 고민이 됩니다.

## 📸 결과 화면

![녹화_2024_03_25_19_35_28_223](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/cb3b8855-5524-4cea-ac60-f837ed00632a)

