### PR TITLE
refactor: 인증을 처리하는 가드계층 추가

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Public } from './common/guard/authentication.guard';
 
+@Public()
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,8 +23,10 @@ import { ProjectToMember } from './project/entity/project-member.entity';
 import { ProjectModule } from './project/project.module';
 import * as cookieParser from 'cookie-parser';
 import { BearerTokenMiddleware } from './common/middleware/parse-bearer-token.middleware';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ErrorExceptionFilter } from './common/exception-filter/exception.filter';
+import { AuthenticationGuard } from './common/guard/authentication.guard';
+import { MemberRepository } from './member/repository/member.repository';
 
 @Module({
   imports: [
@@ -55,6 +57,11 @@ import { ErrorExceptionFilter } from './common/exception-filter/exception.filter
       provide: APP_FILTER,
       useClass: ErrorExceptionFilter,
     },
+    {
+      provide: APP_GUARD,
+      useClass: AuthenticationGuard,
+    },
+	MemberRepository
   ],
 })
 export class AppModule {

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -13,7 +13,9 @@ import { MemberService } from 'src/member/service/member.service';
 import { GithubAuthenticationRequestDto } from './dto/GithubAuthenticationRequest.dto';
 import { GithubSignupRequestDto } from './dto/GithubSignupRequest.dto';
 import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
+import { Public } from 'src/common/guard/authentication.guard';
 
+@Public()
 @Controller('auth')
 export class AuthController {
   constructor(

--- a/backend/src/common/guard/authentication.guard.ts
+++ b/backend/src/common/guard/authentication.guard.ts
@@ -1,0 +1,36 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
+import { Member } from 'src/member/entity/member.entity';
+import { MemberRepository } from 'src/member/repository/member.repository';
+import { BearerTokenRequest } from '../middleware/parse-bearer-token.middleware';
+
+export interface MemberRequest extends BearerTokenRequest {
+  member: Member;
+}
+
+@Injectable()
+export class AuthenticationGuard implements CanActivate {
+  constructor(
+    private readonly lesserJwtService: LesserJwtService,
+    private readonly memberRepository: MemberRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request: MemberRequest = context.switchToHttp().getRequest();
+    const accessToken = request.token;
+    if (!accessToken)
+      throw new UnauthorizedException('Bearer Token is missing');
+    const {
+      sub: { id },
+    } = await this.lesserJwtService.getPayload(accessToken, 'access');
+    const member = await this.memberRepository.findById(id);
+    if (!member) throw new Error('assert: member must be found from database');
+    request.member = member;
+    return true;
+  }
+}

--- a/backend/src/member/controller/member.controller.ts
+++ b/backend/src/member/controller/member.controller.ts
@@ -6,12 +6,17 @@ import {
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
+import {
+  Public,
+} from 'src/common/guard/authentication.guard';
 import { BearerTokenRequest } from 'src/common/middleware/parse-bearer-token.middleware';
 import { MemberService } from '../service/member.service';
 
 @Controller('member')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
+
+  @Public()
   @Get('/availability')
   async getUsernameAvailability(@Query('username') username: string) {
     if (!username) throw new BadRequestException('username is missing');

--- a/backend/src/member/member.module.ts
+++ b/backend/src/member/member.module.ts
@@ -9,7 +9,7 @@ import { Member } from './entity/member.entity';
 @Module({
   imports: [LesserJwtModule, TypeOrmModule.forFeature([Member])],
   providers: [MemberService, MemberRepository],
-  exports: [MemberService],
+  exports: [MemberService, TypeOrmModule],
   controllers: [MemberController],
 })
 export class MemberModule {}

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -1,19 +1,8 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Post,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { ProjectService } from './service/project.service';
 import { CreateProjectRequestDto } from './dto/CreateProjectRequest.dto';
-import {
-  MemberRequest,
-  AuthenticationGuard,
-} from 'src/common/guard/authentication.guard';
+import { MemberRequest } from 'src/common/guard/authentication.guard';
 
-@UseGuards(AuthenticationGuard)
 @Controller('project')
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}

--- a/backend/test/project/create-project.e2e-spec.ts
+++ b/backend/test/project/create-project.e2e-spec.ts
@@ -19,8 +19,11 @@ describe('POST /api/project', () => {
   });
 
   it('should return 400', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+
     const response = await request(app.getHttpServer())
       .post('/api/project')
+      .set('Authorization', `Bearer ${accessToken}`)
       .send({
         invalidProperty: 'invalidProperty',
       });


### PR DESCRIPTION
## 🎟️ 태스크

[가드 구현](https://plastic-toad-cb0.notion.site/80019425274d475b8d977128566cfe1f?pvs=4)

## ✅ 작업 내용

ex)

- 인증역할을 하는 AuthenticationGuard 구현
- 전역가드 설정, 공개경로 public 데코레이터 추가

## 🖊️ 구체적인 작업

### 인증역할을 하는 AuthenticationGuard 구현

- 컨트롤러 핸들러에 진입하기 전 인증을 수행하고 request객체에 member 정보를 수행하는 AuthenticationGuard 구현
- project 컨트롤러의 인증로직을 삭제하고 가드를 적용
- 프로젝트 생성의 body 데이터 형식 검사하는 테스트(400)에서 인증 여부가 영향을 주지 않도록 유효한 엑세스토큰을 추가해 테스트하도록 변경

### 전역가드 설정, 공개경로 public 데코레이터 추가

- app module에 전역가드 설정
- public 커스텀 데코레이터 추가
- public 데코레이터가 설정된 경로에 대해 인증절차 건너뛰도록 가드 변경
- authController등 인증 없는 경로에 대해 public 데코레이터 적용

## 🤔 고민 및 의논할 거리
- 가드의 도입 이유는 반복되는 인증절차를 가드라는 공통적인 계층으로 추상화해 처리하기 위함입니다.
- 미래에 대부분의 API에서 인증을 필수로 처리할 것으로 예상되어 전역가드로 처리했습니다.
- 인증이 필요하지 않은 경로는 @Public() 데코레이터를 붙여 인증에서 제외할 수 있습니다.
- 컨트롤러에서 사용하는 `request`와 bearerToken 정보를 추가한 `BearerTokenRequest`를 확장해 인증정보를 추가한 `MemberRequest`인터페이스를 추가했습니다.
- 400테스트에 유효한 엑세스토큰을 넣어주도록 수정했습니다.
- 전역적으로 가드를 적용했지만, 웹소켓에는 자동으로 적용되지 않는것을 확인했습니다. 이를 어떻게 일관되게 처리할지 논의가 필요합니다.
- 모듈의 의존성 관련해서 import, export, provide에 대해 이해가 부족하고, 정확한 팀의 컨벤션이 약합니다. 이를 추후에 고민해보는 작업을 추가해야 할 것 같습니다.
- 가드가 레포지토리를 직접 사용합니다. 이는 저희가 이전에 논의했던 서비스는 노출시키고 레포지토리는 노출하지 말자고 했던 규칙과 어긋난 상태입니다. 위의 학습이 끝나고 수정하는것이 어떨까요?
- [NestJS 인증가드 적용하기](https://plastic-toad-cb0.notion.site/NestJS-6d2a9587903344b9b325bf7862daa805?pvs=4)에 위에 언급한 고민 및 의논할 거리를 상세히 작성해놓았습니다.
- 내용이 매우 많은점 죄송합니다... ㅠ 개발일지에서 `데코레이터 생성은 어떻게 하고, 리플렉터는 뭘까`를 학습한 부분은 후순위로 읽으셔도 좋을것같습니다!
- 🦊항상 감사합니다🦊
