### PR TITLE
feat: 메모 삭제 웹소켓 API 구현

### DIFF
--- a/backend/src/project/dto/MemoDeleteRequest.dto.ts
+++ b/backend/src/project/dto/MemoDeleteRequest.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber, Matches, ValidateNested } from 'class-validator';
+
+class MemoId {
+  @IsNumber()
+  id: number;
+}
+
+export class MemoDeleteRequestDto {
+  @Matches(/^delete$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => MemoId)
+  content: MemoId;
+}

--- a/backend/src/project/entity/memo.entity.ts
+++ b/backend/src/project/entity/memo.entity.ts
@@ -22,7 +22,6 @@ export class Memo {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
 
-  //   @Column({ nullable: false })
   @ManyToOne(() => Project, (project) => project.id, { nullable: false })
   @JoinColumn({ name: 'project_id' })
   project: Project;

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { Project } from './entity/project.entity';
 import { ProjectToMember } from './entity/project-member.entity';
 import { Member } from 'src/member/entity/member.entity';
-import { Memo, memoColor } from './entity/memo.entity';
+import { Memo } from './entity/memo.entity';
 
 @Injectable()
 export class ProjectRepository {
@@ -55,5 +55,10 @@ export class ProjectRepository {
 
   createMemo(memo: Memo): Promise<Memo> {
     return this.memoRepository.save(memo);
+  }
+
+  async deleteMemo(id: number): Promise<number> {
+    const result = await this.memoRepository.delete({ id });
+    return result.affected ? result.affected : 0;
   }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -23,6 +23,7 @@ describe('ProjectService', () => {
             getProject: jest.fn(),
             getProjectToMember: jest.fn(),
             createMemo: jest.fn(),
+            deleteMemo: jest.fn(),
           },
         },
       ],
@@ -133,5 +134,29 @@ describe('ProjectService', () => {
       expect(memo.color).toBe(color);
       expect(memo.member.id).toBe(member.id);
     });
+  });
+
+  describe('Delete memo', () => {
+    it('should return 1 when deleted a memo', async () => {
+      jest
+        .spyOn(projectRepository, 'deleteMemo')
+        .mockResolvedValue(1);
+
+      const deletedMemoId = 1
+      const result = await projectService.deleteMemo(deletedMemoId)
+
+      expect(result).toBe(true);
+    });
+
+    it('should return 0 when memo is not found', async () => {
+      jest
+      .spyOn(projectRepository, 'deleteMemo')
+      .mockResolvedValue(0);
+
+      const notFoundMemoId = 1
+      const result = await projectService.deleteMemo(notFoundMemoId)
+
+      expect(result).toBe(false);
+    })
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -42,12 +42,14 @@ export class ProjectService {
     return this.projectRepository.getProjectByLinkId(projectLinkId);
   }
 
-  async createMemo(
-    project: Project,
-    member: Member,
-    color: memoColor,
-  ) {
-	const newMemo = Memo.of(project, member, "", "", color);
-	return this.projectRepository.createMemo(newMemo);
+  async createMemo(project: Project, member: Member, color: memoColor) {
+    const newMemo = Memo.of(project, member, '', '', color);
+    return this.projectRepository.createMemo(newMemo);
+  }
+
+  async deleteMemo(id: number): Promise<boolean> {
+    const result = await this.projectRepository.deleteMemo(id);
+    if (result) return true;
+    else return false;
   }
 }

--- a/backend/test/project/ws-memo.e2e-spec.ts
+++ b/backend/test/project/ws-memo.e2e-spec.ts
@@ -78,9 +78,9 @@ describe('WS memo create', () => {
         content: { color: 'yellow' },
       };
       socket.emit('memo', requestData);
-      expectMemo(socket, memberFixture.username, requestData.content.color);
+      expectCreateMemo(socket, memberFixture.username, requestData.content.color);
       socket.emit('memo', requestData);
-      expectMemo(socket, memberFixture.username, requestData.content.color);
+      expectCreateMemo(socket, memberFixture.username, requestData.content.color);
       socket.on('exception', (data) => {
         reject(data);
       });

--- a/backend/test/project/ws-memo.e2e-spec.ts
+++ b/backend/test/project/ws-memo.e2e-spec.ts
@@ -12,7 +12,7 @@ import {
   projectPayload,
 } from 'test/setup';
 
-describe('WS memo', () => {
+describe('WS memo create', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
@@ -50,8 +50,8 @@ describe('WS memo', () => {
         reject();
       });
       await Promise.all([
-        expectMemo(socket1, memberFixture.username, requestData.content.color),
-        expectMemo(socket2, memberFixture.username, requestData.content.color),
+        expectCreateMemo(socket1, memberFixture.username, requestData.content.color),
+        expectCreateMemo(socket2, memberFixture.username, requestData.content.color),
       ]);
       socket1.on('exception', (data) => {
         reject(data);
@@ -146,12 +146,124 @@ describe('WS memo', () => {
   });
 });
 
-const expectMemo = (socket, author, color) => {
+describe('WS memo delete', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  it('should return deleted memo data when received delete memo request', async () => {
+    let socket1;
+    let socket2;
+    return new Promise<void>(async (resolve, reject) => {
+      // 회원1 회원가입 + 프로젝트 생성
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+      // 회원2 회원가입 + 프로젝트 참여
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      await joinProject(accessToken2, projectLinkId);
+
+      socket1 = connectServer(project.id, accessToken);
+      await emitJoinLanding(socket1);
+      await initLanding(socket1);
+
+      socket2 = connectServer(project.id, accessToken2);
+      await emitJoinLanding(socket2);
+      await initLanding(socket2);
+
+      // 메모 생성
+      const createRequestData = {
+        action: 'create',
+        content: { color: 'yellow' },
+      };
+      socket1.emit('memo', createRequestData);
+      socket1.on('error', () => {
+        reject();
+      });
+      const [id1, id2] = await Promise.all([
+        getCreatedMemoId(socket1),
+        getCreatedMemoId(socket2),
+      ]);
+      const deleteMemoId = id1
+
+      // 메모 삭제 테스트
+      const deleteRequestData = {
+        action: 'delete',
+        content: { id: id1 },
+      };
+      socket1.emit('memo', deleteRequestData);
+      await Promise.all([
+        expectDeleteMemo(socket1, deleteMemoId),
+        expectDeleteMemo(socket2, deleteMemoId),
+      ])
+      resolve();
+    }).finally(() => {
+      socket1.close();
+      socket2.close();
+    });
+  });
+
+  it('should return error message list when data format is invalid', async () => {
+    let socket;
+    return new Promise<void>(async (resolve) => {
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+
+      socket = connectServer(project.id, accessToken);
+      await emitJoinLanding(socket);
+      await initLanding(socket);
+
+      const requestData = {
+        action: 'delete',
+        content: { id: 'invalidDataFormat' },
+      };
+      socket.emit('memo', requestData);
+      socket.on('error', (data) => {
+        expect(data.errorList).toBeDefined();
+        expect(data.errorList.length).toBeGreaterThan(0);
+        resolve();
+      });
+    }).finally(() => {
+      socket.close();
+    });
+  });
+});
+
+const getCreatedMemoId = (socket) => {
+  return new Promise<number>((resolve) => {
+    socket.on('landing', (data) => {
+      const { content } = data;
+      socket.off('landing');
+      resolve(content.id);
+    });
+  });
+};
+
+const expectDeleteMemo = (socket, deleteMemoId) => {
+  return new Promise<void>((resolve) => {
+    socket.on('landing', (data) => {
+      const { domain, action, content } = data;
+      expect(domain).toBe('memo');
+      expect(action).toBe('delete');
+      expect(content).toBeDefined();
+      expect(content.id).toBe(deleteMemoId);
+      socket.off('landing');
+      resolve();
+    });
+  });
+};
+
+const expectCreateMemo = (socket, author, color) => {
   return new Promise<void>((res) => {
     socket.on('landing', (data) => {
       const { content, action, domain } = data;
       expect(domain).toBe('memo');
       expect(action).toBe('create');
+      expect(content).toBeDefined();
       expect(content.id).toBeDefined();
       expect(content.title).toBeDefined();
       expect(content.content).toBeDefined();


### PR DESCRIPTION
## 🎟️ 태스크

[메모 삭제 웹소켓 API 구현 (백)](https://plastic-toad-cb0.notion.site/API-b3cf77a7f9f343aebdb5f518f7dbd022?pvs=74)

## ✅ 작업 내용

- [test: 메모 삭제 API e2e 테스트 추가](https://github.com/boostcampwm2023/web10-Lesser/commit/f6ea656559d6bd8705582ca87dc39508343f2e93)
- [feat: 메모를 삭제하는 레포지토리 메서드 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/accf1b0895e17c4edf2212869cb351dec3ef5a68)
- [feat: 메모 삭제 서비스 로직 및 단위테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/054f24ffd5c33061df6d3cc392beaf6501be9a35)
- [feat: 메모 삭제 웹소켓 API 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/1ad72dca56884e2857fd1285a882496ec52ddec4)

## 🖊️ 구체적인 작업

### 메모 삭제 API e2e 테스트 추가
- 회원 2명이 랜딩 페이지에 접속한 상태에서 메모 삭제시 모든 회원이 삭제된 메모 id를 이벤트로 받는 테스트 추가
- 잘못된 데이터 형식 전송시 에러 수신하는 테스트 추가

### 메모를 삭제하는 레포지토리 메서드 구현
- 삭제된 레코드 개수를 반환한다. 삭제된 레코드가 없으면 0을 반환한다.

### 메모 삭제 서비스 로직 및 단위테스트 작성
- deleteMemo 서비스는 삭제 여부를 boolean 값으로 반환

### 메모 삭제 웹소켓 API 구현
- ProjectWebsocketGateway에서 MemoDeleteRequestDto 형식의 요청 데이터를 받으면 해당 메모를 삭제하고, 삭제 성공시 삭제된 메모 데이터를 landing 페이지에 있는 회원들에게 전송

## 🤔 고민 및 의논할 거리
- 웹소켓 게이트웨이의 크기가 커지고 있어 분리할 필요성을 느낍니다. 
