### PR TITLE
fix: 프로젝트 생성, 회원 가입 페이지 버그 해결, 데모 피드백 반영

### DIFF
--- a/frontend/src/components/account/NicknameInput.tsx
+++ b/frontend/src/components/account/NicknameInput.tsx
@@ -74,7 +74,7 @@ const NicknameInput = ({
 
   return (
     <div
-      className={`flex h-[100%] ${
+      className={`flex gap-[4.375rem] h-[100%] ${
         currentStepNumber === SIGNUP_STEP.STEP1.NUMBER
           ? "items-center"
           : "items-end"
@@ -88,7 +88,7 @@ const NicknameInput = ({
           LESSER에서 사용할 제 이름은
         </label>
         <br />
-        <div id="nickname-input-box" className="flex">
+        <div id="nickname-input-box" className="flex w-[525px]">
           <div className="inline">
             <input
               type="text"
@@ -116,11 +116,13 @@ const NicknameInput = ({
           <span className="text-3xl font-semibold text-dark-gray">입니다</span>
         </div>
       </div>
-      {validated && currentStepNumber !== SIGNUP_STEP.STEP2.NUMBER && (
-        <NextStepButton onNextButtonClick={handleNextButtonClick}>
-          Next
-        </NextStepButton>
-      )}
+      <div className="min-w-[6.875rem] self-end">
+        {validated && currentStepNumber !== SIGNUP_STEP.STEP2.NUMBER && (
+          <NextStepButton onNextButtonClick={handleNextButtonClick}>
+            Next
+          </NextStepButton>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/account/NicknameInput.tsx
+++ b/frontend/src/components/account/NicknameInput.tsx
@@ -31,6 +31,10 @@ const NicknameInput = ({
   };
 
   const nicknameAvailabilityCheck = async () => {
+    if (!inputValue) {
+      return;
+    }
+
     const available = await getNicknameAvailability(inputValue);
     if (available) {
       setValidated(true);
@@ -53,10 +57,6 @@ const NicknameInput = ({
 
   useEffect(() => {
     setValidated(null);
-    if (!inputValue) {
-      return;
-    }
-
     debounce(1000, nicknameAvailabilityCheck);
   }, [inputValue]);
 

--- a/frontend/src/components/account/PositionInput.tsx
+++ b/frontend/src/components/account/PositionInput.tsx
@@ -34,13 +34,16 @@ const PositionInput = ({
 
   return (
     <div
-      className={`flex h-[90%] ${
+      className={`flex gap-[4.375rem] h-[90%] ${
         currentStepNumber !== SIGNUP_STEP.STEP3.NUMBER
           ? "items-center"
           : "items-end"
       }`}
     >
-      <div id="position-input-box" className="w-[80%] flex gap-4 items-center">
+      <div
+        id="position-input-box"
+        className="min-w-[567px] flex gap-4 items-center"
+      >
         <span className="text-3xl font-semibold text-dark-gray">
           저의 주요 직무는
         </span>
@@ -53,11 +56,13 @@ const PositionInput = ({
         />
         <span className="text-3xl font-semibold text-dark-gray">입니다</span>
       </div>
-      {currentStepNumber !== SIGNUP_STEP.STEP3.NUMBER && selectedOption && (
-        <NextStepButton onNextButtonClick={handleNextButtonClick}>
-          Next
-        </NextStepButton>
-      )}
+      <div className="min-w-[6.875rem] self-end">
+        {currentStepNumber !== SIGNUP_STEP.STEP3.NUMBER && selectedOption && (
+          <NextStepButton onNextButtonClick={handleNextButtonClick}>
+            Next
+          </NextStepButton>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -75,7 +75,7 @@ const SignupMainSection = ({
   }, [currentStepNumber]);
 
   return (
-    <main className="relative ml-10 pl-7 w-[100%] h-[40.5rem]">
+    <main className="relative ml-10 pl-7 min-w-[720] h-[40.5rem]">
       <div
         className={`absolute top-0 bg-gradient-to-b from-white to-90% min-w-[90%] min-h-[9.25rem] z-10 ${
           currentStepNumber > 1 && "hover:cursor-pointer hover:to-0%"

--- a/frontend/src/components/account/TechStackInput.tsx
+++ b/frontend/src/components/account/TechStackInput.tsx
@@ -29,7 +29,7 @@ const TechStackInput = ({
   };
 
   return (
-    <div id="tech" className="h-[90%] flex items-center">
+    <div id="tech" className="h-[90%] flex items-center gap-[4.375rem]">
       <div className="w-[80%]">
         <p className="mb-3 text-3xl font-semibold text-dark-gray">
           저의 주요 기술 스택은
@@ -44,7 +44,7 @@ const TechStackInput = ({
           ))}
         </div>
         <button
-          className="w-[11.25rem] h-[3.25rem] bg-middle-green rounded-xl text-m text-white mb-3 flex items-center shadow-box pl-3 pr-9"
+          className="w-[11.25rem] h-[3.25rem] bg-middle-green rounded-xl text-m text-white mb-3 flex items-center gap-3 shadow-box pl-3 pr-9"
           type="button"
           onClick={() =>
             open(<TechStackModal {...{ techRef, close, setTechStackList }} />)
@@ -55,11 +55,13 @@ const TechStackInput = ({
         </button>
         <p className="text-3xl font-semibold text-dark-gray">입니다</p>
       </div>
-      {techStackList.length !== 0 && (
-        <NextStepButton onNextButtonClick={onSignupButtonClick}>
-          가입하기
-        </NextStepButton>
-      )}
+      <div className="min-w-[6.875rem] self-end">
+        {techStackList.length !== 0 && (
+          <NextStepButton onNextButtonClick={onSignupButtonClick}>
+            가입하기
+          </NextStepButton>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/common/CategoryButton.tsx
+++ b/frontend/src/components/common/CategoryButton.tsx
@@ -9,7 +9,7 @@ const CategoryButton = ({
   category,
   onCloseButtonClick,
 }: CategoryButtonProps) => (
-  <div className="min-w-[6.5rem] min-h-[3.25rem] bg-light-green rounded-xl text-white text-2xl font-bold flex items-center py-2 pl-9 pr-3 shadow-box">
+  <div className="min-w-[6.5rem] min-h-[3.25rem] bg-light-green rounded-xl text-white text-2xl font-bold flex items-center gap-3 py-2 pl-9 pr-3 shadow-box">
     {category}
     <button
       type="button"

--- a/frontend/src/components/common/NextStepButton.tsx
+++ b/frontend/src/components/common/NextStepButton.tsx
@@ -12,7 +12,12 @@ const NextStepButton = ({
     onClick={onNextButtonClick}
     className="text-[#68790E] font-bold text-3xl self-end"
   >
-    <span style={{ textShadow: "8px 8px 25px 0px #00000051" }}>{children}</span>
+    <p
+      className="min-w-[6.875rem]"
+      style={{ textShadow: "8px 8px 25px 0px #00000051" }}
+    >
+      {children}
+    </p>
   </button>
 );
 

--- a/frontend/src/components/common/NextStepButton.tsx
+++ b/frontend/src/components/common/NextStepButton.tsx
@@ -10,14 +10,9 @@ const NextStepButton = ({
   <button
     type="button"
     onClick={onNextButtonClick}
-    className="text-[#68790E] font-bold text-3xl self-end"
+    className="text-[#68790E] font-bold text-3xl"
   >
-    <p
-      className="min-w-[6.875rem]"
-      style={{ textShadow: "8px 8px 25px 0px #00000051" }}
-    >
-      {children}
-    </p>
+    <p style={{ textShadow: "8px 8px 25px 0px #00000051" }}>{children}</p>
   </button>
 );
 

--- a/frontend/src/components/landing/LandingProject.tsx
+++ b/frontend/src/components/landing/LandingProject.tsx
@@ -7,21 +7,21 @@ interface LandingProjectProps {
   projectId: string;
 }
 
-const LandingProject = ({ project, projectId }: LandingProjectProps) => {
-  return (
-    <div className="w-full p-6 flex flex-col justify-between shadow-box rounded-lg">
-      <div className="flex justify-between items-baseline text-middle-green font-bold">
-        <p className="text-xl">| {project.title}</p>
-        <p className="text-xs">{formatDate(project.createdAt)}</p>
-      </div>
-      <div className="text-xs">{project.subject}</div>
-      <div className="flex justify-between">
-        <LandingProjectLink projectId={projectId} type="BACKLOG" />
-        <LandingProjectLink projectId={projectId} type="SPRINT" />
-        <LandingProjectLink projectId={projectId} type="SETTINGS" />
-      </div>
+const LandingProject = ({ project, projectId }: LandingProjectProps) => (
+  <div className="flex flex-col justify-between w-full p-6 rounded-lg shadow-box">
+    <div className="flex items-baseline justify-between font-bold text-middle-green">
+      <p className="text-xl">| {project.title}</p>
+      <p className="text-xs">
+        {project.createdAt && formatDate(project.createdAt)}
+      </p>
     </div>
-  );
-};
+    <div className="text-xs">{project.subject}</div>
+    <div className="flex justify-between">
+      <LandingProjectLink projectId={projectId} type="BACKLOG" />
+      <LandingProjectLink projectId={projectId} type="SPRINT" />
+      <LandingProjectLink projectId={projectId} type="SETTINGS" />
+    </div>
+  </div>
+);
 
 export default LandingProject;

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -1,6 +1,9 @@
 import { useRef, useState } from "react";
 import NextStepButton from "../common/NextStepButton";
-import { PROJECT_NAME_INPUT_ID } from "../../constants/projects";
+import {
+  MAX_INPUT_LENGTH,
+  PROJECT_NAME_INPUT_ID,
+} from "../../constants/projects";
 import { Step } from "../../types/common/common";
 
 interface ProjectCreateInputProps {
@@ -23,15 +26,20 @@ const ProjectCreateInput = ({
   buttonContent,
   containerHeight,
 }: ProjectCreateInputProps) => {
-  const [valid, setValid] = useState<boolean>(false);
+  const [valid, setValid] = useState<boolean | null>(null);
   const inputElement = useRef<HTMLInputElement>(null);
   const targetStepIsProjectName = elementId === PROJECT_NAME_INPUT_ID;
 
   const handleInputChange = () => {
     const value = inputElement.current?.value.trim();
 
-    if (value) {
+    if (value && value.length <= MAX_INPUT_LENGTH) {
       setValid(true);
+      return;
+    }
+
+    if (!value) {
+      setValid(null);
       return;
     }
 
@@ -79,22 +87,32 @@ const ProjectCreateInput = ({
             targetStepIsProjectName ? "flex" : "w-[525px] flex flex-col"
           }`}
         >
-          <input
-            type="text"
-            name={elementId}
-            id={elementId}
-            ref={inputElement}
-            autoComplete="off"
-            onChange={handleInputChange}
-            onKeyDown={handleEnterDown}
-            className={`${
-              targetStepIsProjectName ? "w-[27.5rem]" : "w-[525px]"
-            } h-[3rem] border-b-2 focus:outline-none focus:border-b-3 font-semibold text-3xl text-middle-green focus:border-middle-green ${
-              valid && "border-b-3 border-middle-green"
-            }`}
-          />
-
-          <p className="self-end mt-3 text-3xl font-semibold w-fit text-dark-gray">
+          <div className="inline">
+            <input
+              type="text"
+              name={elementId}
+              id={elementId}
+              ref={inputElement}
+              autoComplete="off"
+              onChange={handleInputChange}
+              onKeyDown={handleEnterDown}
+              className={`${
+                targetStepIsProjectName ? "w-[27.5rem]" : "w-[525px]"
+              } h-[3rem] border-b-2 focus:outline-none focus:border-b-3 font-semibold text-3xl text-middle-gree ${
+                valid && "border-b-3 border-middle-green"
+              } ${
+                valid !== null && !valid
+                  ? "border-b-3 border-error-red focus:border-error-red"
+                  : "focus:border-middle-green"
+              }`}
+            />
+            {valid !== null && !valid && (
+              <p className="font-bold text-error-red text-xxs">
+                길이가 너무 길어요
+              </p>
+            )}
+          </div>
+          <p className="self-start mt-3 ml-[2px] text-3xl font-semibold w-fit text-dark-gray">
             입니다
           </p>
         </div>

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -49,8 +49,12 @@ const ProjectCreateInput = ({
     onNextButtonClick();
   };
 
-  const handleEnterDown = ({ key }: React.KeyboardEvent) => {
-    if (key === "Enter" && valid) {
+  const handleEnterDown = (event: React.KeyboardEvent) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
+    if (event.key === "Enter" && valid) {
       handleNextButtonClick();
     }
   };

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -57,7 +57,7 @@ const ProjectCreateInput = ({
 
   return (
     <div
-      className={`flex h-[${containerHeight}%] ${
+      className={`flex gap-[4.375rem] h-[${containerHeight}%] ${
         targetStepIsCurrentStep ? "items-center" : "items-end"
       }`}
     >

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -95,11 +95,13 @@ const ProjectCreateInput = ({
           </p>
         </div>
       </div>
-      {valid && targetStepIsCurrentStep && (
-        <NextStepButton onNextButtonClick={handleNextButtonClick}>
-          {buttonContent}
-        </NextStepButton>
-      )}
+      <div className="min-w-[6.875rem] self-end">
+        {valid && targetStepIsCurrentStep && (
+          <NextStepButton onNextButtonClick={handleNextButtonClick}>
+            {buttonContent}
+          </NextStepButton>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/projects/ProjectCreateMainSection.tsx
+++ b/frontend/src/components/projects/ProjectCreateMainSection.tsx
@@ -70,7 +70,7 @@ const ProjectCreateMainSection = ({
   }, [currentStep.NUMBER]);
 
   return (
-    <main className="relative ml-10 pl-7 w-[100%] h-[40.5rem]">
+    <main className="relative ml-10 pl-7 min-w-[720px] h-[40.5rem]">
       <div
         className={`absolute top-0 bg-gradient-to-b from-white to-90% min-w-[90%] min-h-[9.25rem] z-10 ${
           currentStep.NUMBER > 1 && "hover:cursor-pointer hover:to-0%"

--- a/frontend/src/components/projects/ProjectsSideBar.tsx
+++ b/frontend/src/components/projects/ProjectsSideBar.tsx
@@ -30,7 +30,7 @@ const ProjectsSideBar = () => {
       <p className="mb-[9.625rem] font-semibold text-m text-dark-gray">
         확인해 보세요
       </p>
-      <div className="w-[23.375rem] py-6 px-[1.875rem] flex items-center gap-6 bg-gradient-to-bl from-white-transparent to-90% bg-light-green rounded-[1.125rem] text-white">
+      <div className="w-[23.375rem] py-6 px-[1.875rem] flex items-center gap-6 bg-gradient-to-bl from-white-transparent to-90% bg-middle-green rounded-[1.125rem] text-white">
         <ProfileImage imageUrl={userData.imageUrl} pxSize={64} />
         <div className="flex flex-col gap-1">
           <p className="font-semibold text-m">{userData.username}</p>

--- a/frontend/src/constants/projects.ts
+++ b/frontend/src/constants/projects.ts
@@ -10,3 +10,5 @@ export const PROJECT_CREATE_STEP = {
 export const PROJECT_NAME_INPUT_ID = "projectName";
 
 export const PROJECT_SUBJECT_INPUT_ID = "projectSubject";
+
+export const MAX_INPUT_LENGTH = 256;

--- a/frontend/src/pages/account/SignupPage.tsx
+++ b/frontend/src/pages/account/SignupPage.tsx
@@ -17,9 +17,15 @@ const SignupPage = () => {
   }
 
   return (
-    <div className="flex items-center min-w-[76rem] h-[100vh] mx-6">
-      <SignupSideBar currentStepName={currentStep.NAME} currentStepNumber={currentStep.NUMBER} />
-      <SignupMainSection currentStepNumber={currentStep.NUMBER} setCurrentStep={setCurrentStep} />
+    <div className="flex justify-center items-center min-w-[76rem] h-[100vh] mx-6">
+      <SignupSideBar
+        currentStepName={currentStep.NAME}
+        currentStepNumber={currentStep.NUMBER}
+      />
+      <SignupMainSection
+        currentStepNumber={currentStep.NUMBER}
+        setCurrentStep={setCurrentStep}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/projects/ProjectCreatePage.tsx
+++ b/frontend/src/pages/projects/ProjectCreatePage.tsx
@@ -12,7 +12,7 @@ const ProjectCreatePage = () => {
   );
 
   return (
-    <div className="flex items-center min-w-[76rem] h-[100vh] mx-6">
+    <div className="flex justify-center items-center min-w-[76rem] h-[100vh] gap-15">
       <ProjectCreateSideBar currentStep={currentStep} />
       <ProjectCreateMainSection
         currentStep={currentStep}


### PR DESCRIPTION
## 🎟️ 태스크

- [프로젝트 생성 페이지, 회원가입 페이지 UI 개선](https://plastic-toad-cb0.notion.site/UI-f32b836279ae42bfb165f1834d27ca84)
- [프로젝트 버그 픽스](https://plastic-toad-cb0.notion.site/3f73d21dd8f1455092f1d4520b74ceae)
- [회원가입 페이지 버그 픽스](https://plastic-toad-cb0.notion.site/8f13f2a40dd5430892d0729eb88b205d)

## ✅ 작업 내용

- 프로젝트 생성 페이지 및 회원 가입 페이지가 다른 뷰포트에서 일정한 크기로 보일 수 있도록 함
- 프로젝트 목록 페이지 유저 정보 칸 색상을 프로젝트 테마 색으로 변경
- 프로젝트 생성 페이지에서 제목 입력 후 엔터를 쳤을 때 바로 프로젝트가 생성되는 버그 해결
- 프로젝트 페이지에서 프로젝트 데이터가 오기 전에 프로젝트 생성 날짜가 NaN.NaN.NaN으로 보이는 문제 해결
- 회원 가입 페이지에서 닉네임 입력값을 다 지웠는데 중복검사 API 요청되는 버그 해결

## 🖊️ 구체적인 작업

### 프로젝트 생성 페이지 버그 해결
[개발일지](https://plastic-toad-cb0.notion.site/ca1f9f0aee034760b26d543c502acedd?pvs=74)
- 한글 입력 시 IME로 인해 `keyDown` 이벤트가 두 번 감지되어 발생하는 버그였습니다. Mac에서는 `composition` 중에 감지되는 `keyDown` 이벤트에서 받는 key의 값이 `Enter`로 되어 있어서 발생했습니다. 따라서 `composition`중이 아닐 때만 enter 동작이 수행되도록 했습니다.

### 회원 가입 페이지 버그 해결
[개발일지](https://plastic-toad-cb0.notion.site/debounce-f2e731ed8b154a208fba43e4065af8be?pvs=74)
- `debounce`를 새로 호출하지 않더라도 이전 호출로 인한 동작이 취소되지 않는다는 것을 간과해 발생했습니다. `debounce`로 넘겨주는 콜백 함수 내에서 입력값이 없을 시 다음 동작을 하지 않도록 하는 로직을 추가해 해결했습니다.