### PR TITLE
fix: socket.io path추가

### DIFF
--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -11,7 +11,10 @@ interface ClientSocket extends Socket {
   projectId?: number;
 }
 
-@WebSocketGateway({ namespace: /project-.+/ })
+@WebSocketGateway({
+  namespace: /project-\d+/,
+  path: '/api/socket.io',
+})
 export class ProjectWebsocketGateway implements OnGatewayConnection {
   constructor(private readonly projectService: ProjectService) {}
   handleConnection(client: ClientSocket, ...args: any[]) {

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -28,7 +28,9 @@ describe('WS landing', () => {
       .get('/api/project')
       .set('Authorization', `Bearer ${accessToken}`);
     const [project] = response.body.projects;
-    socket = io(`http://localhost:3000/project-${project.id}`);
+    socket = io(`http://localhost:3000/project-${project.id}`, {
+      path: '/api/socket.io',
+    });
 
     return new Promise<void>((resolve) => {
       socket.on('connect', () => {


### PR DESCRIPTION
## 🎟️ 태스크

[웹소켓 API 구현(백엔드)](https://plastic-toad-cb0.notion.site/API-bebd05a66bca4d35b5b4b15b3ddba8ed?pvs=74)

## ✅ 작업 내용

- fix: socket.io path추가

## 🖊️ 구체적인 작업

### - fix: socket.io path추가

-  클라이언트 초기연결시 /api/socket.io로 연결하도록 path 설정

## 🤔 고민 및 의논할 거리
- 클라이언트와 실제로 연결해보니 path를 지정하지 않은 부분과 백엔드 Nginx 설정이 `/api` 로 와만 백엔드 로직에서 처리하는 부분이 맞물려 잘 동작하지 않았습니다.
  - 이러한 문제를 해결한 방법을 [Socket.io 웹소켓 연결 path 설정](https://plastic-toad-cb0.notion.site/Socket-io-path-b2becebf166442f1b10af36000dfe5c4?pvs=4)에 작성했습니다.
- 웹소켓 E2E 테스트를 도입한 내용을 [웹소켓 E2E 테스트 도입](https://plastic-toad-cb0.notion.site/E2E-d876323ae5974e9abddc108e98e9b551?pvs=4)에 작성했습니다.
    