### PR TITLE
feat: 메모 색상 변경 API 구현

### DIFF
--- a/backend/src/project/dto/MemoColorUpdateRequest.dto.ts
+++ b/backend/src/project/dto/MemoColorUpdateRequest.dto.ts
@@ -1,0 +1,27 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { memoColor } from '../entity/memo.entity';
+
+class Content {
+  @IsNumber()
+  id: number;
+
+  @IsEnum(memoColor)
+  color: memoColor;
+}
+
+export class MemoColorUpdateRequestDto {
+  @Matches(/^colorUpdate$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Content)
+  content: Content;
+}

--- a/backend/src/project/entity/memo.entity.ts
+++ b/backend/src/project/entity/memo.entity.ts
@@ -22,7 +22,7 @@ export class Memo {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
 
-  @Column({ name: 'project_id' })
+  @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
   @ManyToOne(() => Project, (project) => project.id, { nullable: false })

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { Project } from './entity/project.entity';
 import { ProjectToMember } from './entity/project-member.entity';
 import { Member } from 'src/member/entity/member.entity';
-import { Memo } from './entity/memo.entity';
+import { Memo, memoColor } from './entity/memo.entity';
 
 @Injectable()
 export class ProjectRepository {
@@ -64,5 +64,16 @@ export class ProjectRepository {
   async deleteMemo(id: number): Promise<number> {
     const result = await this.memoRepository.delete({ id });
     return result.affected ? result.affected : 0;
+  }
+
+  async updateMemoColor(id: number, color: memoColor): Promise<number> {
+    const result = await this.memoRepository.update({ id }, { color: color });
+    return result.affected ? result.affected : 0;
+  }
+
+  async findMemoById(id: number): Promise<Memo> {
+    return this.memoRepository.findOne({
+      where: { id },
+    });
   }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -25,6 +25,8 @@ describe('ProjectService', () => {
             createMemo: jest.fn(),
             deleteMemo: jest.fn(),
             getProjectMemoListWithMember: jest.fn(),
+            updateMemoColor: jest.fn(),
+            findMemoById: jest.fn(),
           },
         },
       ],
@@ -180,6 +182,54 @@ describe('ProjectService', () => {
         await projectService.getProjectMemoListWithMember(projectId);
 
       expect(memoListWithMember).toEqual(newMemoList);
+    });
+  });
+
+  describe('Update memo', () => {
+    const [title, subject] = ['title', 'subject'];
+    const project = Project.of(title, subject);
+    project.id = 1;
+    const color = memoColor.BLUE;
+    const memo = Memo.of(project, member, '', '', memoColor.YELLOW);
+    memo.projectId = project.id;
+    memo.id = 1;
+    it('should return true when updated a memo', async () => {
+      jest.spyOn(projectRepository, 'findMemoById').mockResolvedValue(memo);
+      jest.spyOn(projectRepository, 'updateMemoColor').mockResolvedValue(1);
+
+      const result = await projectService.updateMemoColor(
+        project,
+        memo.id,
+        color,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when memo is not found', async () => {
+      jest.spyOn(projectRepository, 'findMemoById').mockResolvedValue(null);
+      jest.spyOn(projectRepository, 'updateMemoColor').mockResolvedValue(0);
+      const updatedMemoId = 1;
+
+      const result = await projectService.updateMemoColor(
+        project,
+        updatedMemoId,
+        color,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw error when project does not have this memo', async () => {
+      jest.spyOn(projectRepository, 'findMemoById').mockResolvedValue(memo);
+      jest.spyOn(projectRepository, 'updateMemoColor').mockResolvedValue(1);
+      const myProject = Project.of('', '');
+      myProject.id = project.id + 100;
+
+      await expect(
+        async () =>
+          await projectService.updateMemoColor(myProject, memo.id, color),
+      ).rejects.toThrow('project does not have this memo');
     });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -47,6 +47,7 @@ export class ProjectService {
     return this.projectRepository.createMemo(newMemo);
   }
 
+  //ToDo: 메모 접근권한 확인 필요
   async deleteMemo(id: number): Promise<boolean> {
     const result = await this.projectRepository.deleteMemo(id);
     if (result) return true;
@@ -55,5 +56,17 @@ export class ProjectService {
 
   getProjectMemoListWithMember(projectId: number): Promise<Memo[]> {
     return this.projectRepository.getProjectMemoListWithMember(projectId);
+  }
+  async updateMemoColor(
+    project: Project,
+    id: number,
+    color: memoColor,
+  ): Promise<boolean> {
+    const memo = await this.projectRepository.findMemoById(id);
+    if (!memo) return false;
+    if (memo.projectId !== project.id)
+      throw new Error('project does not have this memo');
+    await this.projectRepository.updateMemoColor(id, color);
+    return true;
   }
 }

--- a/backend/test/project/ws-memo.e2e-spec.ts
+++ b/backend/test/project/ws-memo.e2e-spec.ts
@@ -12,288 +12,403 @@ import {
   projectPayload,
 } from 'test/setup';
 
-describe('WS memo create', () => {
+describe('WS memo', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
     await app.listen(3000);
   });
+  describe('memo create', () => {
+    it('should return created memo data when received create memo request', async () => {
+      let socket1;
+      let socket2;
+      return new Promise<void>(async (resolve, reject) => {
+        // 회원1 회원가입 + 프로젝트 생성
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken, project.id);
 
-  it('should return created memo data when received create memo request', async () => {
-    let socket1;
-    let socket2;
-    return new Promise<void>(async (resolve, reject) => {
-      // 회원1 회원가입 + 프로젝트 생성
-      const accessToken = (await createMember(memberFixture, app)).accessToken;
-      const project = await createProject(accessToken, projectPayload, app);
-      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+        // 회원2 회원가입 + 프로젝트 참여
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
 
-      // 회원2 회원가입 + 프로젝트 참여
-      const accessToken2 = (await createMember(memberFixture2, app))
-        .accessToken;
-      await joinProject(accessToken2, projectLinkId);
+        socket1 = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket1);
+        await initLanding(socket1);
 
-      socket1 = connectServer(project.id, accessToken);
-      await emitJoinLanding(socket1);
-      await initLanding(socket1);
+        socket2 = connectServer(project.id, accessToken2);
+        await emitJoinLanding(socket2);
+        await initLanding(socket2);
 
-      socket2 = connectServer(project.id, accessToken2);
-      await emitJoinLanding(socket2);
-      await initLanding(socket2);
-
-      const requestData = {
-        action: 'create',
-        content: { color: 'yellow' },
-      };
-      socket1.emit('memo', requestData);
-      socket1.on('error', () => {
-        reject();
-      });
-      await Promise.all([
-        expectCreateMemo(socket1, memberFixture.username, requestData.content.color),
-        expectCreateMemo(socket2, memberFixture.username, requestData.content.color),
-      ]);
-      socket1.on('exception', (data) => {
-        reject(data);
-      });
-      resolve();
-    }).finally(() => {
-      socket1.close();
-      socket2.close();
-    });
-  });
-
-  it('should succeed create memo when memo is created twice', async () => {
-    let socket;
-    return new Promise<void>(async (resolve, reject) => {
-      const accessToken = (await createMember(memberFixture, app)).accessToken;
-      const project = await createProject(accessToken, projectPayload, app);
-
-      socket = connectServer(project.id, accessToken);
-      await emitJoinLanding(socket);
-      await initLanding(socket);
-
-      const requestData = {
-        action: 'create',
-        content: { color: 'yellow' },
-      };
-      socket.emit('memo', requestData);
-      expectCreateMemo(socket, memberFixture.username, requestData.content.color);
-      socket.emit('memo', requestData);
-      expectCreateMemo(socket, memberFixture.username, requestData.content.color);
-      socket.on('exception', (data) => {
-        reject(data);
-      });
-      resolve();
-    }).finally(() => {
-      socket.close();
-    });
-  });
-
-  it('should return error message list when data format is invalid', async () => {
-    let socket;
-    return new Promise<void>(async (resolve, reject) => {
-      const accessToken = (await createMember(memberFixture, app)).accessToken;
-      const project = await createProject(accessToken, projectPayload, app);
-
-      socket = connectServer(project.id, accessToken);
-      await emitJoinLanding(socket);
-      await initLanding(socket);
-
-      const requestData = {
-        action: 'create',
-        content: { color: 'invalidColor' },
-      };
-      socket.emit('memo', requestData);
-      socket.on('error', (data) => {
-        expect(data.errorList).toBeDefined();
-        expect(data.errorList.length).toBeGreaterThan(0);
+        const requestData = {
+          action: 'create',
+          content: { color: 'yellow' },
+        };
+        socket1.emit('memo', requestData);
+        socket1.on('error', () => {
+          reject();
+        });
+        await Promise.all([
+          expectCreateMemo(
+            socket1,
+            memberFixture.username,
+            requestData.content.color,
+          ),
+          expectCreateMemo(
+            socket2,
+            memberFixture.username,
+            requestData.content.color,
+          ),
+        ]);
+        socket1.on('exception', (data) => {
+          reject(data);
+        });
         resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
       });
-      socket.on('exception', (data) => {
-        reject(data);
-      });
-    }).finally(() => {
-      socket.close();
     });
-  });
 
-  it('should return error message list when color property is empty', async () => {
-    let socket;
-    return new Promise<void>(async (resolve, reject) => {
-      const accessToken = (await createMember(memberFixture, app)).accessToken;
-      const project = await createProject(accessToken, projectPayload, app);
+    it('should succeed create memo when memo is created twice', async () => {
+      let socket;
+      return new Promise<void>(async (resolve, reject) => {
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
 
-      socket = connectServer(project.id, accessToken);
-      await emitJoinLanding(socket);
-      await initLanding(socket);
+        socket = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket);
+        await initLanding(socket);
 
-      const requestData = {
-        action: 'create',
-      };
-      socket.emit('memo', requestData);
-      socket.on('error', (data) => {
-        expect(data.errorList).toBeDefined();
-        expect(data.errorList.length).toBeGreaterThan(0);
+        const requestData = {
+          action: 'create',
+          content: { color: 'yellow' },
+        };
+        socket.emit('memo', requestData);
+        expectCreateMemo(
+          socket,
+          memberFixture.username,
+          requestData.content.color,
+        );
+        socket.emit('memo', requestData);
+        expectCreateMemo(
+          socket,
+          memberFixture.username,
+          requestData.content.color,
+        );
+        socket.on('exception', (data) => {
+          reject(data);
+        });
         resolve();
+      }).finally(() => {
+        socket.close();
       });
-      socket.on('exception', (data) => {
-        reject(data);
-      });
-    }).finally(() => {
-      socket.close();
     });
-  });
-});
 
-describe('WS memo delete', () => {
-  beforeEach(async () => {
-    await app.close();
-    await appInit();
-    await app.listen(3000);
-  });
+    it('should return error message list when data format is invalid', async () => {
+      let socket;
+      return new Promise<void>(async (resolve, reject) => {
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
 
-  it('should return deleted memo data when received delete memo request', async () => {
-    let socket1;
-    let socket2;
-    return new Promise<void>(async (resolve, reject) => {
-      // 회원1 회원가입 + 프로젝트 생성
-      const accessToken = (await createMember(memberFixture, app)).accessToken;
-      const project = await createProject(accessToken, projectPayload, app);
-      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+        socket = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket);
+        await initLanding(socket);
 
-      // 회원2 회원가입 + 프로젝트 참여
-      const accessToken2 = (await createMember(memberFixture2, app))
-        .accessToken;
-      await joinProject(accessToken2, projectLinkId);
-
-      socket1 = connectServer(project.id, accessToken);
-      await emitJoinLanding(socket1);
-      await initLanding(socket1);
-
-      socket2 = connectServer(project.id, accessToken2);
-      await emitJoinLanding(socket2);
-      await initLanding(socket2);
-
-      // 메모 생성
-      const createRequestData = {
-        action: 'create',
-        content: { color: 'yellow' },
-      };
-      socket1.emit('memo', createRequestData);
-      socket1.on('error', () => {
-        reject();
+        const requestData = {
+          action: 'create',
+          content: { color: 'invalidColor' },
+        };
+        socket.emit('memo', requestData);
+        socket.on('error', (data) => {
+          expect(data.errorList).toBeDefined();
+          expect(data.errorList.length).toBeGreaterThan(0);
+          resolve();
+        });
+        socket.on('exception', (data) => {
+          reject(data);
+        });
+      }).finally(() => {
+        socket.close();
       });
-      const [id1, id2] = await Promise.all([
-        getCreatedMemoId(socket1),
-        getCreatedMemoId(socket2),
-      ]);
-      const deleteMemoId = id1
-
-      // 메모 삭제 테스트
-      const deleteRequestData = {
-        action: 'delete',
-        content: { id: id1 },
-      };
-      socket1.emit('memo', deleteRequestData);
-      await Promise.all([
-        expectDeleteMemo(socket1, deleteMemoId),
-        expectDeleteMemo(socket2, deleteMemoId),
-      ])
-      resolve();
-    }).finally(() => {
-      socket1.close();
-      socket2.close();
     });
+
+    it('should return error message list when color property is empty', async () => {
+      let socket;
+      return new Promise<void>(async (resolve, reject) => {
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+
+        socket = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket);
+        await initLanding(socket);
+
+        const requestData = {
+          action: 'create',
+        };
+        socket.emit('memo', requestData);
+        socket.on('error', (data) => {
+          expect(data.errorList).toBeDefined();
+          expect(data.errorList.length).toBeGreaterThan(0);
+          resolve();
+        });
+        socket.on('exception', (data) => {
+          reject(data);
+        });
+      }).finally(() => {
+        socket.close();
+      });
+    });
+
+    const expectCreateMemo = (socket, author, color) => {
+      return new Promise<void>((res) => {
+        socket.on('landing', (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('memo');
+          expect(action).toBe('create');
+          expect(content).toBeDefined();
+          expect(content.id).toBeDefined();
+          expect(content.title).toBeDefined();
+          expect(content.content).toBeDefined();
+          expect(content.createdAt).toBeDefined();
+          expect(content.author).toBe(author);
+          expect(content.color).toBe(color);
+          socket.off('landing');
+          res();
+        });
+      });
+    };
   });
 
-  it('should return error message list when data format is invalid', async () => {
-    let socket;
-    return new Promise<void>(async (resolve) => {
-      const accessToken = (await createMember(memberFixture, app)).accessToken;
-      const project = await createProject(accessToken, projectPayload, app);
+  describe('memo delete', () => {
+    it('should return deleted memo data when received delete memo request', async () => {
+      let socket1;
+      let socket2;
+      return new Promise<void>(async (resolve, reject) => {
+        // 회원1 회원가입 + 프로젝트 생성
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken, project.id);
 
-      socket = connectServer(project.id, accessToken);
-      await emitJoinLanding(socket);
-      await initLanding(socket);
+        // 회원2 회원가입 + 프로젝트 참여
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
 
-      const requestData = {
-        action: 'delete',
-        content: { id: 'invalidDataFormat' },
-      };
-      socket.emit('memo', requestData);
-      socket.on('error', (data) => {
-        expect(data.errorList).toBeDefined();
-        expect(data.errorList.length).toBeGreaterThan(0);
+        socket1 = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket1);
+        await initLanding(socket1);
+
+        socket2 = connectServer(project.id, accessToken2);
+        await emitJoinLanding(socket2);
+        await initLanding(socket2);
+
+        // 메모 생성
+        const createRequestData = {
+          action: 'create',
+          content: { color: 'yellow' },
+        };
+        socket1.emit('memo', createRequestData);
+        socket1.on('error', () => {
+          reject();
+        });
+        const [id1, id2] = await Promise.all([
+          getCreatedMemoId(socket1),
+          getCreatedMemoId(socket2),
+        ]);
+        const deleteMemoId = id1;
+
+        // 메모 삭제 테스트
+        const deleteRequestData = {
+          action: 'delete',
+          content: { id: deleteMemoId },
+        };
+        socket1.emit('memo', deleteRequestData);
+        await Promise.all([
+          expectDeleteMemo(socket1, deleteMemoId),
+          expectDeleteMemo(socket2, deleteMemoId),
+        ]);
         resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
       });
-    }).finally(() => {
-      socket.close();
+    });
+
+    it('should return error message list when data format is invalid', async () => {
+      let socket;
+      return new Promise<void>(async (resolve) => {
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+
+        socket = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket);
+        await initLanding(socket);
+
+        const requestData = {
+          action: 'delete',
+          content: { id: 'invalidDataFormat' },
+        };
+        socket.emit('memo', requestData);
+        socket.on('error', (data) => {
+          expect(data.errorList).toBeDefined();
+          expect(data.errorList.length).toBeGreaterThan(0);
+          resolve();
+        });
+      }).finally(() => {
+        socket.close();
+      });
+    });
+
+    const expectDeleteMemo = (socket, deleteMemoId) => {
+      return new Promise<void>((resolve) => {
+        socket.on('landing', (data) => {
+          const { domain, action, content } = data;
+          expect(domain).toBe('memo');
+          expect(action).toBe('delete');
+          expect(content).toBeDefined();
+          expect(content.id).toBe(deleteMemoId);
+          socket.off('landing');
+          resolve();
+        });
+      });
+    };
+  });
+
+  describe('memo color update', () => {
+    it('should return updated color data when received update color memo request', async () => {
+      let socket1;
+      let socket2;
+      return new Promise<void>(async (resolve, reject) => {
+        // 회원1 회원가입 + 프로젝트 생성
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+        // 회원2 회원가입 + 프로젝트 참여
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
+
+        socket1 = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket1);
+        await initLanding(socket1);
+
+        socket2 = connectServer(project.id, accessToken2);
+        await emitJoinLanding(socket2);
+        await initLanding(socket2);
+
+        // 메모 생성
+        const createRequestData = {
+          action: 'create',
+          content: { color: 'yellow' },
+        };
+        socket1.emit('memo', createRequestData);
+        socket1.on('error', () => {
+          reject();
+        });
+        const [id1, id2] = await Promise.all([
+          getCreatedMemoId(socket1),
+          getCreatedMemoId(socket2),
+        ]);
+        const updateColorMemoId = id1;
+        const updateColor = 'blue';
+
+        // 메모 색상 변경 테스트
+        const deleteRequestData = {
+          action: 'colorUpdate',
+          content: { id: updateColorMemoId, color: updateColor },
+        };
+        socket1.emit('memo', deleteRequestData);
+        await Promise.all([
+          expectUpdateColorMemo(socket1, updateColorMemoId, updateColor),
+          expectUpdateColorMemo(socket2, updateColorMemoId, updateColor),
+        ]);
+        resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
+      });
+    });
+
+    const expectUpdateColorMemo = (socket, updateColorMemoId, updateColor) => {
+      return new Promise<void>((resolve) => {
+        socket.on('landing', (data) => {
+          const { domain, action, content } = data;
+          expect(domain).toBe('memo');
+          expect(action).toBe('colorUpdate');
+          expect(content).toBeDefined();
+          expect(content.id).toBe(updateColorMemoId);
+          expect(content.color).toBe(updateColor);
+          socket.off('landing');
+          resolve();
+        });
+      });
+    };
+
+    it('should return error message list when data format is invalid', async () => {
+      let socket;
+      return new Promise<void>(async (resolve) => {
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+
+        socket = connectServer(project.id, accessToken);
+        await emitJoinLanding(socket);
+        await initLanding(socket);
+
+        const requestData = {
+          action: 'colorUpdate',
+          content: { id: 'invalidDataFormat', color: 'invalidColor' },
+        };
+        socket.emit('memo', requestData);
+        socket.on('error', (data) => {
+          expect(data.errorList).toBeDefined();
+          expect(data.errorList.length).toBe(2);
+          resolve();
+        });
+      }).finally(() => {
+        socket.close();
+      });
     });
   });
-});
-
-const getCreatedMemoId = (socket) => {
-  return new Promise<number>((resolve) => {
-    socket.on('landing', (data) => {
-      const { content } = data;
-      socket.off('landing');
-      resolve(content.id);
-    });
-  });
-};
-
-const expectDeleteMemo = (socket, deleteMemoId) => {
-  return new Promise<void>((resolve) => {
-    socket.on('landing', (data) => {
-      const { domain, action, content } = data;
-      expect(domain).toBe('memo');
-      expect(action).toBe('delete');
-      expect(content).toBeDefined();
-      expect(content.id).toBe(deleteMemoId);
-      socket.off('landing');
-      resolve();
-    });
-  });
-};
-
-const expectCreateMemo = (socket, author, color) => {
-  return new Promise<void>((res) => {
-    socket.on('landing', (data) => {
-      const { content, action, domain } = data;
-      expect(domain).toBe('memo');
-      expect(action).toBe('create');
-      expect(content).toBeDefined();
-      expect(content.id).toBeDefined();
-      expect(content.title).toBeDefined();
-      expect(content.content).toBeDefined();
-      expect(content.createdAt).toBeDefined();
-      expect(content.author).toBe(author);
-      expect(content.color).toBe(color);
-      socket.off('landing');
-      res();
-    });
-  });
-};
-
-const emitJoinLanding = (socket) => {
-  return new Promise<void>((res, rej) => {
-    socket.on('connect', () => {
-      socket.emit('joinLanding');
-      socket.off('connect');
-      res();
-    });
-  });
-};
-
-const initLanding = (socket) => {
-  return new Promise<void>((res, rej) => {
-    socket.on('landing', (data) => {
-      const { action, content, domain } = data;
-      if (action === 'init') {
+  const getCreatedMemoId = (socket) => {
+    return new Promise<number>((resolve) => {
+      socket.on('landing', (data) => {
+        const { content } = data;
         socket.off('landing');
-        res();
-      }
+        resolve(content.id);
+      });
     });
-  });
-};
+  };
+
+  const emitJoinLanding = (socket) => {
+    return new Promise<void>((res, rej) => {
+      socket.on('connect', () => {
+        socket.emit('joinLanding');
+        socket.off('connect');
+        res();
+      });
+    });
+  };
+
+  const initLanding = (socket) => {
+    return new Promise<void>((res, rej) => {
+      socket.on('landing', (data) => {
+        const { action, content, domain } = data;
+        if (action === 'init') {
+          socket.off('landing');
+          res();
+        }
+      });
+    });
+  };
+});


### PR DESCRIPTION
## 🎟️ 태스크

[메모 색상 변경 웹소켓 API 구현 (백)](https://plastic-toad-cb0.notion.site/API-864bee8ab8824fa79cc6301d881ef8fc)

## ✅ 작업 내용

- 메모 색상 업데이트 e2e 테스트 작성
- 프로젝트의 메모조회, 메모 색상 업데이트 레포티토리 메서드 구현
- 메모색상 업데이트 서비스 구현
- 메모색상 업데이트 컨트롤러 구현

## 🖊️ 구체적인 작업

### 메모 색상 업데이트 e2e 테스트 작성
- 모든 테스트의 가장 바깥 describe에 'WS memo' describe 추가
  - 각 테스트의 인덴트 변경
- 메모 색상변경 API 테스트 추가
  - 성공상황 테스트
  - 데이터 형식 오류로 인한 실패상황 테스트
### 프로젝트의 메모조회, 메모 색상 업데이트 레포티토리 메서드 구현
- 프로젝트의 메모조회, 메모 색상 업데이트 레포티토리 메서드 구현
- 메모 엔티티의 projectId의 타입을 int로 명시
### 메모색상 업데이트 서비스 구현
- 메모가 존재하고 해당 프로젝트의 메모일때 메모 색상을 업데이트 하고 true 반환
- 메모가 존재하지 않을때 false 반환
- 메모가 해당 프로젝트의 메모가 아닐때 throw
- 이에대한 테스트와 구현 작성
### 메모색상 업데이트 컨트롤러 구현
- 요청검증을 위한 requestDto 작성
- 메모 색성 업데이트 컨트롤러 로직 구현

## 🤔 고민 및 의논할 거리
- 접근하고자 하는 메모가 해당 프로젝트의 메모가 아닌 경우에 대해 서비스는 throw를 하는 방식으로 처리했습니다. 컨트롤러에서 이를 무시하고 있게 구현했는데 이를 클라이언트에게 보내줄건지 논의하면 좋을것같습니다.
- 현재 메모삭제의 경우 메모가 해당 프로젝트의 메모인지 확인하지 않고있습니다. 확인하는 로직을 추후에 추가해야 할 것 같습니다.