### PR TITLE
feat: 회원의 프로젝트 목록 조회 API 구현

### DIFF
--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -26,10 +26,21 @@ export class ProjectController {
     if (!accessToken)
       throw new UnauthorizedException('Bearer Token is missing');
 
-    // access token 검증을 위한 임시 로직
-    await this.lesserJwtService.getPayload(accessToken, 'access');
+    const {
+      sub: { id },
+    } = await this.lesserJwtService.getPayload(accessToken, 'access');
+    const member = await this.memberRepository.findById(id);
+    if (!member) throw new Error('assert: member must be found from database');
 
-    return { projects: projectFixtures };
+    const projectList = await this.projectService.getProjectList(member);
+    const projects = projectList.map((project) => ({
+      id: project.id,
+      title: project.title,
+      createdAt: project.created_at,
+      currentSprint: null,
+    }));
+
+    return { projects };
   }
 
   @Post('/')

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -23,4 +23,11 @@ export class ProjectRepository {
       ProjectToMember.of(project, member),
     );
   }
+
+  getProjectList(member: Member): Promise<Project[]> {
+    return this.projectRepository.find({
+      where: { projectToMember: { member: { id: member.id } } },
+      relations: { projectToMember: true },
+    });
+  }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -17,6 +17,7 @@ describe('ProjectService', () => {
           useValue: {
             create: jest.fn(),
             addProjectMember: jest.fn(),
+            getProjectList: jest.fn(),
           },
         },
       ],
@@ -26,15 +27,15 @@ describe('ProjectService', () => {
     projectRepository = module.get<ProjectRepository>(ProjectRepository);
   });
 
+  const member = Member.of(
+    1,
+    'githubUsername',
+    'imageUrl',
+    'username',
+    'position',
+    { stacks: ['js', 'ts'] },
+  );
   describe('Create project', () => {
-    const member = Member.of(
-      1,
-      'githubUsername',
-      'imageUrl',
-      'username',
-      'position',
-      { stacks: ['js', 'ts'] },
-    );
     const [title, subject] = ['title', 'subject'];
     const project = Project.of(title, subject);
 
@@ -48,6 +49,23 @@ describe('ProjectService', () => {
         project,
         member,
       );
+    });
+  });
+
+  describe('Get project list', () => {
+    const projectList = [
+      Project.of('title1', 'subject1'),
+      Project.of('title2', 'subject2'),
+    ];
+    it('should return project list', async () => {
+      jest
+        .spyOn(projectRepository, 'getProjectList')
+        .mockResolvedValue(projectList);
+
+      const result = await projectService.getProjectList(member);
+
+      expect(projectRepository.getProjectList).toHaveBeenCalledWith(member);
+      expect(result).toEqual(projectList);
     });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -13,4 +13,8 @@ export class ProjectService {
     );
     await this.projectRepository.addProjectMember(createdProject, member);
   }
+
+  async getProjectList(member: Member): Promise<Project[]> {
+    return await this.projectRepository.getProjectList(member);
+  }
 }

--- a/backend/test/project/get-project.e2e-spec.ts
+++ b/backend/test/project/get-project.e2e-spec.ts
@@ -1,17 +1,37 @@
 import * as request from 'supertest';
 import { app, createMember, memberFixture } from 'test/setup';
-import { projectFixtures } from 'fixtures/project-fixtures';
 
 describe('GET /api/project', () => {
-  it('should return 200', async () => {
+  const projectPayloads = [
+    {
+      title: 'Lesser1',
+      subject: '애자일한 프로젝트 관리 툴',
+    },
+    {
+      title: 'Lesser2',
+      subject: '애자일한 프로젝트 관리 툴',
+    },
+  ];
+
+  it('should return 200, project list', async () => {
     const { accessToken } = await createMember(memberFixture, app);
+    for (const payload of projectPayloads) {
+      await request(app.getHttpServer())
+        .post('/api/project')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(payload);
+    }
 
     const response = await request(app.getHttpServer())
       .get('/api/project')
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(response.status).toBe(200);
-    expect(response.body.projects).toEqual(projectFixtures);
+    expect(response.body.projects).toBeDefined();
+    const projects = response.body.projects;
+    expect(projects.length).toBe(2);
+    expect(projects[0].title).toBe('Lesser1');
+    expect(projects[1].title).toBe('Lesser2');
   });
 
   it('should return 401 (Bearer Token is missing)', async () => {


### PR DESCRIPTION
## 🎟️ 태스크

[회원의 프로젝트 목록 조회 API 구현](https://plastic-toad-cb0.notion.site/API-0077d972a530456994457f3a2681906a)

## ✅ 작업 내용

- 기존의 더미데이터를 반환하는 프로젝트 목록 조회 API를 실제 데이터를 반환하도록 구현했습니다.
- [회원의 프로젝트 목록을 조회하는 서비스 로직 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/0ef0dac75617c466c6f151ef7a4e32794e3863ae)
- [회원의 프로젝트 목록 조회 API 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/a049270bcefecfa3a4dddfff15386c93a83e91f9)

## 🖊️ 구체적인 작업

### 회원의 프로젝트 목록을 조회하는 서비스 로직 구현
- member로 프로젝트 목록을 조회하는 레포지토리 메소드 구현 
  - [개발일지: TypeORM find 메서드 옵션(select, relations, where)](https://plastic-toad-cb0.notion.site/TypeORM-find-select-relations-where-d89278be2b4b44188e8b5e616f321ebc?pvs=74)
- 서비스 로직에 대한 단위 테스트 작성

### 회원의 프로젝트 목록 조회 API 구현
- 컨트롤러 로직 구현
- e2e 테스트 작성
