### PR TITLE
feat: 랜딩페이지 접속 API에 메모 정보 추가구현

### DIFF
--- a/backend/src/project/dto/InitLandingResponse.dto.ts
+++ b/backend/src/project/dto/InitLandingResponse.dto.ts
@@ -1,0 +1,71 @@
+import { Memo, memoColor } from '../entity/memo.entity';
+import { Project } from '../entity/project.entity';
+
+class MemoDto {
+  id: number;
+  title: string;
+  content: string;
+  author: string;
+  createdAt: Date;
+  color: memoColor;
+
+  static of(memoWithMember: Memo) {
+    const dto = new MemoDto();
+    dto.id = memoWithMember.id;
+    dto.title = memoWithMember.title;
+    dto.content = memoWithMember.content;
+    dto.author = memoWithMember.member.username;
+    dto.createdAt = memoWithMember.created_at;
+    dto.color = memoWithMember.color;
+    return dto;
+  }
+}
+
+class ProjectDto {
+  title: string;
+  subject: string;
+  createdAt: Date;
+  static of(project: Project) {
+    const dto = new ProjectDto();
+    dto.title = project.title;
+    dto.subject = project.subject;
+    dto.createdAt = project.created_at;
+    return dto;
+  }
+}
+
+class ProjectLandingPageContentDto {
+  project: ProjectDto;
+  myInfo: {};
+  member: [];
+  sprint: null;
+  memoList: MemoDto[];
+  link: [];
+  inviteLinkId: string;
+  static of(project: Project, memoListWithMember: Memo[]) {
+    const dto = new ProjectLandingPageContentDto();
+    dto.project = ProjectDto.of(project);
+    dto.myInfo = {};
+    dto.member = [];
+    dto.sprint = null;
+    const memoList = memoListWithMember.map((memo) => MemoDto.of(memo));
+    dto.memoList = memoList;
+    dto.link = [];
+    dto.inviteLinkId = project.inviteLinkId;
+    return dto;
+  }
+}
+
+export class InitLandingResponseDto {
+  domain: string;
+  action: string;
+  content: ProjectLandingPageContentDto;
+
+  static of(project: Project, memoListWithMember: Memo[]) {
+    const dto = new InitLandingResponseDto();
+    dto.domain = 'landing';
+    dto.action = 'init';
+    dto.content = ProjectLandingPageContentDto.of(project, memoListWithMember);
+    return dto;
+  }
+}

--- a/backend/src/project/entity/memo.entity.ts
+++ b/backend/src/project/entity/memo.entity.ts
@@ -22,6 +22,9 @@ export class Memo {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
 
+  @Column({ name: 'project_id' })
+  projectId: number;
+
   @ManyToOne(() => Project, (project) => project.id, { nullable: false })
   @JoinColumn({ name: 'project_id' })
   project: Project;

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -53,6 +53,10 @@ export class ProjectRepository {
     });
   }
 
+  getProjectMemoListWithMember(projectId: number): Promise<Memo[]> {
+    return this.memoRepository.find({ where: { projectId }, relations: ["member"] });
+  }
+
   createMemo(memo: Memo): Promise<Memo> {
     return this.memoRepository.save(memo);
   }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -24,6 +24,7 @@ describe('ProjectService', () => {
             getProjectToMember: jest.fn(),
             createMemo: jest.fn(),
             deleteMemo: jest.fn(),
+            getProjectMemoListWithMember: jest.fn(),
           },
         },
       ],
@@ -138,25 +139,47 @@ describe('ProjectService', () => {
 
   describe('Delete memo', () => {
     it('should return 1 when deleted a memo', async () => {
-      jest
-        .spyOn(projectRepository, 'deleteMemo')
-        .mockResolvedValue(1);
+      jest.spyOn(projectRepository, 'deleteMemo').mockResolvedValue(1);
 
-      const deletedMemoId = 1
-      const result = await projectService.deleteMemo(deletedMemoId)
+      const deletedMemoId = 1;
+      const result = await projectService.deleteMemo(deletedMemoId);
 
       expect(result).toBe(true);
     });
 
     it('should return 0 when memo is not found', async () => {
-      jest
-      .spyOn(projectRepository, 'deleteMemo')
-      .mockResolvedValue(0);
+      jest.spyOn(projectRepository, 'deleteMemo').mockResolvedValue(0);
 
-      const notFoundMemoId = 1
-      const result = await projectService.deleteMemo(notFoundMemoId)
+      const notFoundMemoId = 1;
+      const result = await projectService.deleteMemo(notFoundMemoId);
 
       expect(result).toBe(false);
-    })
+    });
+  });
+
+  describe('Get project memo list', () => {
+    it('should return memoList', async () => {
+      const [title, subject] = ['title', 'subject'];
+      const project = Project.of(title, subject);
+      const memo = Memo.of(
+        project,
+        member,
+        'memoTitle',
+        'memoContent',
+        memoColor.YELLOW,
+      );
+      memo.member = member;
+      const newMemoList = [memo];
+
+      jest
+        .spyOn(projectRepository, 'getProjectMemoListWithMember')
+        .mockResolvedValue(newMemoList);
+      const projectId = 1;
+
+      const memoListWithMember =
+        await projectService.getProjectMemoListWithMember(projectId);
+
+      expect(memoListWithMember).toEqual(newMemoList);
+    });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -52,4 +52,8 @@ export class ProjectService {
     if (result) return true;
     else return false;
   }
+
+  getProjectMemoListWithMember(projectId: number): Promise<Memo[]> {
+    return this.projectRepository.getProjectMemoListWithMember(projectId);
+  }
 }

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { Socket } from 'socket.io-client';
 import {
   app,
   appInit,
@@ -9,7 +10,7 @@ import {
 } from 'test/setup';
 
 describe('WS landing', () => {
-  let socket;
+  let socket: Socket;
 
   beforeEach(async () => {
     await app.close();
@@ -32,7 +33,8 @@ describe('WS landing', () => {
       });
 
       socket.on('landing', (data) => {
-        const { action, content } = data;
+        const { action, domain, content } = data;
+        expect(domain).toBe('landing');
         expect(action).toBe('init');
         expect(content.project.title).toBe(projectPayload.title);
         expect(content.project.subject).toBe(projectPayload.subject);
@@ -40,15 +42,95 @@ describe('WS landing', () => {
         expect(content.myInfo).toBeDefined();
         expect(content.member).toBeDefined();
         expect(content.sprint).toBeDefined();
-        expect(content.board).toBeDefined();
+        expect(content.memoList).toBeDefined();
         expect(content.link).toBeDefined();
         expect(content.inviteLinkId).toBeDefined();
         resolve();
       });
 
-      socket.on('connect_error', () => {
-        reject('connect_error fail');
+      handleConnectErrorWithReject(socket, reject);
+    });
+  });
+
+  it('should return created memoList in landing page data when project member has already created memo', async () => {
+    return await new Promise<void>(async (resolve, reject) => {
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+
+      //메모 생성
+      socket = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket, reject);
+      await emitJoinLanding(socket);
+      await initLanding(socket);
+      const requestData = {
+        action: 'create',
+        content: { color: 'yellow' },
+      };
+      socket.emit('memo', requestData);
+      await getCreateMemoMsg(socket);
+      socket.close();
+
+      //메모 검증
+      socket = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket, reject);
+      await emitJoinLanding(socket);
+
+      socket.on('landing', (data) => {
+        const { action, domain, content } = data;
+        const { memoList } = content;
+        expect(memoList.length).toBe(1);
+        const memo = memoList[0];
+        if (action === 'init' && domain === 'landing') {
+          expect(memo.id).toBeDefined();
+          expect(memo.title).toBe('');
+          expect(memo.content).toBe('');
+          expect(memo.author).toBe(memberFixture.username);
+          expect(memo.author).toBe(memberFixture.username);
+          expect(memo.createdAt).toBeDefined();
+          expect(memo.color).toBe(requestData.content.color);
+          resolve();
+        }
       });
     });
   });
 });
+
+const handleConnectErrorWithReject = (socket, reject) => {
+  socket.on('connect_error', () => {
+    reject('connect_error fail');
+  });
+};
+
+const emitJoinLanding = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('connect', () => {
+      socket.emit('joinLanding');
+      socket.off('connect');
+      res();
+    });
+  });
+};
+
+const initLanding = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('landing', (data) => {
+      const { action } = data;
+      if (action === 'init') {
+        socket.off('landing');
+        res();
+      }
+    });
+  });
+};
+
+const getCreateMemoMsg = (socket) => {
+  return new Promise<void>((res) => {
+    socket.on('landing', (data) => {
+      const { action, domain } = data;
+      expect(domain).toBe('memo');
+      expect(action).toBe('create');
+      socket.off('landing');
+      res();
+    });
+  });
+};


### PR DESCRIPTION
## 🎟️ 태스크

[랜딩페이지 API 메모정보 추가 구현 (백)](https://plastic-toad-cb0.notion.site/API-6203dd08d98e436dbad0bedfacb9774f?pvs=74)

## ✅ 작업 내용

- 랜딩페이지 접속 API 프로젝트의 메모 테스트 추가
- 프로젝트의 메모를 조회하는 레포지토리 메서드 구현
- 프로젝트의 메모를 조회하는 서비스로직 구현
- 랜딩페이지 접속 API에서 프로젝트의 메모정보 반환하도록 구현

## 🖊️ 구체적인 작업

### 랜딩페이지 접속 API 프로젝트의 메모 테스트 추가
- 메모를 생성한 후, 랜딩페이지에 접속했을때 생성한 메모를 받는지 확인하는 테스트 추가
### 프로젝트의 메모를 조회하는 레포지토리 메서드 구현
- 프로젝트의 메모를 생성한 회원의 정보와 조인해 반환하는 메서드 구현
- 메모의 프로젝트 Id를 조인없이 접근할 수 있도록 projectId 프로퍼티 추가
### 프로젝트의 메모를 조회하는 서비스로직 구현
- 프로젝트의 메모를 작성자 정보와 함께 반환하는 서비스 구현
- 서비스 테스트 추가
### 랜딩페이지 접속 API에서 프로젝트의 메모정보 반환하도록 구현
- 게이트웨이에서 랜딩페이지 접속일때 메모정보를 추가적으로 반환하도록 구현
- 게이트웨이의 복잡한 반환 메시지를 만드는 로직을 InitLandingResponseDto를 만들어 of 메서드로 추상화