### PR TITLE
feat: 프로젝트 초대링크 API 구현

### DIFF
--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  Generated,
 } from 'typeorm';
 import { ProjectToMember } from './project-member.entity';
 
@@ -18,6 +19,10 @@ export class Project {
 
   @Column({ type: 'varchar', length: 256, nullable: false })
   subject: string;
+
+  @Column({ type: 'uuid' })
+  @Generated('uuid')
+  inviteLinkId: string;
 
   @OneToMany(
     () => ProjectToMember,

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -46,6 +46,7 @@ export class ProjectWebsocketGateway implements OnGatewayConnection {
         sprint: null,
         board: [],
         link: [],
+        inviteLinkId: project.inviteLinkId,
       },
     };
     client.emit('landing', response);

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -47,6 +47,7 @@ describe('WS landing', () => {
         expect(content.sprint).toBeDefined();
         expect(content.board).toBeDefined();
         expect(content.link).toBeDefined();
+        expect(content.inviteLinkId).toBeDefined();
         resolve();
       });
     });


### PR DESCRIPTION
## 🎟️ 태스크

[랜딩페이지 API 추가구현(초대링크)](https://plastic-toad-cb0.notion.site/API-e6cf4e115ac7443e90e89d0a81327f8b)

## ✅ 작업 내용

- project 엔티티에 프로젝트 생성시 uuid가 자동으로 생성되는 inviteLinkId 필드 추가
- 웹소켓 게이트웨이에 joinLanding 이벤트의 첫 데이터 전송으로 inviteLinkId 프로퍼티 추가 전송
- 웹소켓 랜딩페이지 inviteLinkId에 대해 e2e 테스트 추가

## 🤔 고민 및 의논할 거리
    
- mysql에서는 column의 type으로 uuid를 사용하는게 불가능하다고 하네요
    - https://orkhan.gitbook.io/typeorm/docs/entities#column-types-for-mysql-mariadb 
    - 그래도 명시적으로 uuid로 해 놓으면 보기 편할것 같습니다. 
    - mysql에 varchar로 들어가는것을 확인했습니다.
        
  ```bash
  mysql> desc project;
  +------------+--------------+------+-----+----------------------+--------------------------------------------------+
  | Field      | Type         | Null | Key | Default              | Extra                                            |
  +------------+--------------+------+-----+----------------------+--------------------------------------------------+
  | id         | int(11)      | NO   | PRI | NULL                 | auto_increment                                   |
  | title      | varchar(256) | NO   |     | NULL                 |                                                  |
  | subject    | varchar(256) | NO   |     | NULL                 |                                                  |
  | created_at | timestamp(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED                                |
  | updated_at | timestamp(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6) |
  | inviteLink | varchar(36)  | NO   |     | NULL                 |                                                  |
  +------------+--------------+------+-----+----------------------+--------------------------------------------------+
  ```
- generated 데코레이터로 생성시 자동으로 uuid를 만들게 했습니다.
    - https://orkhan.gitbook.io/typeorm/docs/entities#columns-with-generated-values

##