### PR TITLE
feat: 임시 초대 페이지 생성 및 참가 API 연결

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -18,6 +18,7 @@ import PrivateRoute from "./components/common/route/PrivateRoute";
 import PublicRoute from "./components/common/route/PublicRoute";
 import MainPage from "./pages/main/MainPage";
 import LandingPage from "./pages/landing/LandingPage";
+import InvitePage from "./pages/invite/InvitePage";
 
 type RouteType = "PRIVATE" | "PUBLIC";
 
@@ -78,6 +79,10 @@ const router = createBrowserRouter([
           { path: ROUTER_URL.SPRINT, element: <div>sprint Page</div> },
           { path: ROUTER_URL.SETTINGS, element: <div>setting Page</div> },
         ],
+      },
+      {
+        path: ROUTER_URL.INVITE,
+        element: <InvitePage />,
       },
     ],
   },

--- a/frontend/src/apis/api/loginAPI.ts
+++ b/frontend/src/apis/api/loginAPI.ts
@@ -9,14 +9,18 @@ import {
 } from "../../types/DTO/authDTO";
 import { useNavigate } from "react-router-dom";
 import { authAPI, setAccessToken } from "../utils/authAPI";
+import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
 
 export const getLoginURL = async () => {
-  const response = await baseAPI.get<GithubOauthUrlDTO>(API_URL.GITHUB_OAUTH_URL);
+  const response = await baseAPI.get<GithubOauthUrlDTO>(
+    API_URL.GITHUB_OAUTH_URL
+  );
   return response.data.authUrl;
 };
 
 export const postAuthCode = async (authCode: string) => {
   const navigate = useNavigate();
+  const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT);
   const response = await baseAPI.post<AuthenticationDTO>(API_URL.AUTH, {
     authCode,
   });
@@ -24,12 +28,17 @@ export const postAuthCode = async (authCode: string) => {
     const body = response.data as AccessTokenResponse;
     setAccessToken(body.accessToken);
     window.localStorage.setItem("member", JSON.stringify(body.member));
-    navigate(ROUTER_URL.PROJECTS);
+    redirectURL
+      ? navigate(redirectURL, { replace: true })
+      : navigate(ROUTER_URL.PROJECTS);
     return;
   }
   if (response.status === 209) {
     const body = response.data as TempIdTokenResponse;
-    navigate(ROUTER_URL.SIGNUP, { state: { tempIdToken: body.tempIdToken } });
+    navigate(ROUTER_URL.SIGNUP, {
+      state: { tempIdToken: body.tempIdToken },
+      replace: redirectURL ? true : false,
+    });
     return;
   }
 };

--- a/frontend/src/apis/api/loginAPI.ts
+++ b/frontend/src/apis/api/loginAPI.ts
@@ -9,7 +9,7 @@ import {
 } from "../../types/DTO/authDTO";
 import { useNavigate } from "react-router-dom";
 import { authAPI, setAccessToken } from "../utils/authAPI";
-import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
+import { STORAGE_KEY } from "../../constants/storageKey";
 
 export const getLoginURL = async () => {
   const response = await baseAPI.get<GithubOauthUrlDTO>(
@@ -20,14 +20,17 @@ export const getLoginURL = async () => {
 
 export const postAuthCode = async (authCode: string) => {
   const navigate = useNavigate();
-  const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT);
+  const redirectURL = sessionStorage.getItem(STORAGE_KEY.REDIRECT);
   const response = await baseAPI.post<AuthenticationDTO>(API_URL.AUTH, {
     authCode,
   });
   if (response.status === 201) {
     const body = response.data as AccessTokenResponse;
     setAccessToken(body.accessToken);
-    window.localStorage.setItem("member", JSON.stringify(body.member));
+    window.localStorage.setItem(
+      STORAGE_KEY.MEMBER,
+      JSON.stringify(body.member)
+    );
     redirectURL
       ? navigate(redirectURL, { replace: true })
       : navigate(ROUTER_URL.PROJECTS);

--- a/frontend/src/apis/api/projectAPI.ts
+++ b/frontend/src/apis/api/projectAPI.ts
@@ -16,3 +16,9 @@ export const postCreateProject = async (body: {
   const response = await authAPI.post(API_URL.PROJECT, body);
   return response.data;
 };
+
+export const postJoinProject = async (inviteLinkId: string) => {
+  const response = await authAPI.post(API_URL.PROJECT_JOIN, { inviteLinkId });
+
+  return response;
+};

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -6,7 +6,7 @@ import PositionInput from "./PositionInput";
 import TechStackInput from "./TechStackInput";
 import { SIGNUP_STEP } from "../../constants/account";
 import { ROUTER_URL } from "../../constants/path";
-import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
+import { STORAGE_KEY } from "../../constants/storageKey";
 
 interface SignupMainSectionProps {
   currentStepNumber: number;
@@ -46,7 +46,7 @@ const SignupMainSection = ({
       techStack: techRef.current,
       tempIdToken: location.state.tempIdToken,
     });
-    const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT);
+    const redirectURL = sessionStorage.getItem(STORAGE_KEY.REDIRECT);
 
     if (status === 201) {
       redirectURL

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -6,6 +6,7 @@ import PositionInput from "./PositionInput";
 import TechStackInput from "./TechStackInput";
 import { SIGNUP_STEP } from "../../constants/account";
 import { ROUTER_URL } from "../../constants/path";
+import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
 
 interface SignupMainSectionProps {
   currentStepNumber: number;
@@ -45,9 +46,12 @@ const SignupMainSection = ({
       techStack: techRef.current,
       tempIdToken: location.state.tempIdToken,
     });
+    const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT);
 
     if (status === 201) {
-      navigate(ROUTER_URL.PROJECTS);
+      redirectURL
+        ? navigate(redirectURL, { replace: true })
+        : navigate(ROUTER_URL.PROJECTS, { replace: true });
     }
   };
 

--- a/frontend/src/components/common/route/PublicRoute.tsx
+++ b/frontend/src/components/common/route/PublicRoute.tsx
@@ -3,12 +3,12 @@ import checkAuthentication from "../../../utils/route/checkAuthentication";
 import RouteLoading from "./RouteLoading";
 import { Navigate, Outlet } from "react-router-dom";
 import { ROUTER_URL } from "../../../constants/path";
-import { SESSION_STORAGE_KEY } from "../../../constants/storageKey";
+import { STORAGE_KEY } from "../../../constants/storageKey";
 
 const PublicRoute = () => {
   const [loadingState, setLoadingState] = useState<boolean>(true);
   const [authenticated, setAuthenticated] = useState<boolean>(false);
-  const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT);
+  const redirectURL = sessionStorage.getItem(STORAGE_KEY.REDIRECT);
 
   useEffect(() => {
     checkAuthentication().then((result) => {

--- a/frontend/src/components/common/route/PublicRoute.tsx
+++ b/frontend/src/components/common/route/PublicRoute.tsx
@@ -3,10 +3,12 @@ import checkAuthentication from "../../../utils/route/checkAuthentication";
 import RouteLoading from "./RouteLoading";
 import { Navigate, Outlet } from "react-router-dom";
 import { ROUTER_URL } from "../../../constants/path";
+import { SESSION_STORAGE_KEY } from "../../../constants/storageKey";
 
 const PublicRoute = () => {
-  const [loadingState, setLoadingState] = useState<Boolean>(true);
-  const [authenticated, setAuthenticated] = useState<Boolean>(false);
+  const [loadingState, setLoadingState] = useState<boolean>(true);
+  const [authenticated, setAuthenticated] = useState<boolean>(false);
+  const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT);
 
   useEffect(() => {
     checkAuthentication().then((result) => {
@@ -25,7 +27,7 @@ const PublicRoute = () => {
   ) : !authenticated ? (
     <Outlet />
   ) : (
-    <Navigate to={ROUTER_URL.PROJECTS} />
+    <Navigate to={redirectURL ? redirectURL : ROUTER_URL.PROJECTS} />
   );
 };
 

--- a/frontend/src/components/landing/LandingMember.tsx
+++ b/frontend/src/components/landing/LandingMember.tsx
@@ -8,9 +8,13 @@ import { DEFAULT_MEMBER } from "../../constants/projects";
 const LandingMember = ({
   member,
   myInfo,
+  inviteLinkIdRef,
+  projectTitle,
 }: {
   member: LandingMemberDTO[];
   myInfo: LandingMemberDTO;
+  inviteLinkIdRef: React.MutableRefObject<string>;
+  projectTitle: string;
 }) => {
   const { Dropdown, selectedOption } = useDropdown({
     placeholder: "내 상태",
@@ -23,6 +27,19 @@ const LandingMember = ({
   );
   const imageUrl = myInfo.imageUrl ?? userData.imageUrl;
   const username = myInfo.username ?? userData.username;
+
+  const handleInviteButtonClick = () => {
+    window.navigator.clipboard
+      .writeText(
+        `${window.location.origin}/projects/invite/${projectTitle.replace(
+          /\s/g,
+          ""
+        )}/${inviteLinkIdRef.current}`
+      )
+      .then(() => {
+        alert("초대링크가 복사되었습니다.");
+      });
+  };
 
   return (
     <div className="w-full px-6 py-6 overflow-y-scroll rounded-lg shadow-box bg-gradient-to-tr to-light-green-linear-from from-light-green scrollbar-thin scrollbar-thumb-light-green scrollbar-track-transparent scrollbar-thumb-rounded-full">
@@ -44,7 +61,12 @@ const LandingMember = ({
         />
         <div className="flex justify-between text-white">
           <p className="text-xs font-bold">| 함께하는 사람들</p>
-          <button className="text-xxs hover:underline">초대링크 복사</button>
+          <button
+            className="text-xxs hover:underline"
+            onClick={handleInviteButtonClick}
+          >
+            초대링크 복사
+          </button>
         </div>
         {member.map((memberData: LandingMemberDTO) => (
           <UserBlock {...memberData} key={memberData.id} />

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -24,6 +24,7 @@ export const ROUTER_URL = {
   SPRINT: "/projects/:projectId/sprint",
   SPRINT_CREATE: "/projects/:projectId/sprint/create",
   SETTINGS: "/projects/:projectId/settings",
+  INVITE: "projects/invite/:projectTitle/:projectId",
   ERROR: "/error",
 };
 

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -9,6 +9,7 @@ export const API_URL = {
   NICKNAME_AVAILABLILITY: "/member/availability",
   GITHUB_USERNAME: "/auth/github/username",
   PROJECT: "/project",
+  PROJECT_JOIN: "/project/join",
 };
 
 export const ROUTER_URL = {

--- a/frontend/src/constants/storageKey.ts
+++ b/frontend/src/constants/storageKey.ts
@@ -1,3 +1,4 @@
-export const SESSION_STORAGE_KEY = {
-  REDIRECT: 'redirect'
-}
+export const STORAGE_KEY = {
+  MEMBER: "member",
+  REDIRECT: "redirect",
+};

--- a/frontend/src/constants/storageKey.ts
+++ b/frontend/src/constants/storageKey.ts
@@ -1,0 +1,3 @@
+export const SESSION_STORAGE_KEY = {
+  REDIRECT: 'redirect'
+}

--- a/frontend/src/hooks/common/socket/useLandingSocket.ts
+++ b/frontend/src/hooks/common/socket/useLandingSocket.ts
@@ -1,5 +1,5 @@
 import { Socket } from "socket.io-client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   LandingDTO,
   LandingLinkDTO,
@@ -31,11 +31,12 @@ const useLandingSocket = (socket: Socket) => {
   const [sprint, setSprint] = useState<LandingSprintDTO | null>(null);
   const [board, setBoard] = useState<LandingMemoDTO[]>([]);
   const [link, setLink] = useState<LandingLinkDTO[]>([]);
+  const inviteLinkIdRef = useRef<string>('')
 
   const handleOnLanding = ({ action, content }: SocketData) => {
     switch (action) {
       case LandingSocketEvent.INIT:
-        const { project, myInfo, member, sprint, board, link } =
+        const { project, myInfo, member, sprint, board, link, inviteLinkId } =
           content as LandingDTO;
         setProject(project);
         setMyInfo(myInfo);
@@ -43,6 +44,7 @@ const useLandingSocket = (socket: Socket) => {
         setSprint(sprint);
         setBoard(board);
         setLink(link);
+        inviteLinkIdRef.current = inviteLinkId
         break;
     }
   };
@@ -56,7 +58,7 @@ const useLandingSocket = (socket: Socket) => {
     };
   }, [socket]);
 
-  return { project, myInfo, member, sprint, board, link };
+  return { project, myInfo, member, sprint, board, link, inviteLinkIdRef };
 };
 
 export default useLandingSocket;

--- a/frontend/src/pages/TempHomepage.tsx
+++ b/frontend/src/pages/TempHomepage.tsx
@@ -45,6 +45,11 @@ const TempHomepage = () => {
             에러를 던져봅시다!
           </Link>
         </li>
+        <li>
+          <Link to={"projects/invite/projectTitle/projectId"}>
+            초대
+          </Link>
+        </li>
       </ul>
     </div>
   );

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -1,13 +1,29 @@
-import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { checkAccessToken } from "../../apis/utils/authAPI";
 import { ROUTER_URL } from "../../constants/path";
 import { useEffect } from "react";
 import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
+import { postJoinProject } from "../../apis/api/projectAPI";
 
 const InvitePage = () => {
-  const { projectTitle, projectId } = useParams();
+  const { projectTitle, projectId: projectUUID } = useParams();
   const { pathname } = useLocation();
   const navigate = useNavigate();
+
+  const handleJoinButtonClick = async () => {
+    const response = await postJoinProject(projectUUID!);
+
+    switch (response.status) {
+      case 201:
+        alert("프로젝트에 참여되었습니다.");
+        navigate("/projects");
+        break;
+      case 200:
+        alert("이미 참여한 프로젝트입니다.");
+        navigate(`/projects/${response.data.projectId}`);
+        break;
+    }
+  };
 
   useEffect(() => {
     if (!checkAccessToken()) {
@@ -26,15 +42,14 @@ const InvitePage = () => {
     <div className="w-[100%] min-w-[720px] h-[600px] flex justify-center items-center">
       <main>
         <p>프로젝트{projectTitle}에 초대되었습니다.</p>
-        <p>{projectId}</p>
-        <Link to={ROUTER_URL.PROJECTS} replace>
-          <button
-            type="button"
-            className="w-[100px] h-[50px] bg-middle-green rounded text-white"
-          >
-            참여하기
-          </button>
-        </Link>
+        <p>{projectUUID}</p>
+        <button
+          type="button"
+          className="w-[100px] h-[50px] bg-middle-green rounded text-white"
+          onClick={handleJoinButtonClick}
+        >
+          참여하기
+        </button>
       </main>
     </div>
   );

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -1,0 +1,43 @@
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import { checkAccessToken } from "../../apis/utils/authAPI";
+import { ROUTER_URL } from "../../constants/path";
+import { useEffect } from "react";
+import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
+
+const InvitePage = () => {
+  const { projectTitle, projectId } = useParams();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!checkAccessToken()) {
+      sessionStorage.setItem(SESSION_STORAGE_KEY.REDIRECT, pathname);
+      navigate(ROUTER_URL.LOGIN, { replace: true });
+    }
+
+    return () => {
+      if (checkAccessToken()) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY.REDIRECT);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="w-[100%] min-w-[720px] h-[600px] flex justify-center items-center">
+      <main>
+        <p>프로젝트{projectTitle}에 초대되었습니다.</p>
+        <p>{projectId}</p>
+        <Link to={ROUTER_URL.PROJECTS} replace>
+          <button
+            type="button"
+            className="w-[100px] h-[50px] bg-middle-green rounded text-white"
+          >
+            참여하기
+          </button>
+        </Link>
+      </main>
+    </div>
+  );
+};
+
+export default InvitePage;

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { checkAccessToken } from "../../apis/utils/authAPI";
 import { ROUTER_URL } from "../../constants/path";
 import { useEffect } from "react";
-import { SESSION_STORAGE_KEY } from "../../constants/storageKey";
+import { STORAGE_KEY } from "../../constants/storageKey";
 import { postJoinProject } from "../../apis/api/projectAPI";
 
 const InvitePage = () => {
@@ -27,13 +27,13 @@ const InvitePage = () => {
 
   useEffect(() => {
     if (!checkAccessToken()) {
-      sessionStorage.setItem(SESSION_STORAGE_KEY.REDIRECT, pathname);
+      sessionStorage.setItem(STORAGE_KEY.REDIRECT, pathname);
       navigate(ROUTER_URL.LOGIN, { replace: true });
     }
 
     return () => {
       if (checkAccessToken()) {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY.REDIRECT);
+        sessionStorage.removeItem(STORAGE_KEY.REDIRECT);
       }
     };
   }, []);

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -14,7 +14,7 @@ const LandingPage = () => {
 
   const { socket }: { socket: Socket } = useOutletContext();
 
-  const { project, myInfo, member, sprint, link } = useLandingSocket(socket);
+  const { project, myInfo, member, sprint, link, inviteLinkIdRef } = useLandingSocket(socket);
 
   return (
     <div className="flex flex-col justify-between w-full h-full">
@@ -24,7 +24,7 @@ const LandingPage = () => {
       </div>
       <div className="h-[20.5625rem] w-full shrink-0 flex gap-9">
         <LandingSprint {...{ sprint }} />
-        <LandingMember {...{ member, myInfo }} />
+        <LandingMember {...{ member, myInfo, inviteLinkIdRef }} projectTitle={project.title} />
         <LandingLink {...{ link }} />
       </div>
     </div>

--- a/frontend/src/types/DTO/landingDTO.ts
+++ b/frontend/src/types/DTO/landingDTO.ts
@@ -43,4 +43,5 @@ export interface LandingDTO {
   sprint: LandingSprintDTO | null;
   board: LandingMemoDTO[];
   link: LandingLinkDTO[];
+  inviteLinkId: string
 }


### PR DESCRIPTION
## 🎟️ 태스크

- [프로젝트 참여 신청 페이지 UI(디자인 x 기본 기능만 있는 UI)](https://plastic-toad-cb0.notion.site/UI-x-UI-5bb0bc27ea58414b858e45f9b5663a84)
- [프론트 리다이렉트 로직 작성](https://plastic-toad-cb0.notion.site/3d6ab350e8f2431c9674ed3e4218336b)
- [클라이언트 멤버 추가 API 연결 로직 작성 및 연결 확인](https://plastic-toad-cb0.notion.site/API-72f4d62ea1754b2d988c93729a1af750)

## ✅ 작업 내용

- 시나리오에 맞는 클라이언트 리다이렉트 로직 작성
- 임시 초대 페이지 생성 및 라우터 연결
- 프로젝트 참가 API 연결

## 🖊️ 구체적인 작업

### 리다이렉트 로직
- 리다이렉트 로직을 작성할 때 두 가지 방법을 고민했습니다. 하나는 url의 쿼리스트링으로 redirectURL을 관리하는 것이고 하나는 sessionStorage에 관리하는 것입니다. 쿼리스트링으로 관리하려면 OAuth를 사용하기에 github로 redirectURL 정보를 담아 요청을 보내고 다시 받아올 수 있어야 합니다. 찾아본 결과 state라는 파라미터를 인증 절차 이후에 접근하고 싶은 클라이언트의 상태를 보내는 데 사용한다는 정보를 발견했습니다. 하지만 문자열 그대로 보내는 것은 보안상 안전하지 않아 암호화해야 하는데, 그러려면 클라이언트에서 암호화 키를 저장해두어야 하며 리다이렉트 되는 동안 기억하려면 브라우저 Storage에 저장해야 한다고 판단했습니다. 그런데 어차피 Storage를 사용할 것이라면 Storage에 redirectURL을 관리하는 편이 더 효율적이라는 생각이 들었습니다. 따라서 브라우저 Storage에서 관리하는 방식을 사용하였으며, redirectURL 정보는 오래 기억할 필요가 없기 때문에 session 동안만 유지되도록 sessionStorage에 저장했습니다.
- 참여 과정에서 리다이렉트 되는 페이지들(로그인, 회원가입)은 사용자 입장에서 다시 방문할 필요가 없는 페이지이기 때문에 `replace: true` 속성을 통해 뒤로가기로 접근할 수 없도록 했습니다.

### 임시 초대 페이지
- 초대 페이지는 로그인 상태든 아니든 접근할 수 있어야 하기 때문에 PublicRouter와 PrivateRouter 바깥에 위치하도록 했습니다.