### PR TITLE
feat: 프로젝트 생성 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,8 @@ import { TempMember } from './auth/entity/tempMember.entity';
 import { MemberModule } from './member/member.module';
 import { Member } from './member/entity/member.entity';
 import { LoginMember } from './auth/entity/loginMember.entity';
+import { Project } from './project/entity/project.entity';
+import { ProjectToMember } from './project/entity/project-member.entity';
 import { ProjectModule } from './project/project.module';
 import * as cookieParser from 'cookie-parser';
 import { BearerTokenMiddleware } from './common/middleware/parse-bearer-token.middleware';
@@ -35,7 +37,7 @@ import { ErrorExceptionFilter } from './common/exception-filter/exception.filter
         username: ConfigService.get(DATABASE_USER),
         password: ConfigService.get(DATABASE_PASSWORD),
         database: ConfigService.get(DATABASE_NAME),
-        entities: [Member, TempMember, LoginMember],
+        entities: [Member, TempMember, LoginMember, Project, ProjectToMember],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),
     }),

--- a/backend/src/member/entity/member.entity.ts
+++ b/backend/src/member/entity/member.entity.ts
@@ -1,3 +1,4 @@
+import { ProjectToMember } from 'src/project/entity/project-member.entity';
 import {
   Column,
   Entity,
@@ -5,6 +6,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  OneToMany,
 } from 'typeorm';
 
 @Entity()
@@ -31,6 +33,9 @@ export class Member {
 
   @Column({ type: 'json', nullable: false })
   tech_stack: object;
+
+  @OneToMany(() => ProjectToMember, (projectToMember) => projectToMember.member)
+  projectToMember: ProjectToMember;
 
   @CreateDateColumn({ type: 'timestamp' })
   created_at: Date;

--- a/backend/src/project/dto/CreateProjectRequest.dto.ts
+++ b/backend/src/project/dto/CreateProjectRequest.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateProjectRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(256, { message: 'Title is too long' })
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(256, { message: 'Subject is too long' })
+  subject: string;
+}

--- a/backend/src/project/entity/project-member.entity.ts
+++ b/backend/src/project/entity/project-member.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+import { Member } from 'src/member/entity/member.entity';
+
+@Entity()
+export class ProjectToMember {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Project, (project) => project.id, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @ManyToOne(() => Member, (member) => member.id, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'member_id' })
+  member: Member;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  static of(project: Project, member: Member) {
+    const newProjectToMember = new ProjectToMember();
+    newProjectToMember.project = project;
+    newProjectToMember.member = member;
+    return newProjectToMember;
+  }
+}

--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToMany,
+} from 'typeorm';
+import { ProjectToMember } from './project-member.entity';
+
+@Entity()
+export class Project {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  id: number;
+
+  @Column({ type: 'varchar', length: 256, nullable: false })
+  title: string;
+
+  @Column({ type: 'varchar', length: 256, nullable: false })
+  subject: string;
+
+  @OneToMany(
+    () => ProjectToMember,
+    (projectToMember) => projectToMember.project,
+  )
+  projectToMember: ProjectToMember[];
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  static of(title: string, subject: string) {
+    const newProject = new Project();
+    newProject.title = title;
+    newProject.subject = subject;
+    return newProject;
+  }
+}

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -1,12 +1,25 @@
-import { Controller, Get, Req, UnauthorizedException } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { projectFixtures } from 'fixtures/project-fixtures';
 import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
-
 import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
+import { MemberRepository } from 'src/member/repository/member.repository';
+import { ProjectService } from './service/project.service';
+import { CreateProjectRequestDto } from './dto/CreateProjectRequest.dto';
 
 @Controller('project')
 export class ProjectController {
-  constructor(private readonly lesserJwtService: LesserJwtService) {}
+  constructor(
+    private readonly lesserJwtService: LesserJwtService,
+    private readonly projectService: ProjectService,
+    private readonly memberRepository: MemberRepository,
+  ) {}
   @Get('/')
   async getProjectList(@Req() request: BearerTokenRequest) {
     const accessToken = request.token;
@@ -17,5 +30,24 @@ export class ProjectController {
     await this.lesserJwtService.getPayload(accessToken, 'access');
 
     return { projects: projectFixtures };
+  }
+
+  @Post('/')
+  async createProject(
+    @Req() request: BearerTokenRequest,
+    @Body() body: CreateProjectRequestDto,
+  ) {
+    const accessToken = request.token;
+    if (!accessToken)
+      throw new UnauthorizedException('Bearer Token is missing');
+
+    const {
+      sub: { id },
+    } = await this.lesserJwtService.getPayload(accessToken, 'access');
+    const member = await this.memberRepository.findById(id);
+    if (!member) throw new Error('assert: member must be found from database');
+
+    await this.projectService.createProject(member, body.title, body.subject);
+    return;
   }
 }

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -1,9 +1,20 @@
 import { Module } from '@nestjs/common';
 import { LesserJwtModule } from 'src/lesser-jwt/lesser-jwt.module';
 import { ProjectController } from './project.controller';
+import { ProjectService } from './service/project.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Project } from 'src/project/entity/project.entity';
+import { ProjectToMember } from 'src/project/entity/project-member.entity';
+import { Member } from 'src/member/entity/member.entity';
+import { ProjectRepository } from './project.repository';
+import { MemberRepository } from 'src/member/repository/member.repository';
 
 @Module({
-  imports: [LesserJwtModule],
+  imports: [
+    LesserJwtModule,
+    TypeOrmModule.forFeature([Project, ProjectToMember, Member]),
+  ],
   controllers: [ProjectController],
+  providers: [ProjectService, ProjectRepository, MemberRepository],
 })
 export class ProjectModule {}

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -1,0 +1,26 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Project } from './entity/project.entity';
+import { ProjectToMember } from './entity/project-member.entity';
+import { Member } from 'src/member/entity/member.entity';
+
+@Injectable()
+export class ProjectRepository {
+  constructor(
+    @InjectRepository(Project)
+    private readonly projectRepository: Repository<Project>,
+    @InjectRepository(ProjectToMember)
+    private readonly projectToMemberRepository: Repository<ProjectToMember>,
+  ) {}
+
+  create(project: Project): Promise<Project> {
+    return this.projectRepository.save(project);
+  }
+
+  addProjectMember(project: Project, member: Member): Promise<ProjectToMember> {
+    return this.projectToMemberRepository.save(
+      ProjectToMember.of(project, member),
+    );
+  }
+}

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectService } from './project.service';
+import { ProjectRepository } from '../project.repository';
+import { Member } from 'src/member/entity/member.entity';
+import { Project } from '../entity/project.entity';
+
+describe('ProjectService', () => {
+  let projectService: ProjectService;
+  let projectRepository: ProjectRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectService,
+        {
+          provide: ProjectRepository,
+          useValue: {
+            create: jest.fn(),
+            addProjectMember: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    projectService = module.get<ProjectService>(ProjectService);
+    projectRepository = module.get<ProjectRepository>(ProjectRepository);
+  });
+
+  describe('Create project', () => {
+    const member = Member.of(
+      1,
+      'githubUsername',
+      'imageUrl',
+      'username',
+      'position',
+      { stacks: ['js', 'ts'] },
+    );
+    const [title, subject] = ['title', 'subject'];
+    const project = Project.of(title, subject);
+
+    it('should return void when given member, title, subject', async () => {
+      jest.spyOn(projectRepository, 'create').mockResolvedValue(project);
+
+      await projectService.createProject(member, title, subject);
+
+      expect(projectRepository.create).toHaveBeenCalledWith(project);
+      expect(projectRepository.addProjectMember).toHaveBeenCalledWith(
+        project,
+        member,
+      );
+    });
+  });
+});

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { ProjectRepository } from '../project.repository';
+import { Member } from 'src/member/entity/member.entity';
+import { Project } from '../entity/project.entity';
+
+@Injectable()
+export class ProjectService {
+  constructor(private readonly projectRepository: ProjectRepository) {}
+
+  async createProject(member: Member, title: string, subject: string) {
+    const createdProject = await this.projectRepository.create(
+      Project.of(title, subject),
+    );
+    await this.projectRepository.addProjectMember(createdProject, member);
+  }
+}

--- a/backend/test/project/create-project.e2e-spec.ts
+++ b/backend/test/project/create-project.e2e-spec.ts
@@ -1,0 +1,49 @@
+import * as request from 'supertest';
+import { app, createMember, memberFixture } from 'test/setup';
+
+describe('POST /api/project', () => {
+  const createProjectPayload = {
+    title: 'Lesser',
+    subject: '애자일한 프로젝트 관리 툴',
+  };
+
+  it('should return 201', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+
+    const response = await request(app.getHttpServer())
+      .post('/api/project')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(createProjectPayload);
+
+    expect(response.status).toBe(201);
+  });
+
+  it('should return 400', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/project')
+      .send({
+        invalidProperty: 'invalidProperty',
+      });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 401 (Bearer Token is missing)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/project')
+      .send(createProjectPayload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Bearer Token is missing');
+  });
+
+  it('should return 401 (Expired:accessToken) when given invalid access token', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/project')
+      .set('Authorization', `Bearer invalidToken`)
+      .send(createProjectPayload);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:accessToken');
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 생성 API 구현](https://plastic-toad-cb0.notion.site/API-e40c5b055ddb4806bb4b25725dcd5a04?pvs=74)

## ✅ 작업 내용

- [Project 엔티티 생성 및 Member 엔티티와 다대다 관계 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/37b7f59193c06443c49bd2708d07e640a07d5721)
- [ProjectRepository 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/490483ba87ed00d93ec3600253c9af45ab945aa3)
- [프로젝트 생성하는 서비스 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/678282c24e2b1b8a3411e56fb311a0df174a9c70)
- [프로젝트 생성 API 컨트롤러 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/1521b48cd7be5e65f33fed27665f5de04a1351e6)
- [프로젝트 생성 API e2e 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/4e4182a152600df6391e8397f340603db8beeca0)

## 🖊️ 구체적인 작업

### Project 엔티티 생성 및 Member 엔티티와 다대다 관계 구현
- Project, Member 엔티티를 ProjectToMember 엔티티에 각각 OneToMany 관계로 연결하여 다대다 관계 구현

### ProjectRepository 구현
- 프로젝트 생성하는 create 메서드 구현
- 프로젝트 멤버를 추가하는 addProjectMember 메서드 구현

### 프로젝트 생성 API 서비스, 컨트롤러 로직 구현

### 프로젝트 생성 API e2e 테스트 작성

## 🤔 고민 및 의논할 거리

- 페어 프로그래밍 과정에서는 ProjectRepository와 ProjectToMemberRepository를 따로 만들었는데, ProjectRepository 안에서 ProjectToMember 엔티티와 관련한 처리까지 같이 하면 구조를 단순화할 수 있을 것 같아서 ProjectRepository에 `addProjectMember`라는 메서드를 만들었습니다. ProjectRepository 생성자에 projectToMemberRepository를 주입하고, 기존 ProjectToMemberRepository는 제거하였습니다.
  ```ts
  @Injectable()
  export class ProjectRepository {
    constructor(
      @InjectRepository(Project)
      private readonly projectRepository: Repository<Project>,
      @InjectRepository(ProjectToMember)
      private readonly projectToMemberRepository: Repository<ProjectToMember>,
    ) {}

    create(project: Project): Promise<Project> {
      return this.projectRepository.save(project);
    }

    addProjectMember(project: Project, member: Member): Promise<ProjectToMember> {
      return this.projectToMemberRepository.save(
        ProjectToMember.of(project, member),
      );
    }
  }
  ```
