### PR TITLE
feat: 메모 생성 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ErrorExceptionFilter } from './common/exception-filter/exception.filter';
 import { AuthenticationGuard } from './common/guard/authentication.guard';
 import { MemberRepository } from './member/repository/member.repository';
+import { Memo } from './project/entity/memo.entity';
 
 @Module({
   imports: [
@@ -39,7 +40,14 @@ import { MemberRepository } from './member/repository/member.repository';
         username: ConfigService.get(DATABASE_USER),
         password: ConfigService.get(DATABASE_PASSWORD),
         database: ConfigService.get(DATABASE_NAME),
-        entities: [Member, TempMember, LoginMember, Project, ProjectToMember],
+        entities: [
+          Member,
+          TempMember,
+          LoginMember,
+          Project,
+          ProjectToMember,
+          Memo,
+        ],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),
     }),
@@ -61,7 +69,7 @@ import { MemberRepository } from './member/repository/member.repository';
       provide: APP_GUARD,
       useClass: AuthenticationGuard,
     },
-	MemberRepository
+    MemberRepository,
   ],
 })
 export class AppModule {

--- a/backend/src/member/service/member.service.spec.ts
+++ b/backend/src/member/service/member.service.spec.ts
@@ -79,4 +79,25 @@ describe('LesserJwtService', () => {
       expect(githubImageUrl).toBe(newMember.github_image_url);
     });
   });
+
+  describe('Get Member Info By Id', () => {
+    const memberFixture = Member.of(
+      123,
+      'github_username',
+      'avatar_url',
+      'username',
+      'position',
+      { stacks: ['js', 'ts'] },
+    );
+    it('should return member when id is valid', async () => {
+      const storedMember = { ...memberFixture };
+      const id = 0;
+      storedMember.id = id;
+
+      jest.spyOn(memberRepository, 'findById').mockResolvedValue(storedMember);
+
+      const foundMember = await memberService.getMember(id);
+      expect(foundMember).toEqual(storedMember);
+    });
+  });
 });

--- a/backend/src/member/service/member.service.ts
+++ b/backend/src/member/service/member.service.ts
@@ -52,4 +52,8 @@ export class MemberService {
       githubImageUrl: member.github_image_url,
     };
   }
+
+  async getMember(id: number): Promise<Member> {
+    return this.memberRepository.findById(id);
+  }
 }

--- a/backend/src/project/dto/MemoCreateRequest.dto.ts
+++ b/backend/src/project/dto/MemoCreateRequest.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsEnum, Matches, ValidateNested } from 'class-validator';
+import { memoColor } from '../entity/memo.entity';
+
+class Color {
+  @IsEnum(memoColor)
+  color: memoColor;
+}
+
+export class MemoCreateRequestDto {
+  @Matches(/^create$/)
+  action: string;
+
+  @ValidateNested()
+  @Type(() => Color)
+  content: Color;
+}

--- a/backend/src/project/entity/memo.entity.ts
+++ b/backend/src/project/entity/memo.entity.ts
@@ -1,0 +1,65 @@
+import { Member } from 'src/member/entity/member.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+export enum memoColor {
+  YELLOW = 'yellow',
+  BLUE = 'gray',
+  GRAY = 'red',
+  RED = 'blue',
+}
+
+@Entity()
+export class Memo {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  id: number;
+
+  //   @Column({ nullable: false })
+  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @Column({ type: 'varchar', length: 256, nullable: false })
+  title: string;
+
+  @Column({ type: 'varchar', length: 1024, nullable: false })
+  content: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  @OneToOne(() => Member, (member) => member.id, { nullable: false })
+  @JoinColumn({ name: 'member_id' })
+  member: Member;
+
+  @Column({ type: 'varchar', nullable: false })
+  color: memoColor;
+
+  static of(
+    project: Project,
+    member: Member,
+    title: string,
+    content: string,
+    color: memoColor,
+  ) {
+    const newMemo = new Memo();
+    newMemo.project = project;
+    newMemo.member = member;
+    newMemo.title = title;
+    newMemo.content = content;
+    newMemo.color = color;
+    return newMemo;
+  }
+}

--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -6,7 +6,9 @@ import {
   UpdateDateColumn,
   OneToMany,
   Generated,
+  JoinColumn,
 } from 'typeorm';
+import { Memo } from './memo.entity';
 import { ProjectToMember } from './project-member.entity';
 
 @Entity()
@@ -35,6 +37,9 @@ export class Project {
 
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
+
+  @OneToMany(() => Memo, (memo) => memo.id)
+  memoList: Memo[];
 
   static of(title: string, subject: string) {
     const newProject = new Project();

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -9,16 +9,19 @@ import { Member } from 'src/member/entity/member.entity';
 import { ProjectRepository } from './project.repository';
 import { MemberRepository } from 'src/member/repository/member.repository';
 import { ProjectWebsocketGateway } from './websocket.gateway';
+import { Memo } from './entity/memo.entity';
+import { MemberService } from 'src/member/service/member.service';
 
 @Module({
   imports: [
     LesserJwtModule,
-    TypeOrmModule.forFeature([Project, ProjectToMember, Member]),
+    TypeOrmModule.forFeature([Project, ProjectToMember, Member, Memo]),
   ],
   controllers: [ProjectController],
   providers: [
     ProjectService,
     ProjectRepository,
+	MemberService,
     MemberRepository,
     ProjectWebsocketGateway,
   ],

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { Project } from './entity/project.entity';
 import { ProjectToMember } from './entity/project-member.entity';
 import { Member } from 'src/member/entity/member.entity';
+import { Memo, memoColor } from './entity/memo.entity';
 
 @Injectable()
 export class ProjectRepository {
@@ -12,6 +13,8 @@ export class ProjectRepository {
     private readonly projectRepository: Repository<Project>,
     @InjectRepository(ProjectToMember)
     private readonly projectToMemberRepository: Repository<ProjectToMember>,
+    @InjectRepository(Memo)
+    private readonly memoRepository: Repository<Memo>,
   ) {}
 
   create(project: Project): Promise<Project> {
@@ -48,5 +51,9 @@ export class ProjectRepository {
     return this.projectToMemberRepository.findOne({
       where: { project: { id: project.id }, member: { id: member.id } },
     });
+  }
+
+  createMemo(memo: Memo): Promise<Memo> {
+    return this.memoRepository.save(memo);
   }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -4,6 +4,7 @@ import { ProjectRepository } from '../project.repository';
 import { Member } from 'src/member/entity/member.entity';
 import { Project } from '../entity/project.entity';
 import { ProjectToMember } from '../entity/project-member.entity';
+import { Memo, memoColor } from '../entity/memo.entity';
 
 describe('ProjectService', () => {
   let projectService: ProjectService;
@@ -21,6 +22,7 @@ describe('ProjectService', () => {
             getProjectList: jest.fn(),
             getProject: jest.fn(),
             getProjectToMember: jest.fn(),
+            createMemo: jest.fn(),
           },
         },
       ],
@@ -109,6 +111,27 @@ describe('ProjectService', () => {
       await expect(
         async () => await projectService.addMember(project, member),
       ).rejects.toThrow('already joined member');
+    });
+  });
+
+  describe('Create memo', () => {
+    const color = memoColor.YELLOW;
+    const [title, subject] = ['title', 'subject'];
+    const project = Project.of(title, subject);
+    it('should return created memo', async () => {
+      jest
+        .spyOn(projectRepository, 'createMemo')
+        .mockResolvedValue(Memo.of(project, member, '', '', color));
+
+      const memo: Memo = await projectService.createMemo(
+        project,
+        member,
+        color,
+      );
+      expect(memo.title).toBe('');
+      expect(memo.content).toBe('');
+      expect(memo.color).toBe(color);
+      expect(memo.member.id).toBe(member.id);
     });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -3,6 +3,7 @@ import { ProjectRepository } from '../project.repository';
 import { Member } from 'src/member/entity/member.entity';
 import { Project } from '../entity/project.entity';
 import { ProjectToMember } from '../entity/project-member.entity';
+import { Memo, memoColor } from '../entity/memo.entity';
 
 @Injectable()
 export class ProjectService {
@@ -39,5 +40,14 @@ export class ProjectService {
 
   getProjectByLinkId(projectLinkId: string): Promise<Project | null> {
     return this.projectRepository.getProjectByLinkId(projectLinkId);
+  }
+
+  async createMemo(
+    project: Project,
+    member: Member,
+    color: memoColor,
+  ) {
+	const newMemo = Memo.of(project, member, "", "", color);
+	return this.projectRepository.createMemo(newMemo);
   }
 }

--- a/backend/test/project/ws-memo.e2e-spec.ts
+++ b/backend/test/project/ws-memo.e2e-spec.ts
@@ -1,0 +1,126 @@
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  joinProject,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+
+describe('WS memo', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  it('should return created memo data when received create memo request', async () => {
+    let socket1;
+    let socket2;
+    return new Promise<void>(async (resolve, reject) => {
+      // 회원1 회원가입 + 프로젝트 생성
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+      // 회원2 회원가입 + 프로젝트 참여
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      await joinProject(accessToken2, projectLinkId);
+
+      socket1 = connectServer(project.id, accessToken);
+      await emitJoinLanding(socket1);
+      await initLanding(socket1);
+
+      socket2 = connectServer(project.id, accessToken2);
+      await emitJoinLanding(socket2);
+      await initLanding(socket2);
+
+      const requestData = {
+        action: 'create',
+        content: { color: 'yellow' },
+      };
+      socket1.emit('memo', requestData);
+      socket1.on('error', () => {
+        reject();
+      });
+      await Promise.all([
+        expectMemo(socket1, memberFixture.username, requestData.content.color),
+        expectMemo(socket2, memberFixture.username, requestData.content.color),
+      ]);
+      resolve();
+    }).finally(() => {
+      socket1.close();
+      socket2.close();
+    });
+  });
+
+  it('should return error message list when data format is invalid', async () => {
+    let socket;
+    return new Promise<void>(async (resolve) => {
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+
+      socket = connectServer(project.id, accessToken);
+      await emitJoinLanding(socket);
+      await initLanding(socket);
+
+      const requestData = {
+        action: 'create',
+        content: { color: 'invalidColor' },
+      };
+      socket.emit('memo', requestData);
+      socket.on('error', (data) => {
+        expect(data.errorList).toBeDefined();
+        expect(data.errorList.length).toBeGreaterThan(0);
+        resolve();
+      });
+    }).finally(() => {
+      socket.close();
+    });
+  });
+});
+
+const expectMemo = (socket, author, color) => {
+  return new Promise<void>((res) => {
+    socket.on('landing', (data) => {
+      const { content, action, domain } = data;
+      expect(domain).toBe('memo');
+      expect(action).toBe('create');
+      expect(content.id).toBeDefined();
+      expect(content.title).toBeDefined();
+      expect(content.content).toBeDefined();
+      expect(content.createdAt).toBeDefined();
+      expect(content.author).toBe(author);
+      expect(content.color).toBe(color);
+      socket.off('landing');
+      res();
+    });
+  });
+};
+
+const emitJoinLanding = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('connect', () => {
+      socket.emit('joinLanding');
+      socket.off('connect');
+      res();
+    });
+  });
+};
+
+const initLanding = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('landing', (data) => {
+      const { action, content, domain } = data;
+      if (action === 'init') {
+        socket.off('landing');
+        res();
+      }
+    });
+  });
+};

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -104,8 +104,11 @@ export const getProjectLinkId = async (
   return projectLinkId;
 };
 
-export const joinProject = (accessToken: string, projectLinkId: string) => {
-  request(app.getHttpServer())
+export const joinProject = async (
+  accessToken: string,
+  projectLinkId: string,
+) => {
+  await request(app.getHttpServer())
     .post('/api/project/join')
     .set('Authorization', `Bearer ${accessToken}`)
     .send({ inviteLinkId: projectLinkId });


### PR DESCRIPTION
## 🎟️ 태스크

[메모 생성 웹소켓 API 구현 (백)](https://plastic-toad-cb0.notion.site/API-28e767d42bf247bf8d3b8950f30aa313?pvs=74)

## ✅ 작업 내용

- 메모 생성 API e2e 테스트코드 추가
- 메모 엔티티 생성
- 메모생성 서비스 구현
- 메모 생성 게이트웨이 구현

## 🖊️ 구체적인 작업

### 메모 생성 API e2e 테스트코드 추가
- 회원 2명이 랜딩 페이지에 접속한 상태에서 메모 생성시 모든 회원이 생성된 메모 데이터를 받는 테스트 추가
- 잘못된 메모 데이터 전송시 에러 수신하는 테스트 추가

### 메모 엔티티 생성
- 메모 엔티티 생성
- 프로젝트 엔티티에 메모 프로퍼티 추가
- 모듈에 메모 등록

### 메모생성 서비스 구현
- project 레포지토리, 서비스에 메모를 생성하는 createMemo 메서드 구현
- 메모생성 유닛 테스트 추가
- member 서비스에 회원을 id로 조회하는 getMember 메서드 구현
- 회원조회 유닛 테스트 추가

### 메모 생성 게이트웨이 구현
- 'memo' 이벤트를 구독하는 게이트웨이 구현
- 데이터 형식 검증로직 구현
- memoCreateRequest DTO 추가
- 메모 생성시 'landing' 페이지에 접속한 회원에게 이벤트를 전송하는 로직 구현

## 🤔 고민 및 의논할 거리
- 웹소켓 테스트에서 여러명의 클라이언트가 서버에 연결하는 로직을 작성해야 했습니다. 이때 모두가 방에 참여한 상태에서 메모를 생성하고 
적절한 데이터를 받는것을 테스트해야 했는데, socket.io API는 콜백함수를 받는 이벤트 형식으로 되어있어서 여러명의 클라이언트가 모두 방에 참여한 것을 보장하는 로직을 작성하면 콜백지옥에 빠지게 되었습니다.
  ```ts
  socket1.on("connect", () => {
    socket1.emit("joinLanding");
    socket2 = connectServer(project.id, accessToken2);
    socket2.on("connect", () => {
      socket2.emit("joinLanding");
    });
    socket2.on("landing", (data) => {
      const { action, content, domain } = data;
      if (action === "init") {
        const requestData = {
          action: "create",
          content: { color: "yellow" },
        };
        socket2.emit("memo", requestData);
      } else if (domain === "memo") {
        expect(content.author).toBe(memberFixture2.username);
      }
    });
  });
  
  ```
- 이는 테스트의 가독성을 떨어트렸기 때문에 개선이 필요하다고 생각했습니다. 개선방법으로 이벤트를 프로미스로 감싸 await를 사용할 수 있게 해 콜백지옥을 탈출할 수 있었습니다.
  ```ts
  // 회원1 회원가입 + 프로젝트 생성
  const accessToken = (await createMember(memberFixture, app)).accessToken;
  const project = await createProject(accessToken, projectPayload, app);
  const projectLinkId = await getProjectLinkId(accessToken, project.id);
  
  // 회원2 회원가입 + 프로젝트 참여
  const accessToken2 = (await createMember(memberFixture2, app)).accessToken;
  await joinProject(accessToken2, projectLinkId);
  
  // socket1 연결 + 최초 연결 데이터 받아오기
  socket1 = connectServer(project.id, accessToken);
  await emitJoinLanding(socket1);
  await initLanding(socket1);
  
  // socket2 연결 + 최초 연결 데이터 받아오기
  socket2 = connectServer(project.id, accessToken2);
  await emitJoinLanding(socket2);
  await initLanding(socket2);
  
  // socket1에서 서버로 "memo" 이벤트를 전송
  const requestData = {
    action: "create",
    content: { color: "yellow" },
  };
  socket1.emit("memo", requestData);
  socket1.on("error", () => {
    reject();
  });
  
  // socket1, socket2에 대해 각자 테스트 로직 수행하여 서버에서 전송한 메시지를 정상적으로 받는지 확인
  await Promise.all([
    expectMemo(socket1, memberFixture.username, requestData.content.color),
    expectMemo(socket2, memberFixture.username, requestData.content.color),
  ]);
  
  const emitJoinLanding = (socket) => {
    return new Promise<void>((res, rej) => {
      socket.on('connect', () => {
        socket.emit('joinLanding');
        socket.off('connect');
        res();
      });
    });
  };
  
  const initLanding = (socket) => {
    return new Promise<void>((res, rej) => {
      socket.on('landing', (data) => {
        const { action, content, domain } = data;
        if (action === 'init') {
          socket.off('landing');
          res();
        }
      });
    });
  };
  ```


- 이에대한 상세한 내용은 저희팀의 [개발일지](https://plastic-toad-cb0.notion.site/4f6984c09d324268a678ed04aa74b59e?pvs=74)에서 확인할 수 있습니다.