### PR TITLE
feat : 외부 signup 페이지 접근 제한 코드 작성

### DIFF
--- a/frontend/src/GlobalErrorBoundary.tsx
+++ b/frontend/src/GlobalErrorBoundary.tsx
@@ -2,8 +2,13 @@ import { PropsWithChildren } from "react";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
 import ErrorPage from "./pages/error/CommonErrorPage";
 import AuthErrorPage from "./pages/error/AuthErrorPage";
+import { ERROR_MESSAGE } from "./constants/error";
+import NotPermittedPage from "./pages/error/NotPermittedPage";
 
 const GlobalErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  if (error.message === ERROR_MESSAGE.NOT_PERMITTED)
+    return <NotPermittedPage {...{ error, resetErrorBoundary }} />;
+
   if (error.response.status === 401) return <AuthErrorPage {...{ error, resetErrorBoundary }} />;
   return <ErrorPage {...{ error, resetErrorBoundary }} />;
 };

--- a/frontend/src/apis/api/loginAPI.ts
+++ b/frontend/src/apis/api/loginAPI.ts
@@ -10,9 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { authAPI, setAccessToken } from "../utils/authAPI";
 
 export const getLoginURL = async () => {
-  const response = await baseAPI.get<GithubOauthUrlDTO>(
-    API_URL.GITHUB_OAUTH_URL
-  );
+  const response = await baseAPI.get<GithubOauthUrlDTO>(API_URL.GITHUB_OAUTH_URL);
   return response.data.authUrl;
 };
 
@@ -40,6 +38,7 @@ export const postLogout = async () => {
 
   if (response.status === 200) {
     setAccessToken(undefined);
+    window.localStorage.clear();
     return response;
   }
 };

--- a/frontend/src/constants/error.ts
+++ b/frontend/src/constants/error.ts
@@ -1,0 +1,3 @@
+export const ERROR_MESSAGE = {
+  NOT_PERMITTED: "허용되지 않는 접근입니다.",
+};

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -13,7 +13,7 @@ export const API_URL = {
 
 export const ROUTER_URL = {
   ROOT: "/",
-  TEMP: "/temp",
+  TEMP: "/",
   LOGIN: "/login",
   SIGNUP: "/signup",
   AUTH: "/auth/github/callback",

--- a/frontend/src/pages/TempHomepage.tsx
+++ b/frontend/src/pages/TempHomepage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import React from "react";
 import { ROUTER_URL } from "../constants/path";
 
@@ -10,6 +10,10 @@ const TempHomepage = () => {
       console.log(await response.json());
     });
   });
+  const navigate = useNavigate();
+  const navigateToSignupPage = () => {
+    navigate(ROUTER_URL.SIGNUP, { state: { tempIdToken: "hello world" } });
+  };
   return (
     <div>
       <div className="shadow-box bg-white mb-[40px]">
@@ -25,6 +29,11 @@ const TempHomepage = () => {
           <Link to={ROUTER_URL.SIGNUP} className="hover:underline">
             Sign up
           </Link>
+        </li>
+        <li>
+          <button className="hover:underline" onClick={navigateToSignupPage}>
+            Sign up with TempIDToken
+          </button>
         </li>
         <li>
           <Link to={ROUTER_URL.PROJECTS} className="hover:underline">

--- a/frontend/src/pages/account/SignupPage.tsx
+++ b/frontend/src/pages/account/SignupPage.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import SignupSideBar from "../../components/account/SignupSideBar";
 import SignupMainSection from "../../components/account/SignupMainSection";
 import { SIGNUP_STEP } from "../../constants/account";
+import { useLocation } from "react-router-dom";
+import { ERROR_MESSAGE } from "../../constants/error";
 
 const SignupPage = () => {
   const [currentStep, setCurrentStep] = useState<{
@@ -9,16 +11,15 @@ const SignupPage = () => {
     NAME: string;
   }>(SIGNUP_STEP.STEP1);
 
+  const location = useLocation();
+  if (location.state ? false : true) {
+    throw Error(ERROR_MESSAGE.NOT_PERMITTED);
+  }
+
   return (
     <div className="flex items-center min-w-[76rem] h-[100vh] mx-6">
-      <SignupSideBar
-        currentStepName={currentStep.NAME}
-        currentStepNumber={currentStep.NUMBER}
-      />
-      <SignupMainSection
-        currentStepNumber={currentStep.NUMBER}
-        setCurrentStep={setCurrentStep}
-      />
+      <SignupSideBar currentStepName={currentStep.NAME} currentStepNumber={currentStep.NUMBER} />
+      <SignupMainSection currentStepNumber={currentStep.NUMBER} setCurrentStep={setCurrentStep} />
     </div>
   );
 };

--- a/frontend/src/pages/error/NotPermittedPage.tsx
+++ b/frontend/src/pages/error/NotPermittedPage.tsx
@@ -1,0 +1,22 @@
+import { FallbackProps } from "react-error-boundary";
+import { useNavigate } from "react-router-dom";
+import { ROUTER_URL } from "../../constants/path";
+
+const NotPermittedPage = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const navigate = useNavigate();
+  const redirectTempPage = () => {
+    resetErrorBoundary();
+    navigate(ROUTER_URL.TEMP);
+  };
+  return (
+    <div>
+      <p>Error 발생</p>
+      <p>error : {error.message}</p>
+      <button onClick={redirectTempPage} className="hover:underline">
+        Temp Page로 이동
+      </button>
+    </div>
+  );
+};
+
+export default NotPermittedPage;


### PR DESCRIPTION
## ✅ 작업 내용

- signup Page에 접근 제한 기능 개발

## 🖊️ 구체적인 작업

### signup Page 외부 접근 제한 코드 작성

- github 로그인을 통해서 signup Page에 접근할 경우 tempIdToken을 전달받는다.
- 따라서 tempIdToken을 전달받지 않은 상태로 signup Page를 접근할 경우, 에러를 던지는 코드를 작성
- 이를 통해 외부 url을 통한 사이트 접근을 제한
- temp page에 가짜 tempIdToken을 전달하는 버튼의 경우 정상적으로 signup page에 접근이 가능
- 하지만, 일반적인 외부 방식으로 signup Page에 접근할 경우, "정상적이지 않은 접근입니다"의 에러 화면을 띄워줌

### logout 수정
- logout시 localStorage에 들어있는 모든 데이터를 삭제
