### PR TITLE
fix: 메모 생성 API 버그수정 및 회귀 테스트 추가

### DIFF
--- a/backend/src/project/dto/MemoCreateRequest.dto.ts
+++ b/backend/src/project/dto/MemoCreateRequest.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsEnum, Matches, ValidateNested } from 'class-validator';
+import { IsEnum, IsNotEmpty, Matches, ValidateNested } from 'class-validator';
 import { memoColor } from '../entity/memo.entity';
 
 class Color {
@@ -11,6 +11,7 @@ export class MemoCreateRequestDto {
   @Matches(/^create$/)
   action: string;
 
+  @IsNotEmpty()
   @ValidateNested()
   @Type(() => Color)
   content: Color;

--- a/backend/src/project/entity/memo.entity.ts
+++ b/backend/src/project/entity/memo.entity.ts
@@ -5,7 +5,6 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
-  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
@@ -40,7 +39,7 @@ export class Memo {
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
 
-  @OneToOne(() => Member, (member) => member.id, { nullable: false })
+  @ManyToOne(() => Member, (member) => member.id, { nullable: false })
   @JoinColumn({ name: 'member_id' })
   member: Member;
 


### PR DESCRIPTION
## ✅ 작업 내용

### 메모 생성 API 버그수정 및 회귀 테스트 추가
- 같은 회원이 여러개의 메모를 생성할 수 없는 버그 수정
  - 메모와 회원이 one to one으로 연결되어 있어서 메모의 member_id 컬럼에 unique제약조건이 붙음
  - many to one으로 수정함
  - 회귀 테스트 추가
- 메모 생성 API에서 content속성을 보내지 않으면 internal error가 반환되는 버그 수정
  - ClassValidator의 ValidateNested 데코레이터를 사용하고, 검사하고자 하는 객체가 undefined일때 validate를 통과하는 이슈가 있음
  - isNotEmpty 데코레이터를 추가해 해결함
  - 회귀 테스트 추가

## 트러블 슈팅 과정
- 한명의 회원이 여러번 메모를 생성시 아래와 같은 에러가 나왔습니다.
![image](https://github.com/boostcampwm2023/web10-Lesser/assets/66576231/db4dcdca-c988-4895-932b-91365e356b4f)
  - 메모 테이블과 회원 테이블이 OneToOne으로 연결되어있었고 이는 의도하지 않은 구현이었습니다.
  ```
    @OneToOne(() => Member, (member) => member.id, { nullable: false })
    @JoinColumn({ name: 'member_id' })
    member: Member;
  ```
  - 그리고 에러가 생긴 원인은 테이블이 OneToOne으로 연결되어있으면 unique 제약조건을 걸어서 생기는 문제였습니다.
  ![image](https://github.com/boostcampwm2023/web10-Lesser/assets/66576231/fbbbb6cd-8b89-4900-b585-bcb62084d270)
  - 이를 ManyToOne관계로 변경해 해결했습니다.

- 클라이언트가 메모 생성 API에서 content속성을 보내지 않았을때 저희가 정의한 error이벤트를 받는것을 기대했지만 Nest가 보내주는 Exception 이벤트가 오는것을 확인했습니다.
![image](https://github.com/boostcampwm2023/web10-Lesser/assets/66576231/4bc5435c-7960-4b29-9c0c-6c3337cad7a3)
  - 기존의 DTO는 아래의 코드였습니다.
  ```
  class Color {
    @IsEnum(memoColor)
    color: memoColor;
  }
  
  export class MemoCreateRequestDto {
    @Matches(/^create$/)
    action: string;
  
    @ValidateNested()
    @Type(() => Color)
    content: Color;
  }
  ```
  - 그러나 객체를 validateNested로 검사시 객체자체가 undefined일때 검사를 하지 않는 [이슈](https://github.com/typestack/class-validator/issues/1375)가 있다는 것을 확인했습니다.
  - 이를 isNotEmpty 데코레이터를 추가해 반드시 검사하도록 수정했습니다.
  ```
  class Color {
    @IsEnum(memoColor)
    color: memoColor;
  }
  
  export class MemoCreateRequestDto {
    @Matches(/^create$/)
    action: string;
  
    @IsNotEmpty()
    @ValidateNested()
    @Type(() => Color)
    content: Color;
  }
  
  ```
