### PR TITLE
feat : PublicRouter, PrivateRouter 함수 개선

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -6,20 +6,16 @@ import GlobalErrorBoundary from "./GlobalErrorBoundary";
 import PrivateRoute from "./components/common/route/PrivateRoute";
 import PublicRoute from "./components/common/route/PublicRoute";
 
-const createPrivateRouter = (children: RouteObject[]) => {
-  const privateRoute = {
-    element: <PrivateRoute />,
-    children,
-  };
-  return privateRoute;
-};
+type RouteType = "PRIVATE" | "PUBLIC";
 
-const createPublicRouter = (children: RouteObject[]) => {
-  const publicRoute = {
-    element: <PublicRoute />,
-    children,
-  };
-  return publicRoute;
+const createAuthCheckRouter = (routeType: RouteType, children: RouteObject[]) => {
+  const authCheckRouter = children.map((child: RouteObject) => {
+    return {
+      element: routeType === "PRIVATE" ? <PrivateRoute /> : <PublicRoute />,
+      children: [child],
+    };
+  });
+  return authCheckRouter;
 };
 
 const router = createBrowserRouter([
@@ -35,25 +31,21 @@ const router = createBrowserRouter([
         index: true,
         element: <TempHomepage />,
       },
-      createPublicRouter([
+      ...createAuthCheckRouter("PUBLIC", [
         {
           path: ROUTER_URL.LOGIN,
           element: <LoginPage />,
         },
-      ]),
-      createPublicRouter([
         {
           path: ROUTER_URL.SIGNUP,
           element: <SignupPage />,
         },
-      ]),
-      createPublicRouter([
         {
           path: `${ROUTER_URL.AUTH}/*`,
           element: <AuthPage />,
         },
       ]),
-      createPrivateRouter([
+      ...createAuthCheckRouter("PRIVATE", [
         {
           path: ROUTER_URL.PROJECTS,
           element: <ProjectsPage />,

--- a/frontend/src/apis/api/loginAPI.ts
+++ b/frontend/src/apis/api/loginAPI.ts
@@ -4,6 +4,7 @@ import {
   AccessTokenResponse,
   AuthenticationDTO,
   GithubOauthUrlDTO,
+  RefreshDTO,
   TempIdTokenResponse,
 } from "../../types/authDTO";
 import { useNavigate } from "react-router-dom";
@@ -41,4 +42,9 @@ export const postLogout = async () => {
     window.localStorage.clear();
     return response;
   }
+};
+
+export const postRefresh = async () => {
+  const response = await authAPI.post<RefreshDTO>(API_URL.REFRESH);
+  setAccessToken(response.data.accessToken);
 };

--- a/frontend/src/apis/utils/authAPI.ts
+++ b/frontend/src/apis/utils/authAPI.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import { API_URL, BASE_URL } from "../../constants/path";
-import { AccessTokenResponse } from "../../types/authDTO";
+import { RefreshDTO } from "../../types/authDTO";
 
 let accessToken: string | undefined;
 
@@ -44,7 +44,7 @@ const failResponse = async (error: AxiosError) => {
     }
 
     try {
-      const response = await authAPI.post<AccessTokenResponse>(API_URL.REFRESH);
+      const response = await authAPI.post<RefreshDTO>(API_URL.REFRESH);
       successRefresh(response.data.accessToken, error.config);
     } catch {
       unauthorizedErrorRetry = 0;
@@ -63,7 +63,6 @@ const successRefresh = async (
   if (config) {
     config.headers["Authorization"] = `Bearer ${newAccessToken}`;
     const newResponse = await authAPI(config);
-
     return newResponse;
   }
 };

--- a/frontend/src/components/common/route/PrivateRoute.tsx
+++ b/frontend/src/components/common/route/PrivateRoute.tsx
@@ -5,20 +5,20 @@ import { useErrorBoundary } from "react-error-boundary";
 import RouteLoading from "./RouteLoading";
 
 const PrivateRoute = (): React.ReactElement => {
-  const [isLoading, setIsLoading] = useState<Boolean>(false);
+  const [isLoading, setIsLoading] = useState<Boolean>(true);
   const { showBoundary } = useErrorBoundary();
 
   useEffect(() => {
     checkAuthentication().then((result: Boolean | unknown) => {
       if (result === true) {
-        setIsLoading(true);
+        setIsLoading(false);
       } else {
         showBoundary(result);
       }
     });
   }, [checkAuthentication]);
 
-  return isLoading ? <Outlet /> : <RouteLoading />;
+  return isLoading ? <RouteLoading /> : <Outlet />;
 };
 
 export default PrivateRoute;

--- a/frontend/src/components/common/route/PrivateRoute.tsx
+++ b/frontend/src/components/common/route/PrivateRoute.tsx
@@ -5,20 +5,20 @@ import { useErrorBoundary } from "react-error-boundary";
 import RouteLoading from "./RouteLoading";
 
 const PrivateRoute = (): React.ReactElement => {
-  const [isLoading, setIsLoading] = useState<Boolean>(true);
+  const [loadingState, setLoadingState] = useState<Boolean>(true);
   const { showBoundary } = useErrorBoundary();
 
   useEffect(() => {
     checkAuthentication().then((result: Boolean | unknown) => {
       if (result === true) {
-        setIsLoading(false);
+        setLoadingState(false);
       } else {
         showBoundary(result);
       }
     });
   }, [checkAuthentication]);
 
-  return isLoading ? <RouteLoading /> : <Outlet />;
+  return loadingState ? <RouteLoading /> : <Outlet />;
 };
 
 export default PrivateRoute;

--- a/frontend/src/components/common/route/PublicRoute.tsx
+++ b/frontend/src/components/common/route/PublicRoute.tsx
@@ -5,22 +5,22 @@ import { Navigate, Outlet } from "react-router-dom";
 import { ROUTER_URL } from "../../../constants/path";
 
 const PublicRoute = () => {
-  const [isLoading, setIsLoading] = useState<Boolean>(false);
+  const [loadingState, setLoadingState] = useState<Boolean>(true);
   const [authenticated, setAuthenticated] = useState<Boolean>(false);
 
   useEffect(() => {
     checkAuthentication().then((result) => {
       if (result === true) {
-        setIsLoading(true);
+        setLoadingState(false);
         setAuthenticated(true);
       } else {
-        setIsLoading(true);
+        setLoadingState(false);
         setAuthenticated(false);
       }
     });
   }, [checkAuthentication]);
 
-  return !isLoading ? (
+  return loadingState ? (
     <RouteLoading />
   ) : !authenticated ? (
     <Outlet />

--- a/frontend/src/utils/route/checkAuthentication.ts
+++ b/frontend/src/utils/route/checkAuthentication.ts
@@ -1,13 +1,10 @@
-import { authAPI, checkAccessToken, setAccessToken } from "../../apis/utils/authAPI";
-import { API_URL } from "../../constants/path";
-import { RefreshDTO } from "../../types/authDTO";
+import { postRefresh } from "../../apis/api/loginAPI";
+import { checkAccessToken } from "../../apis/utils/authAPI";
 
 const checkAuthentication = async (): Promise<boolean | unknown> => {
   if (checkAccessToken()) return true;
-
   try {
-    const response = await authAPI.post<RefreshDTO>(API_URL.REFRESH);
-    setAccessToken(response.data.accessToken);
+    await postRefresh();
     return true;
   } catch (error) {
     return error;


### PR DESCRIPTION
## ✅ 작업 내용

- PrivateRouter, PublicRouter를 적용하는 함수의 개선
- 헷갈리게 사용한 isLoading 변수명을 loadingState로 변경

## 🖊️ 구체적인 작업

### PrivateRouter, PublicRouter를 적용하는 함수의 개선

- 기존의 PrivateRouter, PublicRouter를 사용하기 위해선 적용되는 페이지를 모두 Router 혹은 기존에 만들었던 Router 함수로 감싸야 했습니다. 이러한 형태의 코드는 읽기 어려울 뿐만 아니라, 작성하고 유지보수하는데에도 많은 수고를 들이게 했습니다.
- 따라서, PrivateRouter 및 PublicRouter를 한번에 적용하는 형태의 코드를 개발하여, PrivateRouter 혹은 PublicRouter를 적용해야 하는 페이지를 함수안에 모아서 호출하여 사용할 수 있도록 코드를 개선했습니다.
```typescript
// PublicRoute 검사가 필요한 페이지는 이 함수의 파라미터로 전달
...createAuthCheckRouter("PUBLIC", [
  {
    path: ROUTER_URL.LOGIN,
    element: <LoginPage />,
  },
  {
    path: ROUTER_URL.SIGNUP,
    element: <SignupPage />,
  },
  {
    path: `${ROUTER_URL.AUTH}/*`,
    element: <AuthPage />,
  },
]),
// PrivateRoute 검사가 필요한 페이지는 이 함수의 파라미터로 전달
...createAuthCheckRouter("PRIVATE", [
  {
    path: ROUTER_URL.PROJECTS,
    element: <ProjectsPage />,
  },
]),
```
