### PR TITLE
feat: 프로젝트 참여 API 구현

### DIFF
--- a/backend/src/project/dto/JoinProjectRequest.dto.ts
+++ b/backend/src/project/dto/JoinProjectRequest.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class JoinProjectRequestDto {
+  @IsNotEmpty()
+  @IsUUID(4, {message: "not uuid"})
+  inviteLinkId: string;
+}

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -1,7 +1,18 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ProjectService } from './service/project.service';
 import { CreateProjectRequestDto } from './dto/CreateProjectRequest.dto';
 import { MemberRequest } from 'src/common/guard/authentication.guard';
+import { JoinProjectRequestDto } from './dto/JoinProjectRequest.dto';
+import { Response } from 'express';
 
 @Controller('project')
 export class ProjectController {
@@ -32,5 +43,27 @@ export class ProjectController {
       body.subject,
     );
     return;
+  }
+
+  @Post('/join')
+  async joinProject(
+    @Req() request: MemberRequest,
+    @Body() body: JoinProjectRequestDto,
+    @Res() response: Response,
+  ) {
+    const project = await this.projectService.getProjectByLinkId(
+      body.inviteLinkId,
+    );
+    if (!project) throw new NotFoundException();
+
+    const isProjectMember = await this.projectService.isProjectMember(
+      project,
+      request.member,
+    );
+    if (isProjectMember)
+      return response.status(200).send({ projectId: project.id });
+
+    await this.projectService.addMember(body.inviteLinkId, request.member);
+    return response.status(201).send();
   }
 }

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -24,14 +24,29 @@ export class ProjectRepository {
     );
   }
 
-  getProject(projectId: number): Promise<Project> {
-    return this.projectRepository.findOne({ where: { id: projectId } });	
+  getProjectByLinkId(projectLinkId: string): Promise<Project | null> {
+    return this.projectRepository.findOne({
+      where: { inviteLinkId: projectLinkId },
+    });
+  }
+
+  getProject(projectId: number): Promise<Project | null> {
+    return this.projectRepository.findOne({ where: { id: projectId } });
   }
 
   getProjectList(member: Member): Promise<Project[]> {
     return this.projectRepository.find({
       where: { projectToMember: { member: { id: member.id } } },
       relations: { projectToMember: true },
+    });
+  }
+
+  getProjectToMember(
+    project: Project,
+    member: Member,
+  ): Promise<ProjectToMember | null> {
+    return this.projectToMemberRepository.findOne({
+      where: { project: { id: project.id }, member: { id: member.id } },
     });
   }
 }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ProjectRepository } from '../project.repository';
 import { Member } from 'src/member/entity/member.entity';
 import { Project } from '../entity/project.entity';
+import { ProjectToMember } from '../entity/project-member.entity';
 
 @Injectable()
 export class ProjectService {
@@ -20,5 +21,30 @@ export class ProjectService {
 
   async getProject(projectId: number): Promise<Project> {
     return await this.projectRepository.getProject(projectId);
+  }
+
+  async addMember(projectLinkId: string, member: Member): Promise<void> {
+    const project =
+      await this.projectRepository.getProjectByLinkId(projectLinkId);
+    if (!project) throw new Error('project link id not found');
+
+    const isProjectMember = await this.isProjectMember(project, member);
+    if (isProjectMember) throw new Error('already joined member');
+
+    await this.projectRepository.addProjectMember(project, member);
+  }
+
+  async isProjectMember(
+    project: Project,
+    member: Member,
+  ): Promise<boolean> {
+    const projectToMember: ProjectToMember | null =
+      await this.projectRepository.getProjectToMember(project, member);
+    if (!projectToMember) return false;
+    return true;
+  }
+
+  getProjectByLinkId(projectLinkId: string): Promise<Project | null> {
+    return this.projectRepository.getProjectByLinkId(projectLinkId);
   }
 }

--- a/backend/test/project/join-project.e2e-spec.ts
+++ b/backend/test/project/join-project.e2e-spec.ts
@@ -1,0 +1,148 @@
+import * as request from 'supertest';
+import {
+  app,
+  appInit,
+  createMember,
+  githubApiService,
+  memberFixture,
+  memberFixture2,
+} from 'test/setup';
+import { io } from 'socket.io-client';
+
+describe('Join Project', () => {
+  let socket;
+  let projectLinkId;
+  let projectId;
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+
+    // projectLinkId를 얻기 위한 사전작업
+    const { accessToken } = await createMember(memberFixture, app);
+    await request(app.getHttpServer())
+      .post('/api/project')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(projectPayload);
+    const response = await request(app.getHttpServer())
+      .get('/api/project')
+      .set('Authorization', `Bearer ${accessToken}`);
+    const [project] = response.body.projects;
+	projectId = project.id;
+    socket = io(`http://localhost:3000/project-${project.id}`, {
+      path: '/api/socket.io',
+    });
+    await new Promise<void>((resolve) => {
+      socket.on('connect', () => {
+        socket.emit('joinLanding');
+      });
+      socket.on('landing', (data) => {
+        const { content } = data;
+        projectLinkId = content.inviteLinkId;
+        resolve();
+      });
+    });
+  });
+  afterEach(async () => {
+    socket.close();
+  });
+
+  const projectPayload = {
+    title: 'Lesser1',
+    subject: '애자일한 프로젝트 관리 툴',
+  };
+
+  it('should return 201', async () => {
+    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
+      id: '321',
+      login: 'username',
+      avatar_url: 'avatar_url',
+    });
+    const { accessToken: newAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+    const response = await request(app.getHttpServer())
+      .post('/api/project/join')
+      .set('Authorization', `Bearer ${newAccessToken}`)
+      .send({ inviteLinkId: projectLinkId });
+    expect(response.status).toBe(201);
+  });
+
+  it('should return 200 when already joined member', async () => {
+    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
+      id: '321',
+      login: 'username',
+      avatar_url: 'avatar_url',
+    });
+    const { accessToken: newAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+    await request(app.getHttpServer())
+      .post('/api/project/join')
+      .set('Authorization', `Bearer ${newAccessToken}`)
+      .send({ inviteLinkId: projectLinkId });
+
+    const response = await request(app.getHttpServer())
+      .post('/api/project/join')
+      .set('Authorization', `Bearer ${newAccessToken}`)
+      .send({ inviteLinkId: projectLinkId });
+    expect(response.status).toBe(200);
+	expect(response.body.projectId).toBe(projectId);
+  });
+
+  it('should return 400 when given bad request', async () => {
+    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
+      id: '321',
+      login: 'username',
+      avatar_url: 'avatar_url',
+    });
+    const { accessToken: newAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+    const response = await request(app.getHttpServer())
+      .post('/api/project/join')
+      .set('Authorization', `Bearer ${newAccessToken}`)
+      .send({ invalidProperty: 'invalidProperty' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 401 (Bearer Token is missing)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/project/join')
+      .send({ inviteLinkId: projectLinkId });
+
+    expect(response.status).toBe(401);
+  });
+
+    it('should return 401 (Expired:accessToken) when given invalid access token', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/project/join')
+        .set('Authorization', `Bearer invalidToken`)
+        .send({ inviteLinkId: projectLinkId });
+
+      expect(response.status).toBe(401);
+      expect(response.body.message).toBe('Expired:accessToken');
+    });
+
+    it('should return 404 when project link ID is not found', async () => {
+      const invalidUUID = 'c93a87e8-a0a4-4b55-bdf2-59bf691f5c37';
+      jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
+        id: '321',
+        login: 'username',
+        avatar_url: 'avatar_url',
+      });
+      const { accessToken: newAccessToken } = await createMember(
+        memberFixture2,
+        app,
+      );
+      const response = await request(app.getHttpServer())
+        .post('/api/project/join')
+        .set('Authorization', `Bearer ${newAccessToken}`)
+        .send({ inviteLinkId: invalidUUID });
+      expect(response.status).toBe(404);
+    });
+});

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -22,6 +22,15 @@ export const memberFixture = {
   tech_stack: { stacks: ['js', 'ts'] },
 };
 
+export const memberFixture2 = {
+  github_id: 321,
+  github_username: 'github_username',
+  github_image_url: 'avatar_url',
+  username: 'username2',
+  position: 'position',
+  tech_stack: { stacks: ['js', 'ts'] },
+};
+
 export const githubUserFixture = {
   id: '123',
   login: 'username',


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 회원추가 API 구현](https://plastic-toad-cb0.notion.site/API-e62f4ab25adc47aab594711d09bc233c?pvs=74)

## ✅ 작업 내용
- feat: project 레포지토리에서 getProjectLinkId, getProjectToMember 메서드 구현
- feat: 프로젝트 서비스에 멤버추가 메서드 구현
- feat: 프로젝트 컨트롤러에 프로젝트 참여 엔드포인트 구현
- test: join project E2E 테스트 구현

## 🖊️ 구체적인 작업

### feat: project 레포지토리에서 getProjectLinkId, getProjectToMember 메서드 구현
- getProjectLinkId는 프로젝트의 초대링크 아이디로 프로젝트를 찾는 메서드임
- getProjectToMember는 멤버와 프로젝트의 정보를 받아 멤버가 프로젝트에 참여한 경우 ProjectToMember 정보를 반환하는 메서드임

### feat: 프로젝트 서비스에 멤버추가 메서드 구현
- addMember 메서드는 프로젝트 링크를 받아 프로젝트에 회원을 추가한다.
- isProjectMember는 회원이 프로젝트의 회원인지 확인한다.
- getProjectByLinkId는 프로젝트 링크로 프로젝트를 찾는다.

### feat: 프로젝트 컨트롤러에 프로젝트 참여 엔드포인트 구현
- joinProject로 회원이 프로젝트 링크로 프로젝트에 참여할 수 있도록 한다.
- JoinProjectRequestDto로 '/join' 엔드포인트의 요청형식을 검증한다.

### test: join project E2E 테스트 구현
- 회원이 정상적으로 프로젝트에 참여할때 201 반환 테스트
- 회원이 이미 프로젝트에 참여한 경우 200 반환 테스트
- 토큰이 유효하지 않을경우 401 반환 테스트
- body의 형식이 유효하지 않을 경우 400 반환 테스트
- 프로젝트 링크가 유효하지 않을 경우 404 반환 테스트

## 🤔 고민 및 의논할 거리
- 이미 프로젝트에 가입한 회원이 API 요청을 하는 경우 어떤 응답코드를 반환할지 고민
  - 409(Conflict), 200(OK), 204(No Content) 중 고민하였다. 
  - 클라이언트의 목적인 프로젝트 가입이 실패하지 않았다고 보는 것이 자연스럽다고 느껴져   200(OK)를 응답하기로 결정했다.
- E2E 테스트 로직이 커지고 있다.
  - E2E 테스트를 할때는 다른 테스트에 영향을 받지 않도록 데이터베이스를 먼저 초기화한다. 이번에 작성한 API를 테스트하기 위해서는 데이터베이스에 회원, 프로젝트 정보가 있어야 하므로 매번 회원을 생성하고 프로젝트를 생성하는 로직부터 실행한 후 본격적인 테스트 로직을 작성할 수 있다. 자주 쓰이는 생성 로직을 함수화할 필요성이 있어 보인다.
