### PR TITLE
feat: 회원가입 페이지에서 마우스 휠로 단계를 넘어가는 기능

### DIFF
--- a/frontend/src/components/account/NicknameInput.tsx
+++ b/frontend/src/components/account/NicknameInput.tsx
@@ -76,6 +76,28 @@ const NicknameInput = ({
     getUsername();
   }, []);
 
+  useEffect(() => {
+    const handleWheelEvent = (event: WheelEvent) => {
+      if (currentStepNumber !== SIGNUP_STEP.STEP1.NUMBER) {
+        return;
+      }
+
+      debounce(100, () => {
+        const downScrolled = event.deltaY > 0;
+
+        if (downScrolled && validated) {
+          setCurrentStep(SIGNUP_STEP.STEP2);
+        }
+      });
+    };
+
+    window.addEventListener("wheel", handleWheelEvent);
+
+    return () => {
+      window.removeEventListener("wheel", handleWheelEvent);
+    };
+  }, [validated, currentStepNumber]);
+
   return (
     <div
       className={`flex gap-[4.375rem] h-[100%] ${

--- a/frontend/src/components/account/NicknameInput.tsx
+++ b/frontend/src/components/account/NicknameInput.tsx
@@ -1,12 +1,13 @@
 import { ChangeEvent, useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { SIGNUP_STEP } from "../../constants/account";
 import NextStepButton from "../common/NextStepButton";
-import useDebounce from "../../hooks/common/useDebounce";
 import {
   getGithubUsername,
   getNicknameAvailability,
 } from "../../apis/api/signupAPI";
-import { useLocation } from "react-router-dom";
+import useWheelDown from "../../hooks/pages/account/useWheelDown";
+import useDebounce from "../../hooks/common/useDebounce";
 
 interface NicknameInputProps {
   currentStepNumber: number;
@@ -15,7 +16,6 @@ interface NicknameInputProps {
   >;
   nicknameValueRef: React.MutableRefObject<string>;
   inputElementRef: React.MutableRefObject<HTMLInputElement | null>;
-  inputAreaElementRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 const NicknameInput = ({
@@ -23,16 +23,23 @@ const NicknameInput = ({
   setCurrentStep,
   nicknameValueRef,
   inputElementRef,
-  inputAreaElementRef,
 }: NicknameInputProps) => {
   const [inputValue, setInputValue] = useState<string>("");
   const [validated, setValidated] = useState<boolean | null>(null);
-  const location = useLocation();
   const debounce = useDebounce();
+  const location = useLocation();
 
-  const handleNextButtonClick = () => {
+  const goToNextStep = () => {
+    inputElementRef.current?.blur;
     setCurrentStep(SIGNUP_STEP.STEP2);
   };
+
+  useWheelDown({
+    currentStepNumber,
+    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    dependency: validated,
+    goToNextStep,
+  });
 
   const nicknameAvailabilityCheck = async () => {
     if (!inputValue) {
@@ -55,7 +62,7 @@ const NicknameInput = ({
 
   const handleEnterDown = ({ key }: React.KeyboardEvent) => {
     if (key === "Enter" && validated) {
-      setCurrentStep(SIGNUP_STEP.STEP2);
+      goToNextStep();
     }
   };
 
@@ -76,28 +83,6 @@ const NicknameInput = ({
     getUsername();
   }, []);
 
-  useEffect(() => {
-    const handleWheelEvent = (event: WheelEvent) => {
-      if (currentStepNumber !== SIGNUP_STEP.STEP1.NUMBER) {
-        return;
-      }
-
-      debounce(100, () => {
-        const downScrolled = event.deltaY > 0;
-
-        if (downScrolled && validated) {
-          setCurrentStep(SIGNUP_STEP.STEP2);
-        }
-      });
-    };
-
-    window.addEventListener("wheel", handleWheelEvent);
-
-    return () => {
-      window.removeEventListener("wheel", handleWheelEvent);
-    };
-  }, [validated, currentStepNumber]);
-
   return (
     <div
       className={`flex gap-[4.375rem] h-[100%] ${
@@ -114,7 +99,7 @@ const NicknameInput = ({
           LESSER에서 사용할 제 이름은
         </label>
         <br />
-        <div ref={inputAreaElementRef} className="flex w-[525px]">
+        <div className="flex w-[525px]">
           <div className="inline">
             <input
               type="text"
@@ -145,9 +130,7 @@ const NicknameInput = ({
       </div>
       <div className="min-w-[6.875rem] self-end">
         {validated && currentStepNumber !== SIGNUP_STEP.STEP2.NUMBER && (
-          <NextStepButton onNextButtonClick={handleNextButtonClick}>
-            Next
-          </NextStepButton>
+          <NextStepButton onNextButtonClick={goToNextStep}>Next</NextStepButton>
         )}
       </div>
     </div>

--- a/frontend/src/components/account/NicknameInput.tsx
+++ b/frontend/src/components/account/NicknameInput.tsx
@@ -13,13 +13,17 @@ interface NicknameInputProps {
   setCurrentStep: React.Dispatch<
     React.SetStateAction<{ NUMBER: number; NAME: string }>
   >;
-  nicknameRef: React.MutableRefObject<string>;
+  nicknameValueRef: React.MutableRefObject<string>;
+  inputElementRef: React.MutableRefObject<HTMLInputElement | null>;
+  inputAreaElementRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 const NicknameInput = ({
   currentStepNumber,
   setCurrentStep,
-  nicknameRef,
+  nicknameValueRef,
+  inputElementRef,
+  inputAreaElementRef,
 }: NicknameInputProps) => {
   const [inputValue, setInputValue] = useState<string>("");
   const [validated, setValidated] = useState<boolean | null>(null);
@@ -46,7 +50,7 @@ const NicknameInput = ({
   const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const value = target.value.trim();
     setInputValue(value);
-    nicknameRef.current = value;
+    nicknameValueRef.current = value;
   };
 
   const handleEnterDown = ({ key }: React.KeyboardEvent) => {
@@ -66,7 +70,7 @@ const NicknameInput = ({
         location.state.tempIdToken
       );
       setInputValue(githubUsername);
-      nicknameRef.current = githubUsername;
+      nicknameValueRef.current = githubUsername;
     };
 
     getUsername();
@@ -88,15 +92,16 @@ const NicknameInput = ({
           LESSER에서 사용할 제 이름은
         </label>
         <br />
-        <div id="nickname-input-box" className="flex w-[525px]">
+        <div ref={inputAreaElementRef} className="flex w-[525px]">
           <div className="inline">
             <input
               type="text"
               name="nickname"
               id="nickname"
+              ref={inputElementRef}
               value={inputValue}
               autoComplete="off"
-              onChange={(e) => handleInputChange(e)}
+              onChange={handleInputChange}
               onKeyDown={handleEnterDown}
               className={`w-[27.5rem] h-[3rem] border-b-2 focus:outline-none focus:border-b-3 font-semibold text-3xl ${
                 inputValue && validated && "border-b-3 border-middle-green "

--- a/frontend/src/components/account/PositionInput.tsx
+++ b/frontend/src/components/account/PositionInput.tsx
@@ -11,12 +11,14 @@ interface JobInputProps {
     React.SetStateAction<{ NUMBER: number; NAME: string }>
   >;
   positionValueRef: React.MutableRefObject<string | null>;
+  positionElementRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 const PositionInput = ({
   currentStepNumber,
   setCurrentStep,
   positionValueRef,
+  positionElementRef,
 }: JobInputProps) => {
   const { Dropdown, selectedOption } = useDropdown({
     placeholder: JOB_INPUT_INFO.PLACEHOLDER,
@@ -62,6 +64,7 @@ const PositionInput = ({
       <div
         id="position-input-box"
         className="min-w-[567px] flex gap-4 items-center"
+        ref={positionElementRef}
       >
         <span className="text-3xl font-semibold text-dark-gray">
           저의 주요 직무는

--- a/frontend/src/components/account/PositionInput.tsx
+++ b/frontend/src/components/account/PositionInput.tsx
@@ -8,13 +8,13 @@ interface JobInputProps {
   setCurrentStep: React.Dispatch<
     React.SetStateAction<{ NUMBER: number; NAME: string }>
   >;
-  positionRef: React.MutableRefObject<string | null>;
+  positionValueRef: React.MutableRefObject<string | null>;
 }
 
 const PositionInput = ({
   currentStepNumber,
   setCurrentStep,
-  positionRef,
+  positionValueRef,
 }: JobInputProps) => {
   const { Dropdown, selectedOption } = useDropdown({
     placeholder: JOB_INPUT_INFO.PLACEHOLDER,
@@ -26,7 +26,7 @@ const PositionInput = ({
   };
 
   useEffect(() => {
-    positionRef.current = selectedOption;
+    positionValueRef.current = selectedOption;
     if (selectedOption) {
       setCurrentStep(SIGNUP_STEP.STEP3);
     }

--- a/frontend/src/components/account/PositionInput.tsx
+++ b/frontend/src/components/account/PositionInput.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 import useDropdown from "../../hooks/common/dropdown/useDropdown";
 import NextStepButton from "../common/NextStepButton";
 import { JOB_INPUT_INFO, SIGNUP_STEP } from "../../constants/account";
-import useDebounce from "../../hooks/common/useDebounce";
+import useWheelDown from "../../hooks/pages/account/useWheelDown";
+import useWheelUp from "../../hooks/pages/account/useWheelUp";
 
 interface JobInputProps {
   currentStepNumber: number;
@@ -21,10 +22,13 @@ const PositionInput = ({
     placeholder: JOB_INPUT_INFO.PLACEHOLDER,
     options: JOB_INPUT_INFO.OPTIONS,
   });
-  const debounce = useDebounce();
 
-  const handleNextButtonClick = () => {
+  const goToNextStep = () => {
     setCurrentStep(SIGNUP_STEP.STEP3);
+  };
+
+  const goToPrevStep = () => {
+    setCurrentStep(SIGNUP_STEP.STEP1);
   };
 
   useEffect(() => {
@@ -34,32 +38,18 @@ const PositionInput = ({
     }
   }, [selectedOption]);
 
-  useEffect(() => {
-    const handleWheelEvent = (event: WheelEvent) => {
-      if (currentStepNumber !== SIGNUP_STEP.STEP2.NUMBER) {
-        return;
-      }
+  useWheelDown({
+    currentStepNumber,
+    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    dependency: selectedOption,
+    goToNextStep,
+  });
 
-      debounce(100, () => {
-        const downScrolled = event.deltaY > 0;
-
-        if (downScrolled && selectedOption) {
-          setCurrentStep(SIGNUP_STEP.STEP3);
-          return;
-        }
-
-        if (!downScrolled) {
-          setCurrentStep(SIGNUP_STEP.STEP1);
-        }
-      });
-    };
-
-    window.addEventListener("wheel", handleWheelEvent);
-
-    return () => {
-      window.removeEventListener("wheel", handleWheelEvent);
-    };
-  }, [selectedOption, currentStepNumber]);
+  useWheelUp({
+    currentStepNumber,
+    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    goToPrevStep,
+  });
 
   return (
     <div
@@ -87,9 +77,7 @@ const PositionInput = ({
       </div>
       <div className="min-w-[6.875rem] self-end">
         {currentStepNumber !== SIGNUP_STEP.STEP3.NUMBER && selectedOption && (
-          <NextStepButton onNextButtonClick={handleNextButtonClick}>
-            Next
-          </NextStepButton>
+          <NextStepButton onNextButtonClick={goToNextStep}>Next</NextStepButton>
         )}
       </div>
     </div>

--- a/frontend/src/components/account/PositionInput.tsx
+++ b/frontend/src/components/account/PositionInput.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import useDropdown from "../../hooks/common/dropdown/useDropdown";
 import NextStepButton from "../common/NextStepButton";
 import { JOB_INPUT_INFO, SIGNUP_STEP } from "../../constants/account";
+import useDebounce from "../../hooks/common/useDebounce";
 
 interface JobInputProps {
   currentStepNumber: number;
@@ -20,6 +21,7 @@ const PositionInput = ({
     placeholder: JOB_INPUT_INFO.PLACEHOLDER,
     options: JOB_INPUT_INFO.OPTIONS,
   });
+  const debounce = useDebounce();
 
   const handleNextButtonClick = () => {
     setCurrentStep(SIGNUP_STEP.STEP3);
@@ -31,6 +33,33 @@ const PositionInput = ({
       setCurrentStep(SIGNUP_STEP.STEP3);
     }
   }, [selectedOption]);
+
+  useEffect(() => {
+    const handleWheelEvent = (event: WheelEvent) => {
+      if (currentStepNumber !== SIGNUP_STEP.STEP2.NUMBER) {
+        return;
+      }
+
+      debounce(100, () => {
+        const downScrolled = event.deltaY > 0;
+
+        if (downScrolled && selectedOption) {
+          setCurrentStep(SIGNUP_STEP.STEP3);
+          return;
+        }
+
+        if (!downScrolled) {
+          setCurrentStep(SIGNUP_STEP.STEP1);
+        }
+      });
+    };
+
+    window.addEventListener("wheel", handleWheelEvent);
+
+    return () => {
+      window.removeEventListener("wheel", handleWheelEvent);
+    };
+  }, [selectedOption, currentStepNumber]);
 
   return (
     <div

--- a/frontend/src/components/account/PositionInput.tsx
+++ b/frontend/src/components/account/PositionInput.tsx
@@ -40,14 +40,14 @@ const PositionInput = ({
 
   useWheelDown({
     currentStepNumber,
-    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    targetStepNumber: SIGNUP_STEP.STEP2.NUMBER,
     dependency: selectedOption,
     goToNextStep,
   });
 
   useWheelUp({
     currentStepNumber,
-    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    targetStepNumber: SIGNUP_STEP.STEP2.NUMBER,
     goToPrevStep,
   });
 

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -83,7 +83,7 @@ const SignupMainSection = ({
     }
 
     return () => {
-      document.documentElement.style.overflow = "auto";
+      document.documentElement.style.overflowY = "visible";
     };
   }, [currentStepNumber]);
 

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -58,7 +58,7 @@ const SignupMainSection = ({
   };
 
   useEffect(() => {
-    document.documentElement.style.overflowY = "hidden";
+    document.documentElement.style.overflow = "hidden";
     switch (currentStepNumber) {
       case SIGNUP_STEP.STEP1.NUMBER:
         inputElementRef.current?.scrollIntoView({
@@ -83,7 +83,7 @@ const SignupMainSection = ({
     }
 
     return () => {
-      document.documentElement.style.overflowY = "visible";
+      document.documentElement.style.overflow = "visible";
     };
   }, [currentStepNumber]);
 
@@ -95,7 +95,7 @@ const SignupMainSection = ({
         }`}
         onClick={handlePrevStepAreaClick}
       ></div>
-      <form className="h-[100%] overflow-y-hidden">
+      <section className="h-[100%] overflow-y-hidden">
         <NicknameInput
           {...{
             currentStepNumber,
@@ -116,7 +116,7 @@ const SignupMainSection = ({
           }}
           onSignupButtonClick={handleSignupButtonClick}
         />
-      </form>
+      </section>
     </main>
   );
 };

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -105,7 +105,12 @@ const SignupMainSection = ({
           {...{ currentStepNumber, setCurrentStep, positionValueRef }}
         />
         <TechStackInput
-          {...{ setCurrentStep, techValueRef, techStackElementRef }}
+          {...{
+            setCurrentStep,
+            techValueRef,
+            techStackElementRef,
+            currentStepNumber,
+          }}
           onSignupButtonClick={handleSignupButtonClick}
         />
       </section>

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -23,7 +23,7 @@ const SignupMainSection = ({
   const positionValueRef = useRef<null | string>(null);
   const techValueRef = useRef<null | string[]>(null);
   const inputElementRef = useRef<HTMLInputElement | null>(null);
-  const techStackElementRef = useRef<HTMLDivElement | null>(null);
+  const positionElementRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -58,7 +58,7 @@ const SignupMainSection = ({
   };
 
   useEffect(() => {
-    document.documentElement.style.overflow = "hidden";
+    document.documentElement.style.overflowY = "hidden";
     switch (currentStepNumber) {
       case SIGNUP_STEP.STEP1.NUMBER:
         inputElementRef.current?.scrollIntoView({
@@ -75,15 +75,15 @@ const SignupMainSection = ({
         break;
 
       case SIGNUP_STEP.STEP3.NUMBER:
-        techStackElementRef.current?.scrollIntoView({
+        positionElementRef.current?.scrollIntoView({
           behavior: "smooth",
-          block: "center",
+          block: "start",
         });
         break;
     }
 
     return () => {
-      document.documentElement.style.overflow = "visible";
+      document.documentElement.style.overflowY = "visible";
     };
   }, [currentStepNumber]);
 
@@ -105,13 +105,17 @@ const SignupMainSection = ({
           }}
         />
         <PositionInput
-          {...{ currentStepNumber, setCurrentStep, positionValueRef }}
+          {...{
+            currentStepNumber,
+            setCurrentStep,
+            positionValueRef,
+            positionElementRef,
+          }}
         />
         <TechStackInput
           {...{
             setCurrentStep,
             techValueRef,
-            techStackElementRef,
             currentStepNumber,
           }}
           onSignupButtonClick={handleSignupButtonClick}

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -19,9 +19,12 @@ const SignupMainSection = ({
   currentStepNumber,
   setCurrentStep,
 }: SignupMainSectionProps) => {
-  const nicknameRef = useRef<string>("");
-  const positionRef = useRef<null | string>(null);
-  const techRef = useRef<null | string[]>(null);
+  const nicknameValueRef = useRef<string>("");
+  const positionValueRef = useRef<null | string>(null);
+  const techValueRef = useRef<null | string[]>(null);
+  const inputElementRef = useRef<HTMLInputElement | null>(null);
+  const inputAreaElementRef = useRef<HTMLDivElement | null>(null);
+  const techStackElementRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -41,9 +44,9 @@ const SignupMainSection = ({
 
   const handleSignupButtonClick = async () => {
     const status = await postSignup({
-      username: nicknameRef.current,
-      position: positionRef.current,
-      techStack: techRef.current,
+      username: nicknameValueRef.current,
+      position: positionValueRef.current,
+      techStack: techValueRef.current,
       tempIdToken: location.state.tempIdToken,
     });
     const redirectURL = sessionStorage.getItem(STORAGE_KEY.REDIRECT);
@@ -56,24 +59,26 @@ const SignupMainSection = ({
   };
 
   useEffect(() => {
-    const nicknameInput = document.getElementById("nickname");
-    const nicknameInputElement = document.getElementById("nickname-input-box");
-    const techStackInput = document.getElementById("tech");
-
     switch (currentStepNumber) {
       case SIGNUP_STEP.STEP1.NUMBER:
-        nicknameInput?.scrollIntoView({ behavior: "smooth", block: "center" });
+        inputElementRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
         break;
 
       case SIGNUP_STEP.STEP2.NUMBER:
-        nicknameInputElement?.scrollIntoView({
+        inputAreaElementRef.current?.scrollIntoView({
           behavior: "smooth",
           block: "start",
         });
         break;
 
       case SIGNUP_STEP.STEP3.NUMBER:
-        techStackInput?.scrollIntoView({ behavior: "smooth", block: "center" });
+        techStackElementRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
         break;
     }
   }, [currentStepNumber]);
@@ -88,13 +93,19 @@ const SignupMainSection = ({
       ></div>
       <section className="h-[100%] overflow-y-hidden">
         <NicknameInput
-          {...{ currentStepNumber, setCurrentStep, nicknameRef }}
+          {...{
+            currentStepNumber,
+            setCurrentStep,
+            nicknameValueRef,
+            inputElementRef,
+            inputAreaElementRef,
+          }}
         />
         <PositionInput
-          {...{ currentStepNumber, setCurrentStep, positionRef }}
+          {...{ currentStepNumber, setCurrentStep, positionValueRef }}
         />
         <TechStackInput
-          {...{ setCurrentStep, techRef }}
+          {...{ setCurrentStep, techValueRef, techStackElementRef }}
           onSignupButtonClick={handleSignupButtonClick}
         />
       </section>

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -23,7 +23,6 @@ const SignupMainSection = ({
   const positionValueRef = useRef<null | string>(null);
   const techValueRef = useRef<null | string[]>(null);
   const inputElementRef = useRef<HTMLInputElement | null>(null);
-  const inputAreaElementRef = useRef<HTMLDivElement | null>(null);
   const techStackElementRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
@@ -59,6 +58,7 @@ const SignupMainSection = ({
   };
 
   useEffect(() => {
+    document.documentElement.style.overflow = "hidden";
     switch (currentStepNumber) {
       case SIGNUP_STEP.STEP1.NUMBER:
         inputElementRef.current?.scrollIntoView({
@@ -68,7 +68,7 @@ const SignupMainSection = ({
         break;
 
       case SIGNUP_STEP.STEP2.NUMBER:
-        inputAreaElementRef.current?.scrollIntoView({
+        inputElementRef.current?.scrollIntoView({
           behavior: "smooth",
           block: "start",
         });
@@ -81,6 +81,10 @@ const SignupMainSection = ({
         });
         break;
     }
+
+    return () => {
+      document.documentElement.style.overflow = "auto";
+    };
   }, [currentStepNumber]);
 
   return (
@@ -91,14 +95,13 @@ const SignupMainSection = ({
         }`}
         onClick={handlePrevStepAreaClick}
       ></div>
-      <section className="h-[100%] overflow-y-hidden">
+      <form className="h-[100%] overflow-y-hidden">
         <NicknameInput
           {...{
             currentStepNumber,
             setCurrentStep,
             nicknameValueRef,
             inputElementRef,
-            inputAreaElementRef,
           }}
         />
         <PositionInput
@@ -113,7 +116,7 @@ const SignupMainSection = ({
           }}
           onSignupButtonClick={handleSignupButtonClick}
         />
-      </section>
+      </form>
     </main>
   );
 };

--- a/frontend/src/components/account/SignupMainSection.tsx
+++ b/frontend/src/components/account/SignupMainSection.tsx
@@ -58,7 +58,7 @@ const SignupMainSection = ({
   };
 
   useEffect(() => {
-    document.documentElement.style.overflow = "hidden";
+    document.documentElement.style.overflowY = "hidden";
     switch (currentStepNumber) {
       case SIGNUP_STEP.STEP1.NUMBER:
         inputElementRef.current?.scrollIntoView({

--- a/frontend/src/components/account/TechStackInput.tsx
+++ b/frontend/src/components/account/TechStackInput.tsx
@@ -41,7 +41,7 @@ const TechStackInput = ({
 
   useWheelUp({
     currentStepNumber,
-    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    targetStepNumber: SIGNUP_STEP.STEP3.NUMBER,
     goToPrevStep,
   });
 

--- a/frontend/src/components/account/TechStackInput.tsx
+++ b/frontend/src/components/account/TechStackInput.tsx
@@ -10,7 +10,6 @@ import useWheelUp from "../../hooks/pages/account/useWheelUp";
 interface TechStackInputProps {
   currentStepNumber: number;
   techValueRef: React.MutableRefObject<null | string[]>;
-  techStackElementRef: React.MutableRefObject<HTMLDivElement | null>;
   setCurrentStep: React.Dispatch<
     React.SetStateAction<{ NUMBER: number; NAME: string }>
   >;
@@ -20,7 +19,6 @@ interface TechStackInputProps {
 const TechStackInput = ({
   currentStepNumber,
   techValueRef,
-  techStackElementRef,
   setCurrentStep,
   onSignupButtonClick,
 }: TechStackInputProps) => {
@@ -46,10 +44,7 @@ const TechStackInput = ({
   });
 
   return (
-    <div
-      ref={techStackElementRef}
-      className="h-[90%] flex items-center gap-[4.375rem]"
-    >
+    <div className="h-[90%] flex items-center gap-[4.375rem]">
       <div className="w-[80%]">
         <p className="mb-3 text-3xl font-semibold text-dark-gray">
           저의 주요 기술 스택은

--- a/frontend/src/components/account/TechStackInput.tsx
+++ b/frontend/src/components/account/TechStackInput.tsx
@@ -1,26 +1,32 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useModal } from "../../hooks/common/modal/useModal";
 import TechStackModal from "./TechStackModal";
 import plus from "../../assets/icons/plus.svg";
 import NextStepButton from "../common/NextStepButton";
 import CategoryButton from "../common/CategoryButton";
+import { SIGNUP_STEP } from "../../constants/account";
+import useDebounce from "../../hooks/common/useDebounce";
 
 interface TechStackInputProps {
+  currentStepNumber: number;
+  techValueRef: React.MutableRefObject<null | string[]>;
+  techStackElementRef: React.MutableRefObject<HTMLDivElement | null>;
   setCurrentStep: React.Dispatch<
     React.SetStateAction<{ NUMBER: number; NAME: string }>
   >;
-  techValueRef: React.MutableRefObject<null | string[]>;
   onSignupButtonClick: () => void;
-  techStackElementRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 const TechStackInput = ({
+  currentStepNumber,
   techValueRef,
-  onSignupButtonClick,
   techStackElementRef,
+  setCurrentStep,
+  onSignupButtonClick,
 }: TechStackInputProps) => {
   const { open, close } = useModal();
   const [techStackList, setTechStackList] = useState<string[]>([]);
+  const debounce = useDebounce();
 
   const handleCloseButtonClick = (techStack: string) => {
     const newTechStackList = [...techStackList];
@@ -29,6 +35,28 @@ const TechStackInput = ({
     techValueRef.current = newTechStackList;
     setTechStackList(newTechStackList);
   };
+
+  useEffect(() => {
+    const handleWheelEvent = (event: WheelEvent) => {
+      if (currentStepNumber !== SIGNUP_STEP.STEP3.NUMBER) {
+        return;
+      }
+
+      debounce(100, () => {
+        const upScrolled = event.deltaY < 0;
+
+        if (upScrolled) {
+          setCurrentStep(SIGNUP_STEP.STEP2);
+        }
+      });
+    };
+
+    window.addEventListener("wheel", handleWheelEvent);
+
+    return () => {
+      window.removeEventListener("wheel", handleWheelEvent);
+    };
+  }, [currentStepNumber]);
 
   return (
     <div

--- a/frontend/src/components/account/TechStackInput.tsx
+++ b/frontend/src/components/account/TechStackInput.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useModal } from "../../hooks/common/modal/useModal";
 import TechStackModal from "./TechStackModal";
 import plus from "../../assets/icons/plus.svg";
 import NextStepButton from "../common/NextStepButton";
 import CategoryButton from "../common/CategoryButton";
 import { SIGNUP_STEP } from "../../constants/account";
-import useDebounce from "../../hooks/common/useDebounce";
+import useWheelUp from "../../hooks/pages/account/useWheelUp";
 
 interface TechStackInputProps {
   currentStepNumber: number;
@@ -26,7 +26,6 @@ const TechStackInput = ({
 }: TechStackInputProps) => {
   const { open, close } = useModal();
   const [techStackList, setTechStackList] = useState<string[]>([]);
-  const debounce = useDebounce();
 
   const handleCloseButtonClick = (techStack: string) => {
     const newTechStackList = [...techStackList];
@@ -36,27 +35,15 @@ const TechStackInput = ({
     setTechStackList(newTechStackList);
   };
 
-  useEffect(() => {
-    const handleWheelEvent = (event: WheelEvent) => {
-      if (currentStepNumber !== SIGNUP_STEP.STEP3.NUMBER) {
-        return;
-      }
+  const goToPrevStep = () => {
+    setCurrentStep(SIGNUP_STEP.STEP2);
+  };
 
-      debounce(100, () => {
-        const upScrolled = event.deltaY < 0;
-
-        if (upScrolled) {
-          setCurrentStep(SIGNUP_STEP.STEP2);
-        }
-      });
-    };
-
-    window.addEventListener("wheel", handleWheelEvent);
-
-    return () => {
-      window.removeEventListener("wheel", handleWheelEvent);
-    };
-  }, [currentStepNumber]);
+  useWheelUp({
+    currentStepNumber,
+    targetStepNumber: SIGNUP_STEP.STEP1.NUMBER,
+    goToPrevStep,
+  });
 
   return (
     <div

--- a/frontend/src/components/account/TechStackInput.tsx
+++ b/frontend/src/components/account/TechStackInput.tsx
@@ -9,13 +9,15 @@ interface TechStackInputProps {
   setCurrentStep: React.Dispatch<
     React.SetStateAction<{ NUMBER: number; NAME: string }>
   >;
-  techRef: React.MutableRefObject<null | string[]>;
+  techValueRef: React.MutableRefObject<null | string[]>;
   onSignupButtonClick: () => void;
+  techStackElementRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 const TechStackInput = ({
-  techRef,
+  techValueRef,
   onSignupButtonClick,
+  techStackElementRef,
 }: TechStackInputProps) => {
   const { open, close } = useModal();
   const [techStackList, setTechStackList] = useState<string[]>([]);
@@ -24,12 +26,15 @@ const TechStackInput = ({
     const newTechStackList = [...techStackList];
     const targetIndex = newTechStackList.indexOf(techStack);
     newTechStackList.splice(targetIndex, 1);
-    techRef.current = newTechStackList;
+    techValueRef.current = newTechStackList;
     setTechStackList(newTechStackList);
   };
 
   return (
-    <div id="tech" className="h-[90%] flex items-center gap-[4.375rem]">
+    <div
+      ref={techStackElementRef}
+      className="h-[90%] flex items-center gap-[4.375rem]"
+    >
       <div className="w-[80%]">
         <p className="mb-3 text-3xl font-semibold text-dark-gray">
           저의 주요 기술 스택은
@@ -47,7 +52,9 @@ const TechStackInput = ({
           className="w-[11.25rem] h-[3.25rem] bg-middle-green rounded-xl text-m text-white mb-3 flex items-center gap-3 shadow-box pl-3 pr-9"
           type="button"
           onClick={() =>
-            open(<TechStackModal {...{ techRef, close, setTechStackList }} />)
+            open(
+              <TechStackModal {...{ techValueRef, close, setTechStackList }} />
+            )
           }
         >
           <img src={plus} alt="plus" />

--- a/frontend/src/components/account/TechStackModal.tsx
+++ b/frontend/src/components/account/TechStackModal.tsx
@@ -2,26 +2,26 @@ import { TECH_STACK_INFO } from "../../constants/account";
 
 interface TechStackModalProps {
   close: () => void;
-  techRef: React.MutableRefObject<null | string[]>;
+  techValueRef: React.MutableRefObject<null | string[]>;
   setTechStackList: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const TechStackModal = ({
   close,
-  techRef,
+  techValueRef,
   setTechStackList,
 }: TechStackModalProps) => {
   const handleTechStackClick = (techStack: string) => {
     setTechStackList((techStackList) => {
-      if (!techRef.current) {
+      if (!techValueRef.current) {
         const newTechStackList = [techStack];
-        techRef.current = [techStack];
+        techValueRef.current = [techStack];
         return newTechStackList;
       }
 
       const newTechStackList = [...techStackList];
       if (techStackList.indexOf(techStack) < 0) {
-        techRef.current.push(techStack);
+        techValueRef.current.push(techStack);
         newTechStackList.push(techStack);
       }
 

--- a/frontend/src/hooks/common/dropdown/useDropdown.tsx
+++ b/frontend/src/hooks/common/dropdown/useDropdown.tsx
@@ -62,6 +62,7 @@ const useDropdown = ({
     return (
       <div className="relative">
         <button
+          type="button"
           ref={dropdownRef}
           onClick={handleButtonClick}
           className={`${buttonClassName} ${open && "shadow-none"}`}

--- a/frontend/src/hooks/pages/account/useWheelDown.ts
+++ b/frontend/src/hooks/pages/account/useWheelDown.ts
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import useDebounce from "../../common/useDebounce";
+
+interface Params {
+  currentStepNumber: number;
+  targetStepNumber: number;
+  dependency?: unknown;
+  goToNextStep: () => void;
+}
+
+const useWheelDown = ({
+  currentStepNumber,
+  targetStepNumber,
+  dependency,
+  goToNextStep,
+}: Params) => {
+  const debounce = useDebounce();
+  useEffect(() => {
+    const handleWheelEvent = (event: WheelEvent) => {
+      if (currentStepNumber !== targetStepNumber) {
+        return;
+      }
+
+      debounce(100, () => {
+        const downScrolled = event.deltaY > 0;
+
+        if (downScrolled && dependency) {
+          goToNextStep();
+        }
+      });
+    };
+
+    window.addEventListener("wheel", handleWheelEvent);
+
+    return () => {
+      window.removeEventListener("wheel", handleWheelEvent);
+    };
+  }, [dependency, currentStepNumber]);
+};
+
+export default useWheelDown;

--- a/frontend/src/hooks/pages/account/useWheelUp.ts
+++ b/frontend/src/hooks/pages/account/useWheelUp.ts
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import useDebounce from "../../common/useDebounce";
+
+interface Params {
+  currentStepNumber: number;
+  targetStepNumber: number;
+  dependency?: unknown;
+  goToPrevStep: () => void;
+}
+
+const useWheelUp = ({
+  currentStepNumber,
+  targetStepNumber,
+  dependency,
+  goToPrevStep,
+}: Params) => {
+  const debounce = useDebounce();
+  useEffect(() => {
+    const handleWheelEvent = (event: WheelEvent) => {
+      if (currentStepNumber !== targetStepNumber) {
+        return;
+      }
+
+      debounce(100, () => {
+        const upScrolled = event.deltaY > 0;
+
+        if (upScrolled && dependency) {
+          goToPrevStep();
+        }
+      });
+    };
+
+    window.addEventListener("wheel", handleWheelEvent);
+
+    return () => {
+      window.removeEventListener("wheel", handleWheelEvent);
+    };
+  }, [dependency, currentStepNumber]);
+};
+
+export default useWheelUp;

--- a/frontend/src/hooks/pages/account/useWheelUp.ts
+++ b/frontend/src/hooks/pages/account/useWheelUp.ts
@@ -4,14 +4,12 @@ import useDebounce from "../../common/useDebounce";
 interface Params {
   currentStepNumber: number;
   targetStepNumber: number;
-  dependency?: unknown;
   goToPrevStep: () => void;
 }
 
 const useWheelUp = ({
   currentStepNumber,
   targetStepNumber,
-  dependency,
   goToPrevStep,
 }: Params) => {
   const debounce = useDebounce();
@@ -22,9 +20,9 @@ const useWheelUp = ({
       }
 
       debounce(100, () => {
-        const upScrolled = event.deltaY > 0;
+        const upScrolled = event.deltaY < 0;
 
-        if (upScrolled && dependency) {
+        if (upScrolled) {
           goToPrevStep();
         }
       });
@@ -35,7 +33,7 @@ const useWheelUp = ({
     return () => {
       window.removeEventListener("wheel", handleWheelEvent);
     };
-  }, [dependency, currentStepNumber]);
+  }, [currentStepNumber]);
 };
 
 export default useWheelUp;


### PR DESCRIPTION
## 🎟️ 태스크

[회원가입 스크롤 단계 이동 동작 구현](https://www.notion.so/94101d27f4c14b5c946423a0734de330?pvs=21)

## ✅ 작업 내용

- 스크롤을 통한 단계 이동 기능 구현
- SignupPage 리팩토링

## 🖊️ 구체적인 작업

### 스크롤을 통한 단계 이동 기능 구현

- 스크롤을 이동하면 다음 단계로 이동하는 것이기에 처음에는 스크롤 이벤트를 통해 구현하려고 했습니다. 그런데 overflow-hidden이 된 상태에서는 스크롤 이벤트를 감지할 수 없어서 다른 방법을 찾아야 했습니다. 그래서 알게 된 것이 wheel 이벤트였습니다. wheel 이벤트는 마우스 휠과 관련된 이벤트이며, 휠을 아래로 움직이면 deltaY의 값이 양수로, 위로 움직이면 양수로 나타납니다. 따라서 이를 이용해 기능을 구현했습니다.

### SignupPage 리팩토링

- 기존에 document.getElementById를 통해 엘리먼트를 특정하고 scroll 이벤트를 발생시키던 것을 Ref를 요소에 연결하고 이를 이용하는 것으로 변경했습니다. 리액트 공식문서에서 ref를 이러한 용도로 사용하는 것이 예시로 나와 있으며, 해당 기능 구현에 순수 자바스크립트를 이용할 필요가 없다고 판단했기 때문에 수정했습니다.

## 🤔 고민 및 의논할 거리

- 브라우저 창이 줄어들면 가로 및 세로 스크롤바가 나타나는데, 이로 인해 wheel 이벤트 관련 로직이 제대로 동작하지 않는 경우가 있었습니다. 스크롤바를 없애지 않는 선에서 여러 방식으로 이를 해결하려 시도해봤지만 완벽한 방법은 없었습니다. 그래서 우선 회원가입 페이지에서 세로 스크롤바가 생기지 않도록 hidden 설정을 주었는데(저희 서비스는 모바일은 고려하지 않고 있고, 대부분의 경우 세로 스크롤바가 없어도 회원가입에 문제가 없을 것이라 판단했습니다.) 다른 방법이 없을지 생각 중에 있습니다.

## 📸 결과 화면(선택)

- Next 버튼을 클릭하지 않고 다음 단계로 이동하는 모습
![녹화_2024_05_12_20_49_25_263](https://github.com/boostcampwm2023/web10-Lesser/assets/97649327/539c84e6-acd1-4b03-87d5-935b2f866422)
