### PR TITLE
feat: 예외처리 필터 구현 및 컨트롤러 리팩토링

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,8 @@ import { LoginMember } from './auth/entity/loginMember.entity';
 import { ProjectModule } from './project/project.module';
 import * as cookieParser from 'cookie-parser';
 import { BearerTokenMiddleware } from './common/middleware/parse-bearer-token.middleware';
+import { APP_FILTER } from '@nestjs/core';
+import { ErrorExceptionFilter } from './common/exception-filter/exception.filter';
 
 @Module({
   imports: [
@@ -45,7 +47,13 @@ import { BearerTokenMiddleware } from './common/middleware/parse-bearer-token.mi
     ProjectModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_FILTER,
+      useClass: ErrorExceptionFilter,
+    },
+  ],
 })
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -58,25 +58,31 @@ export class AuthService {
   }
 
   async getAccessToken(authCode: string) {
+    const body = {
+      client_id: this.configService.get(GITHUB_CLIENT_ID),
+      client_secret: this.configService.get(GITHUB_CLIENT_SECRETS),
+      code: authCode,
+    };
     try {
-      const body = {
-        client_id: this.configService.get(GITHUB_CLIENT_ID),
-        client_secret: this.configService.get(GITHUB_CLIENT_SECRETS),
-        code: authCode,
-      };
-      const { access_token } =
-        await this.githubApiService.fetchAccessToken(body);
-      if (!access_token) throw new Error('Invalid authorization code');
+      const { access_token } = await this.githubApiService
+        .fetchAccessToken(body)
+        .catch(() => {
+          throw new Error('Github fetch access token API error');
+        });
+      if (!access_token) throw new Error('Invalid auth code');
       return access_token;
-    } catch (err) {
+    } catch {
       throw new Error('Cannot retrieve access token');
     }
   }
 
   async getGithubUser(accessToken: string) {
     try {
-      const { id, login, avatar_url } =
-        await this.githubApiService.fetchGithubUser(accessToken);
+      const { id, login, avatar_url } = await this.githubApiService
+        .fetchGithubUser(accessToken)
+        .catch(() => {
+          throw new Error('Github fetch user API error');
+        });
       const githubUser = GithubUserDto.of(id, login, avatar_url);
       return githubUser;
     } catch (err) {

--- a/backend/src/common/exception-filter/exception.filter.ts
+++ b/backend/src/common/exception-filter/exception.filter.ts
@@ -1,0 +1,67 @@
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { STATUS_CODES } from 'http';
+
+@Catch(Error)
+export class ErrorExceptionFilter implements ExceptionFilter {
+  catch(exception: Error, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const message = exception.message;
+      response.status(status).json({
+        statusCode: status,
+        error: STATUS_CODES[status],
+        message: message,
+      });
+      return;
+    }
+
+    const errorMessage = exception.message;
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = errorMessage;
+    switch (errorMessage) {
+      case 'Cannot retrieve access token':
+      case 'Cannot retrieve github user':
+        status = HttpStatus.UNAUTHORIZED;
+        message = 'Invalid authorization code';
+        break;
+
+      case 'Failed to verify token: tempId':
+      case 'tempIdToken does not match':
+        status = HttpStatus.UNAUTHORIZED;
+        message = 'Expired:tempIdToken';
+        break;
+
+      case 'Failed to verify token: access':
+        status = HttpStatus.UNAUTHORIZED;
+        message = 'Expired:accessToken';
+        break;
+
+      case 'Failed to verify token: refresh':
+      case 'No matching refresh token':
+        status = HttpStatus.UNAUTHORIZED;
+        message = 'Expired:refreshToken';
+        break;
+
+      case 'Not a logged in member':
+        status = HttpStatus.UNAUTHORIZED;
+        message = 'Not a logged in member';
+        break;
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      error: STATUS_CODES[status],
+      message,
+    });
+  }
+}

--- a/backend/src/lesser-jwt/lesser-jwt.service.spec.ts
+++ b/backend/src/lesser-jwt/lesser-jwt.service.spec.ts
@@ -59,18 +59,32 @@ describe('LesserJwtService', () => {
       expect(payload.sub).toEqual(sub);
     });
 
-    it('should throw error when given invalid token', async () => {
+    it('should throw error when given invalid access token', async () => {
       const token = 'invalid token';
       await expect(
         async () => await lesserJwtService.getPayload(token, 'access'),
-      ).rejects.toThrow();
+      ).rejects.toThrow('Failed to verify token: access');
+    });
+
+    it('should throw error when given invalid refresh token', async () => {
+      const token = 'invalid token';
+      await expect(
+        async () => await lesserJwtService.getPayload(token, 'refresh'),
+      ).rejects.toThrow('Failed to verify token: refresh');
+    });
+
+    it('should throw error when given invalid tempId token', async () => {
+      const token = 'invalid token';
+      await expect(
+        async () => await lesserJwtService.getPayload(token, 'tempId'),
+      ).rejects.toThrow('Failed to verify token: tempId');
     });
 
     it('should throw error when given expired token', async () => {
       const token = jwtService.sign({ sub: 1 }, { expiresIn: '-1' });
       await expect(
         async () => await lesserJwtService.getPayload(token, 'access'),
-      ).rejects.toThrow();
+      ).rejects.toThrow('Failed to verify token: access');
     });
 
     it('should throw error when token type miss-match', async () => {

--- a/backend/src/lesser-jwt/lesser-jwt.service.ts
+++ b/backend/src/lesser-jwt/lesser-jwt.service.ts
@@ -5,19 +5,19 @@ import { JwtService } from '@nestjs/jwt';
 export class LesserJwtService {
   constructor(private readonly jwtService: JwtService) {}
   createAccessToken(id: number): Promise<string> {
-    const payload = { sub: { id }, tokenType: 'access' };
+    const payload = { sub: { id }, tokenType: 'access', iat: Date.now() };
     const options = { expiresIn: '15m' };
     return this.jwtService.signAsync(payload, options);
   }
 
   createRefreshToken(id: number): Promise<string> {
-    const payload = { sub: { id }, tokenType: 'refresh' };
+    const payload = { sub: { id }, tokenType: 'refresh', iat: Date.now() };
     const options = { expiresIn: '1d' };
     return this.jwtService.signAsync(payload, options);
   }
 
   createTempIdToken(uuid: string): Promise<string> {
-    const payload = { sub: { uuid }, tokenType: 'tempId' };
+    const payload = { sub: { uuid }, tokenType: 'tempId', iat: Date.now() };
     const options = { expiresIn: '30m' };
     return this.jwtService.signAsync(payload, options);
   }

--- a/backend/src/lesser-jwt/lesser-jwt.service.ts
+++ b/backend/src/lesser-jwt/lesser-jwt.service.ts
@@ -28,7 +28,7 @@ export class LesserJwtService {
       if (payload.tokenType !== type) throw Error('Invalid token type');
       return payload;
     } catch (error) {
-      throw new Error('Failed to verify token');
+      throw new Error(`Failed to verify token: ${type}`);
     }
   }
 }

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -3,7 +3,6 @@ import {
   Get,
   Query,
   BadRequestException,
-  InternalServerErrorException,
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -22,22 +21,17 @@ export class MemberController {
     } catch (err) {
       if (err.message === 'duplicate username')
         return { available: false, message: err.message };
-      throw new InternalServerErrorException(err.message);
     }
   }
+
   @Get('/')
   async getMember(@Req() request: BearerTokenRequest) {
     const accessToken = request.token;
     if (!accessToken)
       throw new UnauthorizedException('Bearer Token is missing');
-    try {
-      const { username, githubImageUrl } =
-        await this.memberService.getMemberPublicInfo(accessToken);
-      return { username, imageUrl: githubImageUrl };
-    } catch (err) {
-      if (err.message === 'Failed to verify token')
-        throw new UnauthorizedException('Expired:accessToken');
-      throw new InternalServerErrorException(err.message);
-    }
+
+    const { username, githubImageUrl } =
+      await this.memberService.getMemberPublicInfo(accessToken);
+    return { username, imageUrl: githubImageUrl };
   }
 }

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  Get,
-  Req,
-  UnauthorizedException,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { Controller, Get, Req, UnauthorizedException } from '@nestjs/common';
 import { projectFixtures } from 'fixtures/project-fixtures';
 import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
 
@@ -18,14 +12,10 @@ export class ProjectController {
     const accessToken = request.token;
     if (!accessToken)
       throw new UnauthorizedException('Bearer Token is missing');
-    try {
-      // access token 검증을 위한 임시 로직
-      await this.lesserJwtService.getPayload(accessToken, 'access');
-    } catch (err) {
-      if (err.message === 'Failed to verify token')
-        throw new UnauthorizedException('Expired:accessToken');
-      throw new InternalServerErrorException(err.message);
-    }
+
+    // access token 검증을 위한 임시 로직
+    await this.lesserJwtService.getPayload(accessToken, 'access');
+
     return { projects: projectFixtures };
   }
 }

--- a/backend/test/auth/github-authentication.e2e-spec.ts
+++ b/backend/test/auth/github-authentication.e2e-spec.ts
@@ -44,11 +44,28 @@ describe('POST /api/auth/github/authentication', () => {
     expect(response.status).toBe(400);
   });
 
-  it('should return 401', async () => {
-    jest.spyOn(githubApiService, 'fetchAccessToken').mockResolvedValue({});
+  it('should return 401 when given fetch github access token error', async () => {
+    jest
+      .spyOn(githubApiService, 'fetchAccessToken')
+      .mockRejectedValue(undefined);
     const response = await request(app.getHttpServer())
       .post('/api/auth/github/authentication')
       .send({ authCode: 'invalidAuthCode' });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 401 when given fetch github user error', async () => {
+    jest
+      .spyOn(githubApiService, 'fetchAccessToken')
+      .mockResolvedValue({ access_token: 'accessToken' });
+    jest
+      .spyOn(githubApiService, 'fetchGithubUser')
+      .mockRejectedValue(undefined);
+
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/authentication')
+      .send({ authCode: 'authCode' });
 
     expect(response.status).toBe(401);
   });

--- a/backend/test/auth/github-signup.e2e-spec.ts
+++ b/backend/test/auth/github-signup.e2e-spec.ts
@@ -48,12 +48,32 @@ describe('POST /api/auth/github/signup', () => {
     expect(response.body.message).toBe('Bearer Token is missing');
   });
 
-  it('should return 401 (Expired:tempIdToken)', async () => {
+  it('should return 401 (Expired:tempIdToken) when given invalid temp id token', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/auth/github/signup')
       .set('Authorization', `Bearer invalidToken`)
       .send(memberSignupPayload);
 
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:tempIdToken');
+  });
+
+  it('should return 401 (Expired:tempIdToken) when given not matching temp id token', async () => {
+    const {
+      body: { tempIdToken },
+    } = await request(app.getHttpServer())
+      .post('/api/auth/github/authentication')
+      .send({ authCode: 'authCode' });
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await request(app.getHttpServer())
+      .post('/api/auth/github/authentication')
+      .send({ authCode: 'authCode' });
+
+    const response = await request(app.getHttpServer())
+      .post('/api/auth/github/signup')
+      .set('Authorization', `Bearer ${tempIdToken}`)
+      .send(memberSignupPayload);
     expect(response.status).toBe(401);
     expect(response.body.message).toBe('Expired:tempIdToken');
   });

--- a/backend/test/auth/github-signup.e2e-spec.ts
+++ b/backend/test/auth/github-signup.e2e-spec.ts
@@ -65,7 +65,6 @@ describe('POST /api/auth/github/signup', () => {
       .post('/api/auth/github/authentication')
       .send({ authCode: 'authCode' });
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     await request(app.getHttpServer())
       .post('/api/auth/github/authentication')
       .send({ authCode: 'authCode' });


### PR DESCRIPTION
## 🎟️ 태스크

[백엔드 예외처리 필터 만들기](https://plastic-toad-cb0.notion.site/cfa3e5bdaf4a4f8a851238c58fe84f45)

## ✅ 작업 내용

- [예외처리 필터 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/6dd2615beccf8a605edb125fec3239a6965df482)
- [JWT 검증에서 에러 발생시 어떤 토큰인지 알 수 있도록 토큰 타입을 에러 메시지에 명시](https://github.com/boostcampwm2023/web10-Lesser/commit/21a02d1e9b7cda9c9980792557a41bc136fb25b4)
- [깃허브 외부 API에서 발생하는 에러를 처리할 수 있도록 catch문 추가](https://github.com/boostcampwm2023/web10-Lesser/commit/75a295138a339f1f691c3a4643f8a46f1dd16f4a)
- [e2e 테스트 추가](https://github.com/boostcampwm2023/web10-Lesser/commit/c9b53d6e75b4c2780a7747b3a82b6fa15e32936c)
- [컨트롤러에서 반복되는 에러처리 로직 제거](https://github.com/boostcampwm2023/web10-Lesser/commit/603e954dedc48941e36e6ff597ff3e502cf0a888)
- [JWT 토큰 발행시간(iat)을 ms 단위로 설정](https://github.com/boostcampwm2023/web10-Lesser/pull/253/commits/067ae4368e591c7b4731c7e051590c7d3ad2450a)

## 🖊️ 구체적인 작업

### ⭐️ 예외처리 필터 구현
- [개발일지: Nest 커스텀 필터 적용하기](https://plastic-toad-cb0.notion.site/Nest-7b9c56ced88944d8a08653d1143c4ff9?pvs=74)
- NestJS app에서 발생하는 모든 Error를 ErrorExceptionFilter에서 catch
- 잡힌 Error가 컨트롤러에서 발생시킨 HttpException인 경우에는 해당 exception의 status, message를 그대로 응답
- HttpException이 아닌 경우 exception의 에러 메시지에 따라 status, message 설정하여 응답

### JWT 검증에서 에러 발생시 어떤 토큰인지 알 수 있도록 토큰 타입을 에러 메시지에 명시
- access, refresh, tempId 중 어느 토큰 검증 과정에서 발생한 에러인지 알 수 있어야 예외처리 필터에서 각 상황에 맞는 HttpException을 발생시킬 수 있으므로, 에러 메시지에 토큰 타입을 명시하도록 수정하였다.
  ```ts
  throw new Error(`Failed to verify token: ${type}`);
   ```
- 서비스 로직 변경에 따른 단위테스트를 추가하였다.

### 깃허브 외부 API에서 발생하는 에러를 처리할 수 있도록 catch문 추가
- [개발일지: async/await with try/catch](https://plastic-toad-cb0.notion.site/async-await-with-try-catch-bd042f6f394e4d02ad95c2022288c2d0)
- 깃허브 API 같은 외부 API를 fetch 메서드로 호출할 때 발생하는 네트워크 에러를 커스텀 에러로 핸들링할 수 있도록 fetch 메서드에서 발생하는 reject를 잡을 수 있는 catch문을 추가하였다. 
  ```ts
  const { access_token } = await this.githubApiService
    .fetchAccessToken(body)
    .catch(() => {
      throw new Error('Github fetch access token API error');
    });
  ```

### e2e 테스트 추가
- 외부 깃허브 API를 호출하는 fetchAccessToken, fetchGithubUser 서비스에서 reject 발생하는 경우 401 에러를 반환하는지 테스트
- tempIdToken 업데이트 후, 이전 tempIdToken으로 회원가입을 시도하면 401 에러를 반환하는지 테스트

### ⭐️ 컨트롤러에서 반복되는 에러처리 로직 제거
- 예외처리 필터 적용 이전
  ```ts
  try {
    await this.authService.logout(accessToken);
  } catch (err) {
    if (err.message === 'Not a logged in member') {
      throw new UnauthorizedException('Not a logged in member');
    }
    if (err.message === 'Failed to verify token') {
      throw new UnauthorizedException('Expired:accessToken');
    }
    throw new InternalServerErrorException(err.message);
  }
  ```
- 예외처리 필터 적용 이후
  ```ts
  await this.authService.logout(accessToken);
  ```

## 🤔 고민 및 의논할 거리
    
- e2e 테스트에서 값이 서로 다른 JWT 토큰을 발행하기 위해 1초 후 새로운 토큰을 발행하는 로직을 사용했다. 현재 e2e 테스트는 테스트 간에 영향을 주지 않도록 테스트를 동기적으로 실행(jest의 --runInBand 속성 사용)하고 있기 때문에 테스트 전체가 1초 블로킹된다. 테스트 시간 효율적으로 사용할 방법에 대해 논의해보았다. 
- 기존에는 JWT 토큰 발행시간이 초(s) 단위로 발행되었기 때문에 값이 서로 다른 JWT 토큰을 발행하려면 적어도 1초 뒤에 토큰을 발행해야했다. 토큰 발행시간이 ms 단위로 설정되도록 수정함으로써 1초를 기다리지 않아도 서로 다른 값을 가지는 토큰을 발행할 수 있었다.
- 이에 따라 e2e 테스트 실행 시간을 1초 이상 단축시킬 수 있었다.
  - JWT 토큰 발행시간 수정 전 e2e 테스트
  ![image](https://github.com/boostcampwm2023/web10-Lesser/assets/109324498/4af63400-94a2-4fea-8d4f-31fa6c8b7ed9)
  - JWT 토큰 발행시간 수정 후 e2e 테스트
  ![image](https://github.com/boostcampwm2023/web10-Lesser/assets/109324498/b4ee2a6b-6800-422d-aecf-1c598627812e)
