### PR TITLE
feat: 로컬 환경에서 깃허브 인증시 localhost 환경으로 리다이렉트 되도록 설정

### DIFF
--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -30,7 +30,7 @@ export class AuthController {
 
   @Get('github/authorization-server')
   getGithubAuthServerUrl(@Req() request: Request) {
-    const isLocal = request.headers.origin.includes('localhost');
+    const isLocal = request.headers.origin?.includes('localhost');
     return { authUrl: this.authService.getGithubAuthUrl(isLocal) };
   }
 

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -1,12 +1,12 @@
 import {
-	Body,
-	Controller,
-	Get,
-	InternalServerErrorException,
-	Post,
-	Req,
-	Res,
-	UnauthorizedException,
+  Body,
+  Controller,
+  Get,
+  InternalServerErrorException,
+  Post,
+  Req,
+  Res,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { CookieOptions, Response, Request } from 'express';
 import { AuthService } from '../service/auth.service';
@@ -14,31 +14,33 @@ import { MemberService } from 'src/member/service/member.service';
 import { GithubAuthenticationRequestDto } from './dto/GithubAuthenticationRequest.dto';
 import { GithubSignupRequestDto } from './dto/GithubSignupRequest.dto';
 import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
+
 @Controller('auth')
 export class AuthController {
-	constructor(
-		private readonly authService: AuthService,
-		private readonly memberService: MemberService,
-		) {}
-		private cookieOptions: CookieOptions = {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === 'LOCAL' ? false : true,
-			path: '/api/auth/',
-			sameSite: 'none',
-		};
-		
-		@Get('github/authorization-server')
-		getGithubAuthServerUrl() {
-			return { authUrl: this.authService.getGithubAuthUrl() };
-		}
-		
-		@Post('github/authentication')
-		async githubAuthentication(
-			@Body() body: GithubAuthenticationRequestDto,
-			@Res() response: Response,
-			) {
-				try {
-					const result = await this.authService.githubAuthentication(body.authCode);
+  constructor(
+    private readonly authService: AuthService,
+    private readonly memberService: MemberService,
+  ) {}
+  private cookieOptions: CookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'LOCAL' ? false : true,
+    path: '/api/auth/',
+    sameSite: 'none',
+  };
+
+  @Get('github/authorization-server')
+  getGithubAuthServerUrl(@Req() request: Request) {
+    const isLocal = request.headers.origin.includes('localhost');
+    return { authUrl: this.authService.getGithubAuthUrl(isLocal) };
+  }
+
+  @Post('github/authentication')
+  async githubAuthentication(
+    @Body() body: GithubAuthenticationRequestDto,
+    @Res() response: Response,
+  ) {
+    try {
+      const result = await this.authService.githubAuthentication(body.authCode);
       if ('accessToken' in result && 'refreshToken' in result) {
         const { accessToken, refreshToken } = result;
         const { username, githubImageUrl } =

--- a/backend/src/auth/service/auth.service.spec.ts
+++ b/backend/src/auth/service/auth.service.spec.ts
@@ -91,7 +91,7 @@ describe('Auth Service Unit Test', () => {
     it('should return a valid GitHub authorization URL', async () => {
       jest.spyOn(configService, 'get').mockReturnValue('client_id');
 
-      const authUrl = authService.getGithubAuthUrl();
+      const authUrl = authService.getGithubAuthUrl(false);
 
       const urlPattern = new RegExp(
         `^https://github.com/login/oauth/authorize\\?client_id=[\\w]+&scope=[\\w]*$`,

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -10,9 +10,9 @@ import { GithubUserDto } from './dto/github-user.dto';
 import { TempMember } from '../entity/tempMember.entity';
 import { LoginMember } from '../entity/loginMember.entity';
 import {
-	GITHUB_CLIENT_ID,
-	GITHUB_CLIENT_SECRETS,
-  } from 'src/lesser-config/constants';
+  GITHUB_CLIENT_ID,
+  GITHUB_CLIENT_SECRETS,
+} from 'src/lesser-config/constants';
 
 @Injectable()
 export class AuthService {
@@ -26,9 +26,12 @@ export class AuthService {
   ) {}
   private readonly ENV_GITHUB_CLIENT_ID =
     this.configService.get(GITHUB_CLIENT_ID);
+  private readonly GITHUB_AUTH_URL = `https://github.com/login/oauth/authorize?client_id=${this.ENV_GITHUB_CLIENT_ID}&scope=`;
 
-  getGithubAuthUrl(): string {
-    return `https://github.com/login/oauth/authorize?client_id=${this.ENV_GITHUB_CLIENT_ID}&scope=`;
+  getGithubAuthUrl(isLocal: boolean): string {
+    if (isLocal)
+      return `${this.GITHUB_AUTH_URL}&redirect_uri=https://dev.lesser-project.site/auth/github/callback/local`;
+    return this.GITHUB_AUTH_URL;
   }
 
   async githubAuthentication(

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -49,7 +49,7 @@ const router = createBrowserRouter([
       ]),
       createPublicRouter([
         {
-          path: ROUTER_URL.AUTH,
+          path: `${ROUTER_URL.AUTH}/*`,
           element: <AuthPage />,
         },
       ]),

--- a/frontend/src/pages/login/AuthPage.tsx
+++ b/frontend/src/pages/login/AuthPage.tsx
@@ -5,7 +5,7 @@ const AuthPage = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code");
 
-  const isLocal = window.location.pathname.split("/").pop() == "local";
+  const isLocal = window.location.pathname.split("/").pop() === "local";
   if (isLocal) {
     window.location.href = `http://localhost:5173/auth/github/callback?code=${code}`;
     return;

--- a/frontend/src/pages/login/AuthPage.tsx
+++ b/frontend/src/pages/login/AuthPage.tsx
@@ -5,6 +5,12 @@ const AuthPage = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code");
 
+  const isLocal = window.location.pathname.split("/").pop() == "local";
+  if (isLocal) {
+    window.location.href = `http://localhost:5173/auth/github/callback?code=${code}`;
+    return;
+  }
+
   if (!code) {
     return <div>Login 에러</div>;
   }


### PR DESCRIPTION
## 🎟️ 태스크

[로컬 환경에서 깃허브 인증시 localhost 환경으로 리다이렉트](https://plastic-toad-cb0.notion.site/localhost-726acf5f018f4db5abc0b1579a276a08?pvs=74)

## ✅ 작업 내용

- [로컬 환경에서 깃허브 인증시 localhost 환경으로 리다이렉트 되도록 설정](https://github.com/boostcampwm2023/web10-Lesser/commit/61066125d4e9daa7f8d4fce7937131fb42d3f3f7)
- [request.headers.origin 값에 optional chaining 적용](https://github.com/boostcampwm2023/web10-Lesser/commit/b298109313d6072d4c366ffb1f2f639583185e79)

## 🖊️ 구체적인 작업

### 로컬 환경에서 깃허브 인증시 localhost 환경으로 리다이렉트 되도록 설정
- 프론트엔드 개발환경의 편의를 위해 localhost에서 개발할 때 깃허브 인증시 localhost로 리다이렉트되도록 설정
- 로컬 환경에서 깃허브 인증시 `localhost:5173/auth/github/callback` 로 리다이렉트한다.
- 원격 환경에서 깃허브 인증시 `dev.lesser-project.site/auth/github/callback` 로 리다이렉트한다.

### request.headers.origin 값에 optional chaining 적용
- same-site 요청은 request.headers.origin 값이 undefined이므로, includes 메서드에서 오류가 발생하지 않도록 optional chaining 적용
```ts
  @Get('github/authorization-server')
  getGithubAuthServerUrl(@Req() request: Request) {
    const isLocal = request.headers.origin?.includes('localhost');
    return { authUrl: this.authService.getGithubAuthUrl(isLocal) };
  }
```


## 💡 문제 해결 과정
    
- 문제 및 요구사항 정의, 해결한 방법, 트러블슈팅과 관련하여 [개발일지: 서버로 되어있는 GitHub OAuth 콜백 URL을 바꾸지 않고 로컬로 리다이렉트 시키기](https://plastic-toad-cb0.notion.site/github-OAuth-redirect_url-b70e841cf8aa4cca8727b4a5665db0ae)에 기록했습니다.