### PR TITLE
refector: 테스트 셋업 메서드 추가

### DIFF
--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -123,7 +123,7 @@ export class AuthService {
     tempIdToken: string,
     username: string,
     position: string,
-    techStack: object,
+    techStack: { stacks: string[] },
   ) {
     const tempMember = await this.getTempMember(tempIdToken);
     const memberId = await this.memberService.save(

--- a/backend/src/member/entity/member.entity.ts
+++ b/backend/src/member/entity/member.entity.ts
@@ -32,7 +32,7 @@ export class Member {
   position: string;
 
   @Column({ type: 'json', nullable: false })
-  tech_stack: object;
+  tech_stack: { stacks: string[] };
 
   @OneToMany(() => ProjectToMember, (projectToMember) => projectToMember.member)
   projectToMember: ProjectToMember;
@@ -49,7 +49,7 @@ export class Member {
     githubImageUrl: string,
     username: string,
     position: string,
-    techStack: object,
+    techStack: { stacks: string[] },
   ) {
     const newMember = new Member();
     newMember.github_id = githubId;

--- a/backend/src/member/service/member.service.ts
+++ b/backend/src/member/service/member.service.ts
@@ -19,7 +19,7 @@ export class MemberService {
     githubImageUrl: string,
     username: string,
     position: string,
-    techStack: object,
+    techStack: { stacks: string[] },
   ): Promise<number> {
     const member = await this.memberRepository.create(
       Member.of(

--- a/backend/test/auth/get-github-username.e2e-spec.ts
+++ b/backend/test/auth/get-github-username.e2e-spec.ts
@@ -1,8 +1,16 @@
 import * as request from 'supertest';
-import { app, githubUserFixture } from 'test/setup';
+import { app, githubApiService } from 'test/setup';
 
 describe('GET /api/auth/github/username', () => {
   it('should return 200 when given valid tempIdToken', async () => {
+    const githubUserFixture = {
+      id: '123',
+      login: 'username',
+      avatar_url: 'avatar_url',
+    };
+    jest
+      .spyOn(githubApiService, 'fetchGithubUser')
+      .mockResolvedValue(githubUserFixture);
     const authenticationResponse = await request(app.getHttpServer())
       .post('/api/auth/github/authentication')
       .send({ authCode: 'authCode' });

--- a/backend/test/auth/github-signup.e2e-spec.ts
+++ b/backend/test/auth/github-signup.e2e-spec.ts
@@ -1,5 +1,10 @@
 import * as request from 'supertest';
-import { app, jwtTokenPattern, memberFixture } from 'test/setup';
+import {
+  app,
+  githubApiService,
+  jwtTokenPattern,
+  memberFixture,
+} from 'test/setup';
 
 describe('POST /api/auth/github/signup', () => {
   const memberSignupPayload = {
@@ -8,6 +13,14 @@ describe('POST /api/auth/github/signup', () => {
     techStack: memberFixture.tech_stack.stacks,
   };
   it('should return 201', async () => {
+    const githubUserFixture = {
+      id: '123',
+      login: 'username',
+      avatar_url: 'avatar_url',
+    };
+    jest
+      .spyOn(githubApiService, 'fetchGithubUser')
+      .mockResolvedValue(githubUserFixture);
     const authenticationResponse = await request(app.getHttpServer())
       .post('/api/auth/github/authentication')
       .send({ authCode: 'authCode' });

--- a/backend/test/project/join-project.e2e-spec.ts
+++ b/backend/test/project/join-project.e2e-spec.ts
@@ -40,11 +40,6 @@ describe('Join Project', () => {
   });
 
   it('should return 201', async () => {
-    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
-      id: '321',
-      login: 'username',
-      avatar_url: 'avatar_url',
-    });
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,
@@ -57,11 +52,6 @@ describe('Join Project', () => {
   });
 
   it('should return 200 when already joined member', async () => {
-    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
-      id: '321',
-      login: 'username',
-      avatar_url: 'avatar_url',
-    });
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,
@@ -80,11 +70,6 @@ describe('Join Project', () => {
   });
 
   it('should return 400 when given bad request', async () => {
-    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
-      id: '321',
-      login: 'username',
-      avatar_url: 'avatar_url',
-    });
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,
@@ -117,11 +102,6 @@ describe('Join Project', () => {
 
   it('should return 404 when project link ID is not found', async () => {
     const invalidUUID = 'c93a87e8-a0a4-4b55-bdf2-59bf691f5c37';
-    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
-      id: memberFixture2.github_id,
-      login: memberFixture2.github_username,
-      avatar_url: memberFixture2.github_image_url,
-    });
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,

--- a/backend/test/project/join-project.e2e-spec.ts
+++ b/backend/test/project/join-project.e2e-spec.ts
@@ -2,56 +2,50 @@ import * as request from 'supertest';
 import {
   app,
   appInit,
-  connectServer,
   createMember,
   createProject,
-  githubApiService,
+  getProjectLinkId,
   memberFixture,
   memberFixture2,
   projectPayload,
 } from 'test/setup';
 
 describe('Join Project', () => {
-  let socket;
-  let projectLinkId;
-  let projectId;
   beforeEach(async () => {
     await app.close();
     await appInit();
     await app.listen(3000);
-
-    const { accessToken } = await createMember(memberFixture, app);
-    const project = await createProject(accessToken, projectPayload, app);
-    projectId = project.id;
-    socket = connectServer(projectId, accessToken);
-    await new Promise<void>((resolve) => {
-      socket.on('connect', () => {
-        socket.emit('joinLanding');
-      });
-      socket.on('landing', (data) => {
-        const { content } = data;
-        projectLinkId = content.inviteLinkId;
-        resolve();
-      });
-    });
-  });
-  afterEach(async () => {
-    socket.close();
   });
 
   it('should return 201', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(accessToken, projectId);
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,
     );
+
     const response = await request(app.getHttpServer())
       .post('/api/project/join')
       .set('Authorization', `Bearer ${newAccessToken}`)
       .send({ inviteLinkId: projectLinkId });
+
     expect(response.status).toBe(201);
   });
 
   it('should return 200 when already joined member', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(accessToken, projectId);
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,
@@ -65,6 +59,7 @@ describe('Join Project', () => {
       .post('/api/project/join')
       .set('Authorization', `Bearer ${newAccessToken}`)
       .send({ inviteLinkId: projectLinkId });
+
     expect(response.status).toBe(200);
     expect(response.body.projectId).toBe(projectId);
   });
@@ -83,6 +78,14 @@ describe('Join Project', () => {
   });
 
   it('should return 401 (Bearer Token is missing)', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(accessToken, projectId);
+
     const response = await request(app.getHttpServer())
       .post('/api/project/join')
       .send({ inviteLinkId: projectLinkId });
@@ -91,6 +94,14 @@ describe('Join Project', () => {
   });
 
   it('should return 401 (Expired:accessToken) when given invalid access token', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(accessToken, projectId);
+
     const response = await request(app.getHttpServer())
       .post('/api/project/join')
       .set('Authorization', `Bearer invalidToken`)

--- a/backend/test/project/ws-connection.e2e-spec.ts
+++ b/backend/test/project/ws-connection.e2e-spec.ts
@@ -119,11 +119,6 @@ describe('WS landing', () => {
 
   it('should connect_error (Not Project Member)', async () => {
     const accessToken = (await createMember(memberFixture, app)).accessToken;
-    jest.spyOn(githubApiService, 'fetchGithubUser').mockResolvedValue({
-      id: memberFixture2.github_id,
-      login: memberFixture2.github_username,
-      avatar_url: memberFixture2.github_image_url,
-    });
     const { accessToken: newAccessToken } = await createMember(
       memberFixture2,
       app,

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -84,7 +84,32 @@ export const createProject = async (
   return project;
 };
 
-export const joinProject = async () => {};
+export const getProjectLinkId = async (
+  accessToken: string,
+  projectId: number,
+) => {
+  let projectLinkId;
+  const socket = connectServer(projectId, accessToken);
+  await new Promise<void>((resolve) => {
+    socket.on('connect', () => {
+      socket.emit('joinLanding');
+    });
+    socket.on('landing', (data) => {
+      const { content } = data;
+      projectLinkId = projectLinkId = content.inviteLinkId;
+      resolve();
+    });
+  });
+  socket.close();
+  return projectLinkId;
+};
+
+export const joinProject = (accessToken: string, projectLinkId: string) => {
+  request(app.getHttpServer())
+    .post('/api/project/join')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({ inviteLinkId: projectLinkId });
+};
 
 export const connectServer = (projectId, accessToken) => {
   const socket = io(`http://localhost:3000/project-${projectId}`, {


### PR DESCRIPTION
## 🎟️ 태스크

[E2E 테스트 멤버, 프로젝트 등 Fixture 데이터베이스에 저장하는 메서드 만들기 (JoinProject)](https://plastic-toad-cb0.notion.site/E2E-Fixture-JoinProject-bf75bb5dfff2456b9854bd5130e55d1f?pvs=74)

## ✅ 작업 내용

- refector: setup에서 기본적으로 이루어지는 깃허브 모킹로직 삭제, createMember 메서드 내부에서 모킹을 하도록 변경
- refector: Member 엔티티의 techStack 프로퍼티 타입 변경
- refector: setup 모듈에서 프로젝트의 링크아이디 얻는 메서드, 프로젝트에 참여하는 메서드 추가

## 🖊️ 구체적인 작업
### setup에서 기본적으로 이루어지는 깃허브 모킹로직 삭제, createMember 메서드 내부에서 모킹을 하도록 변경
올바른 타입 추론을 위해 Member 엔티티의 techStack 프로퍼티 타입을 `object`에서 `stacks: string[]`으로 변경

### Member 엔티티의 techStack 프로퍼티 타입 변경
- setup에서 기본적으로 이루어지는 깃허브 모킹로직 삭제
- setup 단계의 로직을 이해하고 있지 않으면, 테스트로직만 보고 이해할 수 없기 때문에 setup의 모킹 로직 삭제
- createMember 메서드 내부에서 모킹을 하도록 변경
- 기존의 로직은 모킹을 한 후, createMember를 호출해야 정상적인 처리가 가능했음. 이 사실을 몰라도 createMember를 사용할 수 있도록 변경
- createMember의 매개변수를 Member타입으로 지정
- memberFixture를 member 타입으로 변경

### setup 모듈에서 프로젝트의 링크아이디 얻는 메서드, 프로젝트에 참여하는 메서드 추가
- setup 모듈에서 프로젝트의 링크아이디 얻는 메서드
- 프로젝트에 참여하는 메서드 추가
- E2E 테스트에서 beforeEach에 있는 테스트 관련 로직 삭제