### PR TITLE
feat : 메모 생성 및 삭제 기능 완성

### DIFF
--- a/frontend/src/components/landing/memo/LandingMemoList.tsx
+++ b/frontend/src/components/landing/memo/LandingMemoList.tsx
@@ -1,8 +1,10 @@
+import { LandingMemoDTO } from "../../../types/DTO/landingDTO";
 import { MemoColorType } from "../../../types/common/landing";
 import LandingTitleUI from "../common/LandingTitleUI";
 import MemoBlock from "./MemoBlock";
 
 interface LandingMemoListProps {
+  memoList: LandingMemoDTO[];
   memoSocketEvent: {
     emitMemoCreateEvent: () => void;
     emitMemoDeleteEvent: (id: number) => void;
@@ -10,7 +12,10 @@ interface LandingMemoListProps {
   };
 }
 
-const LandingMemoList = ({ memoSocketEvent }: LandingMemoListProps) => {
+const LandingMemoList = ({
+  memoList,
+  memoSocketEvent,
+}: LandingMemoListProps) => {
   const { emitMemoCreateEvent, emitMemoDeleteEvent, emitMemoColorUpdateEvent } =
     memoSocketEvent;
   return (
@@ -21,26 +26,14 @@ const LandingMemoList = ({ memoSocketEvent }: LandingMemoListProps) => {
           handleClick={emitMemoCreateEvent}
         />
         <div className="mt-6 flex flex-wrap w-full h-[11rem] gap-4 overflow-y-scroll scrollbar-thin scrollbar-thumb-dark-green scrollbar-track-transparent scrollbar-thumb-rounded-full">
-          <MemoBlock
-            author={"김용현"}
-            id={1}
-            title={""}
-            content={"world"}
-            createdAt="2024-03-14T12:00:00Z"
-            color="yellow"
-            emitMemoDeleteEvent={emitMemoDeleteEvent}
-            emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
-          />
-          <MemoBlock
-            author={"김용현"}
-            id={2}
-            title={"hello"}
-            content={"world"}
-            createdAt="2024-03-14T12:00:00Z"
-            color="gray"
-            emitMemoDeleteEvent={emitMemoDeleteEvent}
-            emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
-          />
+          {memoList.map((memo: LandingMemoDTO) => {
+            return (
+              <MemoBlock
+                {...{ ...memo, emitMemoColorUpdateEvent, emitMemoDeleteEvent }}
+                key={memo.id}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/frontend/src/components/landing/memo/LandingMemoList.tsx
+++ b/frontend/src/components/landing/memo/LandingMemoList.tsx
@@ -1,15 +1,24 @@
+import { MemoColorType } from "../../../types/common/landing";
 import LandingTitleUI from "../common/LandingTitleUI";
 import MemoBlock from "./MemoBlock";
 
-const LandingMemoList = () => {
+interface LandingMemoListProps {
+  memoSocketEvent: {
+    emitMemoCreateEvent: () => void;
+    emitMemoDeleteEvent: (id: number) => void;
+    emitMemoColorUpdateEvent: (id: number, color: MemoColorType) => void;
+  };
+}
+
+const LandingMemoList = ({ memoSocketEvent }: LandingMemoListProps) => {
+  const { emitMemoCreateEvent, emitMemoDeleteEvent, emitMemoColorUpdateEvent } =
+    memoSocketEvent;
   return (
     <div className="w-full rounded-lg shadow-box bg-gradient-to-tr from-dark-green-linear-from to-dark-green-linear-to">
       <div className="py-6 ps-6 pe-3 w-[32rem]">
         <LandingTitleUI
           title={"프로젝트 메모"}
-          handleClick={() => {
-            console.log("hello");
-          }}
+          handleClick={emitMemoCreateEvent}
         />
         <div className="mt-6 flex flex-wrap w-full h-[11rem] gap-4 overflow-y-scroll scrollbar-thin scrollbar-thumb-dark-green scrollbar-track-transparent scrollbar-thumb-rounded-full">
           <MemoBlock
@@ -19,6 +28,8 @@ const LandingMemoList = () => {
             content={"world"}
             createdAt="2024-03-14T12:00:00Z"
             color="yellow"
+            emitMemoDeleteEvent={emitMemoDeleteEvent}
+            emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
           />
           <MemoBlock
             author={"김용현"}
@@ -27,6 +38,8 @@ const LandingMemoList = () => {
             content={"world"}
             createdAt="2024-03-14T12:00:00Z"
             color="gray"
+            emitMemoDeleteEvent={emitMemoDeleteEvent}
+            emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
           />
         </div>
       </div>

--- a/frontend/src/components/landing/memo/MemoBlock.tsx
+++ b/frontend/src/components/landing/memo/MemoBlock.tsx
@@ -1,9 +1,22 @@
 import MemoEditor from "./MemoEditor";
 import { LandingMemoDTO } from "../../../types/DTO/landingDTO";
-import { MemoColorStyle } from "../../../types/common/landing";
+import { MemoColorStyle, MemoColorType } from "../../../types/common/landing";
 import useLandingMemo from "../../../hooks/common/landing/useLandingMemo";
 
-const MemoBlock = ({ title, content, author, color }: LandingMemoDTO) => {
+interface MemoBlockProps extends LandingMemoDTO {
+  emitMemoDeleteEvent: (id: number) => void;
+  emitMemoColorUpdateEvent: (id: number, color: MemoColorType) => void;
+}
+
+const MemoBlock = ({
+  id,
+  title,
+  content,
+  author,
+  color,
+  emitMemoColorUpdateEvent,
+  emitMemoDeleteEvent,
+}: MemoBlockProps) => {
   const {
     editorOpened,
     memoTitle,
@@ -39,7 +52,13 @@ const MemoBlock = ({ title, content, author, color }: LandingMemoDTO) => {
       <div className="flex justify-between items-center">
         <p className="text-xxxs h-5 font-bold">{author}</p>
         {editorOpened && (
-          <MemoEditor color={memoColor} changeMemoColor={changeMemoColor} />
+          <MemoEditor
+            id={id}
+            color={memoColor}
+            changeMemoColor={changeMemoColor}
+            emitMemoDeleteEvent={emitMemoDeleteEvent}
+            emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/components/landing/memo/MemoColorButton.tsx
+++ b/frontend/src/components/landing/memo/MemoColorButton.tsx
@@ -1,15 +1,19 @@
 import { MemoColorStyle, MemoColorType } from "../../../types/common/landing";
 
 interface MemoColorButtonProps {
+  id: number;
   active: Boolean;
   color: MemoColorType;
   changeMemoColor: (color: MemoColorType) => void;
+  emitMemoColorUpdateEvent: (id: number, color: MemoColorType) => void;
 }
 
 const MemoColorButton = ({
+  id,
   active,
   color,
   changeMemoColor,
+  emitMemoColorUpdateEvent,
 }: MemoColorButtonProps) => {
   const borderStyle = active
     ? "border-blue-500 border-2"
@@ -17,6 +21,7 @@ const MemoColorButton = ({
 
   const handleOnClick = () => {
     changeMemoColor(color);
+    emitMemoColorUpdateEvent(id, color);
   };
 
   return (

--- a/frontend/src/components/landing/memo/MemoEditor.tsx
+++ b/frontend/src/components/landing/memo/MemoEditor.tsx
@@ -3,34 +3,58 @@ import { MemoColorType } from "../../../types/common/landing";
 import MemoColorButton from "./MemoColorButton";
 
 interface MemoEditorProps {
+  id: number;
   color: MemoColorType;
   changeMemoColor: (color: MemoColorType) => void;
+  emitMemoDeleteEvent: (id: number) => void;
+  emitMemoColorUpdateEvent: (id: number, color: MemoColorType) => void;
 }
 
-const MemoEditor = ({ color, changeMemoColor }: MemoEditorProps) => {
+const MemoEditor = ({
+  id,
+  color,
+  changeMemoColor,
+  emitMemoDeleteEvent,
+  emitMemoColorUpdateEvent,
+}: MemoEditorProps) => {
+  const handleClickDeleteButton = () => {
+    emitMemoDeleteEvent(id);
+  };
+
   return (
     <div className="w-32 h-fit rounded-full flex justify-between items-center duration-100">
       <MemoColorButton
+        id={id}
         active={color === "yellow"}
         color={"yellow"}
         changeMemoColor={changeMemoColor}
+        emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
       />
       <MemoColorButton
+        id={id}
         active={color === "blue"}
         color={"blue"}
         changeMemoColor={changeMemoColor}
+        emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
       />
       <MemoColorButton
+        id={id}
         active={color === "red"}
         color={"red"}
         changeMemoColor={changeMemoColor}
+        emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
       />
       <MemoColorButton
+        id={id}
         active={color === "gray"}
         color={"gray"}
         changeMemoColor={changeMemoColor}
+        emitMemoColorUpdateEvent={emitMemoColorUpdateEvent}
       />
-      <button className="w-5 h-5 rounded-full border-white border bg-error-red flex justify-center items-center hover:border-blue-500 hover:border-2 hover:scale-125 transition-all ease-in-out">
+      <button
+        onClick={handleClickDeleteButton}
+        className="w-5 h-5 rounded-full border-white border bg-error-red flex justify-center items-center hover:border-blue-500 hover:border-2 hover:scale-125 transition-all ease-in-out"
+      >
         <TrashBinIcon width={12} height={12} color="#FFFFFF" />
       </button>
     </div>

--- a/frontend/src/hooks/common/socket/useLandingEmitEvent.ts
+++ b/frontend/src/hooks/common/socket/useLandingEmitEvent.ts
@@ -1,0 +1,20 @@
+import { Socket } from "socket.io-client";
+import { MemoColorType } from "../../../types/common/landing";
+
+const useLandingEmitEvent = (socket: Socket) => {
+  const memoSocketEvent = {
+    emitMemoCreateEvent: () => {
+      socket.emit("memo", { action: "create", content: { color: "yellow" } });
+    },
+    emitMemoDeleteEvent: (id: number) => {
+      socket.emit("memo", { action: "delete", content: { id } });
+    },
+    emitMemoColorUpdateEvent: (id: number, color: MemoColorType) => {
+      socket.emit("memo", { action: "colorUpdate", content: { id, color } });
+    },
+  };
+
+  return { memoSocketEvent };
+};
+
+export default useLandingEmitEvent;

--- a/frontend/src/hooks/common/socket/useLandingSocket.ts
+++ b/frontend/src/hooks/common/socket/useLandingSocket.ts
@@ -27,7 +27,6 @@ const useLandingSocket = (socket: Socket) => {
   const inviteLinkIdRef = useRef<string>("");
 
   const handleInitEvent = (content: LandingDTO) => {
-    console.log(content);
     const { project, myInfo, member, sprint, memoList, link, inviteLinkId } =
       content as LandingDTO;
     setProject(project);
@@ -68,7 +67,6 @@ const useLandingSocket = (socket: Socket) => {
   };
 
   const handleOnLanding = ({ domain, action, content }: LandingSocketData) => {
-    console.log(domain, action, content);
     switch (domain) {
       case LandingSocketDomain.INIT:
         handleInitEvent(content);

--- a/frontend/src/hooks/common/socket/useLandingSocket.ts
+++ b/frontend/src/hooks/common/socket/useLandingSocket.ts
@@ -20,6 +20,7 @@ enum LandingSocketEvent {
   MEMBER_UPDATE = "memberUpdate",
   MEMBER_CREATE = "memberCreate",
   MEMBER_DELETE = "memberDelete",
+  MEMO_CREATE = "create",
 }
 
 const useLandingSocket = (socket: Socket) => {
@@ -53,6 +54,12 @@ const useLandingSocket = (socket: Socket) => {
     }
   };
 
+  // const handleMemoCreateEvent = (content: LandingMemoDTO) => {
+  //   setMemoList((state: LandingMemoDTO[]) => {
+  //     return [content, ...state];
+  //   });
+  // };
+
   useEffect(() => {
     socket.emit("joinLanding");
     socket.on("landing", handleOnLanding);
@@ -62,7 +69,15 @@ const useLandingSocket = (socket: Socket) => {
     };
   }, [socket]);
 
-  return { project, myInfo, member, sprint, memoList, link, inviteLinkIdRef };
+  return {
+    project,
+    myInfo,
+    member,
+    sprint,
+    memoList,
+    link,
+    inviteLinkIdRef,
+  };
 };
 
 export default useLandingSocket;

--- a/frontend/src/hooks/common/socket/useLandingSocket.ts
+++ b/frontend/src/hooks/common/socket/useLandingSocket.ts
@@ -33,25 +33,22 @@ const useLandingSocket = (socket: Socket) => {
   const [link, setLink] = useState<LandingLinkDTO[]>([]);
   const inviteLinkIdRef = useRef<string>("");
 
+  const handleInitEvent = (content: LandingDTO) => {
+    const { project, myInfo, member, sprint, memoList, link, inviteLinkId } =
+      content as LandingDTO;
+    setProject(project);
+    setMyInfo(myInfo);
+    setMember(member);
+    setSprint(sprint);
+    setMemoList(memoList);
+    setLink(link);
+    inviteLinkIdRef.current = inviteLinkId;
+  };
+
   const handleOnLanding = ({ action, content }: SocketData) => {
     switch (action) {
       case LandingSocketEvent.INIT:
-        const {
-          project,
-          myInfo,
-          member,
-          sprint,
-          memoList,
-          link,
-          inviteLinkId,
-        } = content as LandingDTO;
-        setProject(project);
-        setMyInfo(myInfo);
-        setMember(member);
-        setSprint(sprint);
-        setMemoList(memoList);
-        setLink(link);
-        inviteLinkIdRef.current = inviteLinkId;
+        handleInitEvent(content);
         break;
     }
   };

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -15,7 +15,7 @@ const LandingPage = () => {
   }
 
   const { socket }: { socket: Socket } = useOutletContext();
-  const { project, myInfo, member, sprint, link, inviteLinkIdRef } =
+  const { project, myInfo, member, sprint, link, memoList, inviteLinkIdRef } =
     useLandingSocket(socket);
   const { memoSocketEvent } = useLandingEmitEvent(socket);
 
@@ -23,7 +23,7 @@ const LandingPage = () => {
     <div className="flex flex-col justify-between w-full h-full">
       <div className="h-[17.6875rem] w-full shrink-0 flex gap-9">
         <LandingProject {...{ project, projectId }} />
-        <LandingMemoList memoSocketEvent={memoSocketEvent} />
+        <LandingMemoList {...{ memoList, memoSocketEvent }} />
       </div>
       <div className="h-[20.5625rem] w-full shrink-0 flex gap-9">
         <LandingSprint {...{ sprint }} />

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -6,6 +6,7 @@ import LandingLink from "../../components/landing/link/LandingLink";
 import { Socket } from "socket.io-client";
 import useLandingSocket from "../../hooks/common/socket/useLandingSocket";
 import LandingMemoList from "../../components/landing/memo/LandingMemoList";
+import useLandingEmitEvent from "../../hooks/common/socket/useLandingEmitEvent";
 
 const LandingPage = () => {
   const { projectId } = useParams();
@@ -14,15 +15,15 @@ const LandingPage = () => {
   }
 
   const { socket }: { socket: Socket } = useOutletContext();
-
   const { project, myInfo, member, sprint, link, inviteLinkIdRef } =
     useLandingSocket(socket);
+  const { memoSocketEvent } = useLandingEmitEvent(socket);
 
   return (
     <div className="flex flex-col justify-between w-full h-full">
       <div className="h-[17.6875rem] w-full shrink-0 flex gap-9">
         <LandingProject {...{ project, projectId }} />
-        <LandingMemoList />
+        <LandingMemoList memoSocketEvent={memoSocketEvent} />
       </div>
       <div className="h-[20.5625rem] w-full shrink-0 flex gap-9">
         <LandingSprint {...{ sprint }} />

--- a/frontend/src/types/common/landing.ts
+++ b/frontend/src/types/common/landing.ts
@@ -1,3 +1,31 @@
+import { LandingDTO, LandingMemoDTO } from "../DTO/landingDTO";
+
+export enum LandingSocketDomain {
+  INIT = "landing",
+  MEMO = "memo",
+  MEMBER = "member",
+}
+
+export enum LandingSocketMemoAction {
+  CREATE = "create",
+  DELETE = "delete",
+  COLOR_UPDATE = "colorUpdate",
+}
+
+interface LandingSocketInitData {
+  domain: LandingSocketDomain.INIT;
+  action: "init";
+  content: LandingDTO;
+}
+
+interface LandingSocketMemoData {
+  domain: LandingSocketDomain.MEMO;
+  action: LandingSocketMemoAction;
+  content: LandingMemoDTO;
+}
+
+export type LandingSocketData = LandingSocketInitData | LandingSocketMemoData;
+
 export enum MemoColorStyle {
   yellow = "bg-[#FFD966]",
   red = "bg-[#FFAFA3]",


### PR DESCRIPTION
## 🎟️ 태스크

[웹소켓 메모 생성 이벤트 처리 로직 작성 (프론트)](https://www.notion.so/30bb88503ecd4281b0c79e843e106185?pvs=4)
[웹소켓 메모 삭제 이벤트 처리 로직 작성 (프론트)](https://www.notion.so/65a474cc64e641178d09da0b9f1c6962?pvs=4)

## ✅ 작업 내용

- Memo 삭제 / 생성 / 색상 변경 소켓 통신 데이터를 규격에 맞추어 전달하는 코드 생성
- 서버로부터 전달 받는 Memo 삭제 / 생성 신호에 맞추어 memoList 상태값을 새롭게 갱신하는 형태로 데이터 수정
   - 메모 색상 변경의 경우, 서버의 api 작업이 완료되면 새로운 PR로 올릴 예정 
- useLandingSocket 내 landing 이벤트 핸들링 함수의 리팩토링


## 🖊️ 구체적인 작업

### Memo 삭제 / 생성 / 색상 변경 소켓 통신 데이터를 규격에 맞추어 전달하는 코드 생성

- useLandingEmitEvent 커스텀 훅을 생성
   - 사용자가 특정 행동(요소 생성 / 삭제 / 수정)을 취할 경우, 해당 내역을 서버에 전달해야 합니다. 이를 위해, Socket.io를 통해 생성한 Socket 객체를 통해 정해진 신호를 전달하는 함수를 생성하여 전달하는 커스텀 훅 useLandingEmitEvent를 만들어 Landing페이지의 모든 이벤트를 관리할 수 있도록 만들었습니다.

- useLandingEmitEvent를 통해 만들어진 "신호 전달 함수"를 각 요소에 전달
   - useLandingEmitEvent를 통해 만들어진 메모 생성/수정/삭제 함수를 각 버튼 요소에 전달할 수 있도록 각 요소를 prop을 통해 전달하는 구조로 설계했습니다.

### 서버로부터 전달 받는 Memo 삭제 / 생성 신호에 맞추어 memoList 상태값을 새롭게 갱신 
- useLandingSocket 내 landing 이벤트 핸들링 함수의 리팩토링

   - useLandingSocket 내에는 최초 데이터를 받는 기능 외에도 memo, member와 같은 여러 데이터와 새롭게 전달받고 갱신하는 구조로 이루어져야 합니다. 이 때, 각 파트(memo, member, link 등)를 하나의 handling 함수에 몰아서 처리할 경우, 코드를 읽고 유지 보수하는 것이 굉장히 불리할 것으로 판단 되었기 때문에 각 파트별로 핸들링 하는 함수를 나누어 실행시키고자 했습니다.

   - 또한, 서버로 부터 전달받는 데이터의 구조가 "domin"을 통해 파트별로 나누어 처리하는 방식으로 바뀌었기 때문에, 함수를 분리하고 domain 별로 나누어진 함수를 수행하는 것이 더 유리했습니다.

- 서버로부터 전달 받는 Memo 삭제 / 생성 신호에 맞추어 memoList 상태값을 새롭게 갱신하는 형태로 데이터 수정
   - 낙관적 데이터 업데이트가 아닌 서버로부터 전달받는 데이터를 통해 화면을 새롭게 구성하는 방식으로 설계하였습니다. 같은 페이지를 보는 사용자들 간, 동일한 데이터를 통해 같은 자료를 보고 관리하는 것이 주제 상 가장 중요하다고 판단했고, 이를 위해선 낙관적 업데이트보다는 서버로부터 해당 메모가 완성되었다는 신호가 온 상황에서 상태값을 처리하는 것이 더 정확하게 동작할 것이라 판단했습니다.
   
## 🤔 고민 및 의논할 거리(선택)

- useLandingEmitEvent의 경우 훅의 형태로 사용하여 관리하고 있습니다. 하지만, 내부에서 훅을 사용하는 일이 없을 것으로 판단되어 이를 함수형으로 바꾸는 것이 더 효율적일지 아니면 만일을 대비하여 훅 형태로 유지해야 할지에 대해 고민하고 있습니다. 

## 📸 결과 화면(선택)

![화면 기록 2024-05-11 오후 2 51 57](https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/3dcee9bd-9b5d-4fd5-ac47-12668031e120)
