### PR TITLE
feat : 클라이언트에서 웹소켓 연결시 액세스 토큰 보내기

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -69,17 +69,17 @@ const router = createBrowserRouter([
           path: ROUTER_URL.PROJECTS_CREATE,
           element: <ProjectCreatePage />,
         },
+        {
+          path: ROUTER_URL.MAIN,
+          element: <MainPage />,
+          children: [
+            { index: true, element: <LandingPage /> },
+            { path: ROUTER_URL.BACKLOG, element: <div>backlog Page</div> },
+            { path: ROUTER_URL.SPRINT, element: <div>sprint Page</div> },
+            { path: ROUTER_URL.SETTINGS, element: <div>setting Page</div> },
+          ],
+        },
       ]),
-      {
-        path: ROUTER_URL.MAIN,
-        element: <MainPage />,
-        children: [
-          { index: true, element: <LandingPage /> },
-          { path: ROUTER_URL.BACKLOG, element: <div>backlog Page</div> },
-          { path: ROUTER_URL.SPRINT, element: <div>sprint Page</div> },
-          { path: ROUTER_URL.SETTINGS, element: <div>setting Page</div> },
-        ],
-      },
       {
         path: ROUTER_URL.INVITE,
         element: <InvitePage />,

--- a/frontend/src/apis/utils/authAPI.ts
+++ b/frontend/src/apis/utils/authAPI.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import axios, {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from "axios";
 import { API_URL, BASE_URL } from "../../constants/path";
 import { RefreshDTO } from "../../types/DTO/authDTO";
 
@@ -10,6 +14,10 @@ const setAccessToken = (newAccessToken: string | undefined) => {
 
 const checkAccessToken = (): boolean => {
   return !!accessToken;
+};
+
+const getAccessToken = (): string | undefined => {
+  return accessToken;
 };
 
 const authAPI = axios.create({
@@ -69,4 +77,4 @@ const successRefresh = async (
 
 authAPI.interceptors.response.use(successResponse, failResponse);
 
-export { authAPI, setAccessToken, checkAccessToken };
+export { authAPI, setAccessToken, checkAccessToken, getAccessToken };

--- a/frontend/src/hooks/common/socket/useSocket.ts
+++ b/frontend/src/hooks/common/socket/useSocket.ts
@@ -1,11 +1,15 @@
 import { io } from "socket.io-client";
 import { BASE_URL } from "../../../constants/path";
 import { useEffect, useState } from "react";
+import { getAccessToken } from "../../../apis/utils/authAPI";
 
 const useSocket = (projectId: string) => {
   const WS_URL = `${BASE_URL}/project-${projectId}`;
   const socket = io(WS_URL, {
     path: `/api/socket.io`,
+    auth: {
+      accessToken: getAccessToken(),
+    },
   });
   const [connected, setConnected] = useState<boolean>(false);
 


### PR DESCRIPTION
[클라이언트에서 웹소켓 연결시 액세스 토큰 보내기](https://www.notion.so/95e0d5fe9d814f58ab8f9b215aeed7a5?pvs=4)

## ✅ 작업 내용

- 웹소켓에서 엑세스토큰을 담아 전달하도록 코드 수정
- main page를 private router로 이동

## 🖊️ 구체적인 작업

### 액세스 토큰 전달
accessToken을 socket.io에 전달하여 웹소켓 통신 생성
1. accessToken을 가지고 오는 getAccessToken 함수 작성
    - 함수 형태로 가져오는 코드 작성 : accessToken을 가지고 오면서 추가적인 처리가 있을 수 있기 때문에 함수로 처리
2. io함수에 auth 설정 추가

### private router로 main page를 이동
- main page의 경우, 새로고침 혹은 accessToken 만료의 경우 새롭게 데이터를 받아오지 못하는 문제 발생
- private router에 main page를 배치하여 accessToken을 검증하며 refresh하는 코드 동작