### PR TITLE
refactor: 프로젝트 addMember 서비스의 매개변수를 projectLinkId → project로 변경

### DIFF
--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -6,7 +6,6 @@ import {
   Post,
   Req,
   Res,
-  UseGuards,
 } from '@nestjs/common';
 import { ProjectService } from './service/project.service';
 import { CreateProjectRequestDto } from './dto/CreateProjectRequest.dto';
@@ -63,7 +62,7 @@ export class ProjectController {
     if (isProjectMember)
       return response.status(200).send({ projectId: project.id });
 
-    await this.projectService.addMember(body.inviteLinkId, request.member);
+    await this.projectService.addMember(project, request.member);
     return response.status(201).send();
   }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -20,7 +20,6 @@ describe('ProjectService', () => {
             addProjectMember: jest.fn(),
             getProjectList: jest.fn(),
             getProject: jest.fn(),
-            getProjectByLinkId: jest.fn(),
             getProjectToMember: jest.fn(),
           },
         },
@@ -86,21 +85,16 @@ describe('ProjectService', () => {
   });
 
   describe('Add Member', () => {
-    const projectLinkId = 'inviteUuid';
     const project = Project.of('title', 'subject');
-    it('should return void when given member, title, subject', async () => {
-      jest
-        .spyOn(projectRepository, 'getProjectByLinkId')
-        .mockResolvedValue(project);
+    project.inviteLinkId = 'inviteUuid';
+
+    it('should return void when given project and member', async () => {
       jest
         .spyOn(projectRepository, 'getProjectToMember')
         .mockResolvedValue(null);
 
-      await projectService.addMember(projectLinkId, member);
+      await projectService.addMember(project, member);
 
-      expect(projectRepository.getProjectByLinkId).toHaveBeenCalledWith(
-        projectLinkId,
-      );
       expect(projectRepository.addProjectMember).toHaveBeenCalledWith(
         project,
         member,
@@ -109,25 +103,12 @@ describe('ProjectService', () => {
 
     it('should throw when already joined member', async () => {
       jest
-        .spyOn(projectRepository, 'getProjectByLinkId')
-        .mockResolvedValue(project);
-      jest
         .spyOn(projectRepository, 'getProjectToMember')
         .mockResolvedValue(ProjectToMember.of(project, member));
 
       await expect(
-        async () => await projectService.addMember(projectLinkId, member),
+        async () => await projectService.addMember(project, member),
       ).rejects.toThrow('already joined member');
-    });
-
-    it('should throw when invalid project link id', async () => {
-      jest
-        .spyOn(projectRepository, 'getProjectByLinkId')
-        .mockResolvedValue(null);
-
-      await expect(
-        async () => await projectService.addMember(projectLinkId, member),
-      ).rejects.toThrow('project link id not found');
     });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -23,21 +23,14 @@ export class ProjectService {
     return await this.projectRepository.getProject(projectId);
   }
 
-  async addMember(projectLinkId: string, member: Member): Promise<void> {
-    const project =
-      await this.projectRepository.getProjectByLinkId(projectLinkId);
-    if (!project) throw new Error('project link id not found');
-
+  async addMember(project: Project, member: Member): Promise<void> {
     const isProjectMember = await this.isProjectMember(project, member);
     if (isProjectMember) throw new Error('already joined member');
 
     await this.projectRepository.addProjectMember(project, member);
   }
 
-  async isProjectMember(
-    project: Project,
-    member: Member,
-  ): Promise<boolean> {
+  async isProjectMember(project: Project, member: Member): Promise<boolean> {
     const projectToMember: ProjectToMember | null =
       await this.projectRepository.getProjectToMember(project, member);
     if (!projectToMember) return false;


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 addMember 서비스의 매개변수를 projectLinkId → project로 변경](https://plastic-toad-cb0.notion.site/addMember-projectLinkId-project-3fb96fa0838d4071aeac2b712d25a432)

## ✅ 작업 내용
- [프로젝트 addMember 서비스의 매개변수를 projectLinkId → project로 변경](https://github.com/boostcampwm2023/web10-Lesser/commit/ed7b77e7370c208660569430d20549ceb7afc640)

## 🖊️ 구체적인 작업

### 프로젝트 addMember 서비스의 매개변수 변경

- addMember 서비스 로직의 재사용성을 고려해 기존에 uuid인 projectLinkId를 매개변수로 받던 부분을 Project 객체를 받도록 변경하였습니다. 
- 이에 따라 addMember 서비스 로직에서 getProjectByLinkId를 호출하던 부분을 삭제했고, 
- 단위 테스트 및 컨트롤러 addMember 호출자를 수정했습니다.
```ts
  async addMember(project: Project, member: Member): Promise<void> {
    const isProjectMember = await this.isProjectMember(project, member);
    if (isProjectMember) throw new Error('already joined member');

    await this.projectRepository.addProjectMember(project, member);
  }
```