### PR TITLE
feat: 서버 socket.io 인증, 인가 구현

### DIFF
--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -19,10 +19,11 @@ export class ProjectService {
     return await this.projectRepository.getProjectList(member);
   }
 
-  async getProject(projectId: number): Promise<Project> {
+  async getProject(projectId: number): Promise<Project | null> {
     return await this.projectRepository.getProject(projectId);
   }
 
+  //ToDo: ProjectLinkId가 아닌 project를 매개변수로 사용하도록 변경
   async addMember(projectLinkId: string, member: Member): Promise<void> {
     const project =
       await this.projectRepository.getProjectByLinkId(projectLinkId);
@@ -34,10 +35,7 @@ export class ProjectService {
     await this.projectRepository.addProjectMember(project, member);
   }
 
-  async isProjectMember(
-    project: Project,
-    member: Member,
-  ): Promise<boolean> {
+  async isProjectMember(project: Project, member: Member): Promise<boolean> {
     const projectToMember: ProjectToMember | null =
       await this.projectRepository.getProjectToMember(project, member);
     if (!projectToMember) return false;

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -1,32 +1,46 @@
 import {
   SubscribeMessage,
   WebSocketGateway,
-  OnGatewayConnection,
   ConnectedSocket,
+  OnGatewayInit,
 } from '@nestjs/websockets';
-import { Socket } from 'socket.io';
+import { Server, Socket } from 'socket.io';
+import { AuthenticationGuard } from 'src/common/guard/authentication.guard';
+import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
+import { Member } from 'src/member/entity/member.entity';
+import { MemberRepository } from 'src/member/repository/member.repository';
 import { ProjectService } from 'src/project/service/project.service';
 
 interface ClientSocket extends Socket {
   projectId?: number;
+  member: Member;
 }
 
 @WebSocketGateway({
   namespace: /project-\d+/,
   path: '/api/socket.io',
 })
-export class ProjectWebsocketGateway implements OnGatewayConnection {
-  constructor(private readonly projectService: ProjectService) {}
-  handleConnection(client: ClientSocket, ...args: any[]) {
-    const projectId = client.nsp.name.match(/\/project-(\d+)/);
+export class ProjectWebsocketGateway implements OnGatewayInit {
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly lesserJwtService: LesserJwtService,
+    private readonly memberRepository: MemberRepository,
+  ) {}
 
-    // Todo: 인증(access Token)
-    // Todo: 인가(projectId에 접근할 수 있는 멤버인지 확인하기!)
-    if (projectId) {
-      client.projectId = parseInt(projectId[1], 10);
-    } else {
-      // Todo: disconnect socket
-    }
+  afterInit(server: Server) {
+    server.use(async (client: ClientSocket, next) => {
+      try {
+        await this.authentication(client);
+        await this.projectAuthorization(client);
+      } catch (error) {
+        if (error.message === 'Failed to verify token: access')
+          error.message = 'Expired:accessToken';
+        if (error.message === 'Project is not number')
+          error.message = 'project not found';
+        next(error);
+      }
+      next();
+    });
   }
 
   @SubscribeMessage('joinLanding')
@@ -50,5 +64,31 @@ export class ProjectWebsocketGateway implements OnGatewayConnection {
       },
     };
     client.emit('landing', response);
+  }
+
+  private async authentication(client: ClientSocket) {
+    const accessToken = client.handshake.auth?.accessToken;
+    if (!accessToken) throw new Error('Bearer Token is missing');
+    const {
+      sub: { id },
+    } = await this.lesserJwtService.getPayload(accessToken, 'access');
+    const member = await this.memberRepository.findById(id);
+    if (!member) throw new Error('assert: member must be found from database');
+    client.member = member;
+  }
+
+  private async projectAuthorization(client: ClientSocket) {
+    const projectId = client.nsp.name.match(/\/project-(\d+)/);
+    if (projectId) {
+      client.projectId = parseInt(projectId[1], 10);
+      if (isNaN(client.projectId)) throw new Error('Project is not number');
+    }
+    const project = await this.projectService.getProject(client.projectId);
+    if (!project) throw new Error('Project not found');
+    const isProjectMember = await this.projectService.isProjectMember(
+      project,
+      client.member,
+    );
+    if (!isProjectMember) throw new Error('Not project member');
   }
 }

--- a/backend/test/project/ws-connection.e2e-spec.ts
+++ b/backend/test/project/ws-connection.e2e-spec.ts
@@ -1,0 +1,155 @@
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  githubApiService,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import { io } from 'socket.io-client';
+
+describe('WS landing', () => {
+  const serverUrl = 'http://localhost:3000/project';
+  let socket;
+
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  afterEach(async () => {
+    socket.close();
+  });
+
+  it('should connect', async () => {
+    const accessToken = (await createMember(memberFixture, app)).accessToken;
+    const project = await createProject(accessToken, projectPayload, app);
+    socket = connectServer(project.id, accessToken);
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect', () => {
+        resolve();
+      });
+      socket.on('connect_error', () => {
+        reject('connect_error fail');
+      });
+    });
+  });
+
+  it('should connect_error (Token is missing)', async () => {
+    const accessToken = (await createMember(memberFixture, app)).accessToken;
+    const project = await createProject(accessToken, projectPayload, app);
+    socket = io(`${serverUrl}-${project.id}`, {
+      path: '/api/socket.io',
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect_error', (error) => {
+        expect(error).toBeDefined();
+        expect(error.message).toContain('Token is missing');
+        resolve();
+      });
+      registerConnectReject(socket, reject);
+    });
+  });
+
+  it('should connect_error (Expired:tempIdToken)', async () => {
+    const accessToken = (await createMember(memberFixture, app)).accessToken;
+    const project = await createProject(accessToken, projectPayload, app);
+    socket = io(`${serverUrl}-${project.id}`, {
+      path: '/api/socket.io',
+      auth: {
+        accessToken: 'invalidToken',
+      },
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect_error', (error) => {
+        expect(error).toBeDefined();
+        expect(error.message).toContain('Expired:accessToken');
+        resolve();
+      });
+      registerConnectReject(socket, reject);
+    });
+  });
+
+  it('should connect_error (Project not found)', async () => {
+    const accessToken = (await createMember(memberFixture, app)).accessToken;
+    const notFoundProjectId = 0;
+    socket = io(`${serverUrl}-${notFoundProjectId}`, {
+      path: '/api/socket.io',
+      auth: {
+        accessToken,
+      },
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect_error', (error) => {
+        expect(error).toBeDefined();
+        expect(error.message).toContain('Project not found');
+        resolve();
+      });
+      registerConnectReject(socket, reject);
+    });
+  });
+
+  it('should connect_error (Invalid namespace)', async () => {
+    const accessToken = (await createMember(memberFixture, app)).accessToken;
+    const invalidProjectId = 'invalidId';
+    socket = io(`${serverUrl}-${invalidProjectId}`, {
+      path: '/api/socket.io',
+      auth: {
+        accessToken,
+      },
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect_error', (error) => {
+        expect(error).toBeDefined();
+        expect(error.message).toContain('Invalid namespace');
+        resolve();
+      });
+      registerConnectReject(socket, reject);
+    });
+  });
+
+  it('should connect_error (Not Project Member)', async () => {
+    const accessToken = (await createMember(memberFixture, app)).accessToken;
+    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
+      id: memberFixture2.github_id,
+      login: memberFixture2.github_username,
+      avatar_url: memberFixture2.github_image_url,
+    });
+    const { accessToken: newAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+    const newProject = await createProject(newAccessToken, projectPayload, app);
+
+    socket = io(`${serverUrl}-${newProject.id}`, {
+      path: '/api/socket.io',
+      auth: {
+        accessToken,
+      },
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect_error', (error) => {
+        expect(error).toBeDefined();
+        expect(error.message).toContain('Not project member');
+        resolve();
+      });
+      registerConnectReject(socket, reject);
+    });
+  });
+
+  function registerConnectReject(socket, reject) {
+    socket.on('connect', () => {
+      reject('connect fail');
+    });
+  }
+});


### PR DESCRIPTION
## 🎟️ 태스크

[socket.io API 인증, 인가 (백엔드)](https://plastic-toad-cb0.notion.site/socket-io-API-6e2999b629c54253a5fe27a5f93ed9e0?pvs=74)

## ✅ 작업 내용

- feat: 웹소켓 인증, 인가 구현
- test: 클라이언트 socket io 연결시의 성공, 실패 테스트 구현
- refector: setup 모듈을 이용한 테스트 중복제거

## 🖊️ 구체적인 작업

### feat: 웹소켓 인증, 인가 구현
- 웹소켓 게이트웨이에 afterInit을 추가해 클라이언트가 핸드쉐이크시 인증, 인가 성공시에 연결되도록 구현
- 가드를 재활용하기 어려줘 게이트웨이 내부에 authentcation, authorization 함수 추가

### test: 클라이언트 socket io 연결시의 성공, 실패 테스트 구현
- socket io 연결 성공시 connect 이벤트 확인
- token 없이 핸드쉐이크시 connect_error 확인
- 유효하지 않은 token으로 핸드쉐이크시 connect_error 확인
- 존재하지 않는 프로젝트로 연결시 connect_error 확인
- 유효하지 않은 형식의 프로젝트Id로 연결시 connect_error 확인
- 내가 참여하지 않은 프로젝트로 연결시 connect_error 확인
- 테스트 실패시 최대한 타임아웃이 안나도록 connect/connect_error시 reject하도록 변경
- setup 모듈에 createProject 구현
- setup 모듈에 projectPayload 추가
- setup 모듈에 서버 소켓과 연결하는 connectServer 구현

### refector: setup 모듈을 이용한 테스트 중복제거
- projectPayload setup모듈의 객체 사용
- setup모듈의 export인 createProject, connectServer사용해 중복제거
- 타임아웃을 최대한 막기위해 connect_error시 reject하도록 변경

## 🤔 고민 및 의논할 거리

### 핸드쉐이크 시 인증, 인가
- socket.io에서의 여러가지 인증, 인가 방법 중 핸드쉐이크를 하는 시점에서 인증, 인가를 하는것으로 구현했습니다.
- 이에 대한 선택 근거를 [개발일지](https://plastic-toad-cb0.notion.site/socket-io-2960eeb8deb442fb9a7cf5f346127474?pvs=74)에 작성해 놓았습니다.

### 테스트 타임아웃 문제 개선
- 웹소켓 테스트때 실패상황에서 타임아웃까지 기다려야하는 문제를 개선했습니다.
  - 의도하지 않은 연결/연결 실패 상황에서 reject를 호출해 테스트를 즉시 실패하게 했습니다.
``` typescript
  return new Promise<void>((resolve, reject) => {
  .
  .
  .
      socket.on('landing', (data) => {
        resolve();
      });

      socket.on('connect_error', () => {
        reject('connect_error fail');
      });
   });
```

### 테스트 로직 중복제거
- setup 모듈에 공통적으로 사용하는 함수를 추가해 중복로직을 제거했습니다.

``` typescript
//setup 모듈입니다.
export const createProject = async (
  accessToken: String,
  projectPayload: CreateProjectRequestDto,
  app: INestApplication,
): Promise<Project> => {
  await request(app.getHttpServer())
    .post('/api/project')
    .set('Authorization', `Bearer ${accessToken}`)
    .send(projectPayload);
  const response = await request(app.getHttpServer())
    .get('/api/project')
    .set('Authorization', `Bearer ${accessToken}`);
  const [project] = response.body.projects;
  return project;
};

export const connectServer = (projectId, accessToken) => {
  const socket = io(`http://localhost:3000/project-${projectId}`, {
    path: '/api/socket.io',
    auth: {
      accessToken,
    },
  });
  return socket;
};
```

### 10명 초과 프로젝트 참여 접속 테스트 어떻게?
- 시연방식을 보니 10명이 넘는 프로젝트는 참여하지 못하게 해야합니다. 현재 이러한 경우를 처리하는 태스크가 없어 추가해놓겠습니다.


### 웹소켓 에러를 메시지말고 번호로 구분할 수 있는지 궁금함
- 제가 학습한 바에 따르면 핸드쉐이크 상황에서는 실패시 에러 텍스트만 보낼 수 있는것 같습니다. 메시지 뿐만 아니라 에러번호로 에러를 구분할 수 있게, 에러상황에서 추가적인 정보를 보낼 수 있는지 궁금합니다.