### PR TITLE
refactor: bearer 형식으로 들어오는 토큰을 파싱하는 미들웨어 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { MiddlewareConsumer, Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -20,6 +20,7 @@ import { Member } from './member/entity/member.entity';
 import { LoginMember } from './auth/entity/loginMember.entity';
 import { ProjectModule } from './project/project.module';
 import * as cookieParser from 'cookie-parser';
+import { BearerTokenMiddleware } from './common/middleware/parse-bearer-token.middleware';
 
 @Module({
   imports: [
@@ -49,5 +50,8 @@ import * as cookieParser from 'cookie-parser';
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(cookieParser()).forRoutes('*');
+    consumer
+      .apply(BearerTokenMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,14 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
+import { GithubApiModule } from 'src/github-api/github-api.module';
+import { MemberModule } from 'src/member/member.module';
 import { AuthController } from './controller/auth.controller';
 import { AuthService } from './service/auth.service';
-import { GithubApiModule } from 'src/github-api/github-api.module';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { TempMember } from './entity/tempMember.entity';
-import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
 import { TempMemberRepository } from './repository/tempMember.repository';
-import { MemberModule } from 'src/member/member.module';
-import { LoginMember } from './entity/loginMember.entity';
 import { LoginMemberRepository } from './repository/loginMember.repository';
+import { TempMember } from './entity/tempMember.entity';
+import { LoginMember } from './entity/loginMember.entity';
 
 @Module({
   imports: [

--- a/backend/src/auth/entity/loginMember.entity.ts
+++ b/backend/src/auth/entity/loginMember.entity.ts
@@ -1,4 +1,3 @@
-import { Member } from 'src/member/entity/member.entity';
 import {
   Column,
   CreateDateColumn,
@@ -8,6 +7,7 @@ import {
   PrimaryColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { Member } from 'src/member/entity/member.entity';
 
 @Entity()
 export class LoginMember {

--- a/backend/src/auth/repository/loginMember.repository.ts
+++ b/backend/src/auth/repository/loginMember.repository.ts
@@ -1,7 +1,6 @@
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { TempMember } from '../entity/tempMember.entity';
-import { Injectable } from '@nestjs/common';
 import { LoginMember } from '../entity/loginMember.entity';
 
 @Injectable()

--- a/backend/src/auth/repository/tempMember.repository.ts
+++ b/backend/src/auth/repository/tempMember.repository.ts
@@ -1,7 +1,7 @@
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TempMember } from '../entity/tempMember.entity';
-import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class TempMemberRepository {

--- a/backend/src/auth/service/auth.service.spec.ts
+++ b/backend/src/auth/service/auth.service.spec.ts
@@ -2,13 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { GithubApiService } from 'src/github-api/github-api.service';
-import { GithubUserDto } from './dto/github-user.dto';
-import { TempMemberRepository } from '../repository/tempMember.repository';
 import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
-import { TempMember } from '../entity/tempMember.entity';
 import { MemberService } from 'src/member/service/member.service';
-import { Member } from 'src/member/entity/member.entity';
+import { TempMemberRepository } from '../repository/tempMember.repository';
 import { LoginMemberRepository } from '../repository/loginMember.repository';
+import { GithubUserDto } from './dto/github-user.dto';
+import { TempMember } from '../entity/tempMember.entity';
+import { Member } from 'src/member/entity/member.entity';
 import { LoginMember } from '../entity/loginMember.entity';
 
 describe('Auth Service Unit Test', () => {

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -1,18 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GithubApiService } from 'src/github-api/github-api.service';
-import {
-  GITHUB_CLIENT_ID,
-  GITHUB_CLIENT_SECRETS,
-} from 'src/lesser-config/constants';
-import { GithubUserDto } from './dto/github-user.dto';
-import { TempMemberRepository } from '../repository/tempMember.repository';
-import { TempMember } from '../entity/tempMember.entity';
-import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
 import { v4 as uuidv4 } from 'uuid';
+import { GithubApiService } from 'src/github-api/github-api.service';
+import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
 import { MemberService } from 'src/member/service/member.service';
+import { TempMemberRepository } from '../repository/tempMember.repository';
 import { LoginMemberRepository } from '../repository/loginMember.repository';
+import { GithubUserDto } from './dto/github-user.dto';
+import { TempMember } from '../entity/tempMember.entity';
 import { LoginMember } from '../entity/loginMember.entity';
+import {
+	GITHUB_CLIENT_ID,
+	GITHUB_CLIENT_SECRETS,
+  } from 'src/lesser-config/constants';
 
 @Injectable()
 export class AuthService {

--- a/backend/src/common/middleware/parse-bearer-token.middleware.ts
+++ b/backend/src/common/middleware/parse-bearer-token.middleware.ts
@@ -1,0 +1,22 @@
+import { NestMiddleware } from '@nestjs/common';
+import { NextFunction } from 'express';
+
+export interface BearerTokenRequest extends Request {
+  headers: Request['headers'] & {
+    authorization: string;
+  };
+  token: string;
+}
+
+export class BearerTokenMiddleware implements NestMiddleware {
+  use(request: BearerTokenRequest, response: Response, next: NextFunction) {
+    const authHeader = request.headers.authorization;
+    if (authHeader) {
+      const [bearer, token] = authHeader.split(' ');
+      if (bearer === 'Bearer' && token) {
+        request.token = token;
+      }
+    }
+    next();
+  }
+}

--- a/backend/src/lesser-jwt/lesser-jwt.module.ts
+++ b/backend/src/lesser-jwt/lesser-jwt.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
-import { LesserJwtService } from './lesser-jwt.service';
-import { LesserConfigModule } from 'src/lesser-config/lesser-config.module';
 import { ConfigService } from '@nestjs/config';
+import { LesserConfigModule } from 'src/lesser-config/lesser-config.module';
+import { LesserJwtService } from './lesser-jwt.service';
 import { JWT_SECRET } from 'src/lesser-config/constants';
 
 @Module({

--- a/backend/src/lesser-jwt/lesser-jwt.service.spec.ts
+++ b/backend/src/lesser-jwt/lesser-jwt.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { LesserJwtService } from './lesser-jwt.service';
 import { JwtModule, JwtService } from '@nestjs/jwt';
+import { LesserJwtService } from './lesser-jwt.service';
 
 describe('LesserJwtService', () => {
   let lesserJwtService: LesserJwtService;

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -7,7 +7,7 @@ import {
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
-import { CustomHeaders } from 'src/auth/controller/auth.controller';
+import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
 import { MemberService } from '../service/member.service';
 
 @Controller('member')
@@ -26,15 +26,10 @@ export class MemberController {
     }
   }
   @Get('/')
-  async getMember(@Req() request: Request & { headers: CustomHeaders }) {
-    const authHeader = request.headers.authorization;
-    if (!authHeader) {
-      throw new UnauthorizedException('Authorization header is missing');
-    }
-    const [bearer, accessToken] = authHeader.split(' ');
-    if (bearer !== 'Bearer' || !accessToken) {
-      throw new UnauthorizedException('Invalid authorization header format');
-    }
+  async getMember(@Req() request: BearerTokenRequest) {
+    const accessToken = request.token;
+    if (!accessToken)
+      throw new UnauthorizedException('Bearer Token is missing');
     try {
       const { username, githubImageUrl } =
         await this.memberService.getMemberPublicInfo(accessToken);

--- a/backend/src/member/member.module.ts
+++ b/backend/src/member/member.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { MemberService } from './service/member.service';
-import { Member } from './entity/member.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { MemberRepository } from './repository/member.repository';
-import { MemberController } from './controller/member.controller';
 import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
+import { MemberController } from './controller/member.controller';
+import { MemberService } from './service/member.service';
+import { MemberRepository } from './repository/member.repository';
+import { Member } from './entity/member.entity';
 
 @Module({
   imports: [LesserJwtModule, TypeOrmModule.forFeature([Member])],

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -6,24 +6,18 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { projectFixtures } from 'fixtures/project-fixtures';
+import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
 
-import { CustomHeaders } from 'src/auth/controller/auth.controller';
 import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
 
 @Controller('project')
 export class ProjectController {
   constructor(private readonly lesserJwtService: LesserJwtService) {}
   @Get('/')
-  async getProjectList(@Req() request: Request & { headers: CustomHeaders }) {
-    const authHeader = request.headers.authorization;
-    if (!authHeader) {
-      throw new UnauthorizedException('Authorization header is missing');
-    }
-    const [bearer, accessToken] = authHeader.split(' ');
-    if (bearer !== 'Bearer' || !accessToken) {
-      throw new UnauthorizedException('Invalid authorization header format');
-    }
-
+  async getProjectList(@Req() request: BearerTokenRequest) {
+    const accessToken = request.token;
+    if (!accessToken)
+      throw new UnauthorizedException('Bearer Token is missing');
     try {
       // access token 검증을 위한 임시 로직
       await this.lesserJwtService.getPayload(accessToken, 'access');

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { ProjectController } from './project.controller';
 import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
+import { ProjectController } from './project.controller';
 
 @Module({
   imports: [LesserJwtModule],

--- a/backend/test/auth/get-github-username.e2e-spec.ts
+++ b/backend/test/auth/get-github-username.e2e-spec.ts
@@ -16,22 +16,13 @@ describe('GET /api/auth/github/username', () => {
     expect(response.body.githubUsername).toBe(githubUserFixture.login);
   });
 
-  it('should return 401 (Authorization header is missing)', async () => {
+  it('should return 401 (Bearer Token is missing)', async () => {
     const response = await request(app.getHttpServer()).get(
       '/api/auth/github/username',
     );
 
     expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Authorization header is missing');
-  });
-
-  it('should return 401 (Invalid authorization header format)', async () => {
-    const response = await request(app.getHttpServer())
-      .get('/api/auth/github/username')
-      .set('Authorization', 'accessToken');
-
-    expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Invalid authorization header format');
+    expect(response.body.message).toBe('Bearer Token is missing');
   });
 
   it('should return 401 (Expired:tempIdToken)', async () => {

--- a/backend/test/auth/github-signup.e2e-spec.ts
+++ b/backend/test/auth/github-signup.e2e-spec.ts
@@ -39,23 +39,13 @@ describe('POST /api/auth/github/signup', () => {
     expect(response.status).toBe(400);
   });
 
-  it('should return 401 (Authorization header is missing)', async () => {
+  it('should return 401 (Bearer Token is missing)', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/auth/github/signup')
       .send(memberSignupPayload);
 
     expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Authorization header is missing');
-  });
-
-  it('should return 401 (Invalid authorization header format)', async () => {
-    const response = await request(app.getHttpServer())
-      .post('/api/auth/github/signup')
-      .set('Authorization', `No Bearer tempIdToken`)
-      .send(memberSignupPayload);
-
-    expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Invalid authorization header format');
+    expect(response.body.message).toBe('Bearer Token is missing');
   });
 
   it('should return 401 (Expired:tempIdToken)', async () => {

--- a/backend/test/auth/logout.e2e-spec.ts
+++ b/backend/test/auth/logout.e2e-spec.ts
@@ -35,23 +35,13 @@ describe('POST /api/auth/logout', () => {
     expect(response.body.message).toBe('Not a logged in member');
   });
 
-  it('should return 401 (Authorization header is missing)', async () => {
+  it('should return 401 (Bearer Token is missing)', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/auth/logout')
       .send();
 
     expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Authorization header is missing');
-  });
-
-  it('should return 401 (Invalid authorization header format)', async () => {
-    const response = await request(app.getHttpServer())
-      .post('/api/auth/logout')
-      .set('Authorization', `accessToken`)
-      .send();
-
-    expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Invalid authorization header format');
+    expect(response.body.message).toBe('Bearer Token is missing');
   });
 
   it('should return 401 (Expired:accessToken)', async () => {

--- a/backend/test/member/get-member.e2e-spec.ts
+++ b/backend/test/member/get-member.e2e-spec.ts
@@ -13,20 +13,11 @@ describe('GET /api/member', () => {
     expect(response.body.imageUrl).toBe(memberFixture.github_image_url);
   });
 
-  it('should return 401 (Authorization header is missing)', async () => {
+  it('should return 401 (Bearer Token is missing)', async () => {
     const response = await request(app.getHttpServer()).get('/api/member');
 
     expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Authorization header is missing');
-  });
-
-  it('should return 401 (Invalid authorization header format)', async () => {
-    const response = await request(app.getHttpServer())
-      .get('/api/member')
-      .set('Authorization', 'accessToken');
-
-    expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Invalid authorization header format');
+    expect(response.body.message).toBe('Bearer Token is missing');
   });
 
   it('should return 401 (Expired:accessToken)', async () => {

--- a/backend/test/project/get-project.e2e-spec.ts
+++ b/backend/test/project/get-project.e2e-spec.ts
@@ -14,20 +14,11 @@ describe('GET /api/project', () => {
     expect(response.body.projects).toEqual(projectFixtures);
   });
 
-  it('should return 401 (Authorization header is missing)', async () => {
+  it('should return 401 (Bearer Token is missing)', async () => {
     const response = await request(app.getHttpServer()).get('/api/project');
 
     expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Authorization header is missing');
-  });
-
-  it('should return 401 (Invalid authorization header format)', async () => {
-    const response = await request(app.getHttpServer())
-      .get('/api/project')
-      .set('Authorization', `accessToken`);
-
-    expect(response.status).toBe(401);
-    expect(response.body.message).toBe('Invalid authorization header format');
+    expect(response.body.message).toBe('Bearer Token is missing');
   });
 
   it('should return 401 Expired:accessToken', async () => {


### PR DESCRIPTION
## 🎟️ 태스크

[헤더의 토큰 처리: access token, temp id token](https://plastic-toad-cb0.notion.site/access-token-temp-id-token-583e4f05daf14f0cbee04a7b307cacf9?pvs=4)

## ✅ 작업 내용

- 사용하지 않는 import 삭제
- bearer 형식으로 들어오는 토큰을 파싱하는 미들웨어 추가


## 🖊️ 구체적인 작업

### 사용하지 않는 import 삭제
- 사용하지 않는 import 삭제
- 모듈-컨트롤러-서비스-레포지토리-DTO-엔티티-컨스턴스-미들웨어 순서로 import하도록 수정

### bearer 형식으로 들어오는 토큰을 파싱하는 미들웨어 추가
- bearer 형식으로 들어오는 토큰을 파싱하는 미들웨어 추가
- 컨트롤러 파싱로직 수정
- bearer토큰이 들어오지 않는 경우에 대해 모두 'Bearer Token is missing' 에러메시지를 던지도록 수정
- e2e 테스트 변경

## 🤔 고민 및 의논할 거리
- bearer형식으로 들어오는 토큰을 파싱하는 로직이 여러차례 반복되고, 앞으로도 반복이 될것으로 예상되어서 미들웨어로 일괄적으로 파싱하게끔 작성했습니다.
- 후보로 가드, 미들웨어, 인터셉터를 생각했고 파싱로직 자체는 실행맥락에 접근할 필요가 없다고 판단해 미들웨어로 구현하게 되었습니다.
- 헤더로 bearer 토큰이 들어오는 경우에만 처리해 req.token에 넣어놓았습니다.
- 추후 가드로 인증로직을 구현하게 되면, 컨트롤러로직에서 throw 하고 있는 'Bearer Token is missing'과 'Expired:accessToken' 과 같은 인증실패에 관련된 중복로직을 많이 줄일 수 있을것 같습니다.
- [NestJS 미들웨어로 Bearer 토큰 파싱하기](https://plastic-toad-cb0.notion.site/NestJS-Bearer-240d50b2b7d5466eac6e8e73f1f15d54?pvs=74)