### PR TITLE
feat: 회원의 상태 변경 API 구현

### DIFF
--- a/backend/src/project/dto/InitLandingResponse.dto.ts
+++ b/backend/src/project/dto/InitLandingResponse.dto.ts
@@ -1,3 +1,4 @@
+import { Member } from 'src/member/entity/member.entity';
 import { Memo, memoColor } from '../entity/memo.entity';
 import { Project } from '../entity/project.entity';
 
@@ -34,19 +35,41 @@ class ProjectDto {
   }
 }
 
+class MemberInfo {
+  id: number;
+  username: string;
+  imageUrl: string;
+  status: string;
+  static of(member: Member, status: string) {
+    const newMemberInfo = new MemberInfo();
+    newMemberInfo.id = member.id;
+    newMemberInfo.username = member.username;
+    newMemberInfo.imageUrl = member.github_image_url;
+    newMemberInfo.status = status;
+    return newMemberInfo;
+  }
+}
+
 class ProjectLandingPageContentDto {
   project: ProjectDto;
-  myInfo: {};
-  member: [];
+  myInfo: MemberInfo;
+  member: MemberInfo[];
   sprint: null;
   memoList: MemoDto[];
   link: [];
   inviteLinkId: string;
-  static of(project: Project, memoListWithMember: Memo[]) {
+  static of(
+    project: Project,
+    myInfo: Member,
+    projectMemberList: Member[],
+    memoListWithMember: Memo[],
+  ) {
     const dto = new ProjectLandingPageContentDto();
     dto.project = ProjectDto.of(project);
-    dto.myInfo = {};
-    dto.member = [];
+    dto.myInfo = MemberInfo.of(myInfo, 'off');
+    dto.member = projectMemberList
+      .filter((member) => member.id !== myInfo.id)
+      .map((member) => MemberInfo.of(member, 'off'));
     dto.sprint = null;
     const memoList = memoListWithMember.map((memo) => MemoDto.of(memo));
     dto.memoList = memoList;
@@ -61,11 +84,21 @@ export class InitLandingResponseDto {
   action: string;
   content: ProjectLandingPageContentDto;
 
-  static of(project: Project, memoListWithMember: Memo[]) {
+  static of(
+    project: Project,
+    myInfo: Member,
+    projectMemberList: Member[],
+    memoListWithMember: Memo[],
+  ) {
     const dto = new InitLandingResponseDto();
     dto.domain = 'landing';
     dto.action = 'init';
-    dto.content = ProjectLandingPageContentDto.of(project, memoListWithMember);
+    dto.content = ProjectLandingPageContentDto.of(
+      project,
+      myInfo,
+      projectMemberList,
+      memoListWithMember,
+    );
     return dto;
   }
 }

--- a/backend/src/project/dto/MemberUpdateRequest.dto.ts
+++ b/backend/src/project/dto/MemberUpdateRequest.dto.ts
@@ -1,0 +1,38 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { MemberStatus } from '../enum/MemberStatus.enum';
+
+class Content {
+  @IsNumber()
+  id: number;
+
+  @IsString()
+  @IsOptional()
+  username: string;
+
+  @IsString()
+  @IsOptional()
+  imageUrl: string;
+
+  @IsEnum(MemberStatus)
+  @IsOptional()
+  status: MemberStatus;
+}
+
+export class MemberUpdateRequestDto {
+  @Matches(/^update$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Content)
+  content: Content;
+}

--- a/backend/src/project/enum/MemberStatus.enum.ts
+++ b/backend/src/project/enum/MemberStatus.enum.ts
@@ -1,0 +1,5 @@
+export enum MemberStatus {
+	ON = 'on',
+	OFF = 'off',
+	AWAY = 'away',
+  }

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -5,6 +5,7 @@ import { Project } from './entity/project.entity';
 import { ProjectToMember } from './entity/project-member.entity';
 import { Member } from 'src/member/entity/member.entity';
 import { Memo, memoColor } from './entity/memo.entity';
+import { MemberRepository } from 'src/member/repository/member.repository';
 
 @Injectable()
 export class ProjectRepository {
@@ -13,6 +14,8 @@ export class ProjectRepository {
     private readonly projectRepository: Repository<Project>,
     @InjectRepository(ProjectToMember)
     private readonly projectToMemberRepository: Repository<ProjectToMember>,
+    @InjectRepository(Member)
+    private readonly memberRepository: Repository<Member>,
     @InjectRepository(Memo)
     private readonly memoRepository: Repository<Memo>,
   ) {}
@@ -44,6 +47,13 @@ export class ProjectRepository {
     });
   }
 
+  getProjectMemberList(project: Project) {
+    return this.memberRepository.find({
+      where: { projectToMember: { project: { id: project.id } } },
+      relations: { projectToMember: true },
+    });
+  }
+
   getProjectToMember(
     project: Project,
     member: Member,
@@ -54,7 +64,10 @@ export class ProjectRepository {
   }
 
   getProjectMemoListWithMember(projectId: number): Promise<Memo[]> {
-    return this.memoRepository.find({ where: { projectId }, relations: ["member"] });
+    return this.memoRepository.find({
+      where: { projectId },
+      relations: ['member'],
+    });
   }
 
   createMemo(memo: Memo): Promise<Memo> {

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -27,6 +27,7 @@ describe('ProjectService', () => {
             getProjectMemoListWithMember: jest.fn(),
             updateMemoColor: jest.fn(),
             findMemoById: jest.fn(),
+            getProjectMemberList: jest.fn(),
           },
         },
       ],
@@ -115,6 +116,18 @@ describe('ProjectService', () => {
       await expect(
         async () => await projectService.addMember(project, member),
       ).rejects.toThrow('already joined member');
+    });
+  });
+
+  describe('Get project member list', () => {
+    it('should return project member', async () => {
+      jest
+        .spyOn(projectRepository, 'getProjectMemberList')
+        .mockResolvedValue([member]);
+      const [title, subject] = ['title', 'subject'];
+      const project = Project.of(title, subject);
+      const memberList = await projectService.getProjectMemberList(project);
+      expect(memberList[0]).toEqual(member);
     });
   });
 

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -31,6 +31,10 @@ export class ProjectService {
     await this.projectRepository.addProjectMember(project, member);
   }
 
+  async getProjectMemberList(project: Project) {
+    return this.projectRepository.getProjectMemberList(project);
+  }
+
   async isProjectMember(project: Project, member: Member): Promise<boolean> {
     const projectToMember: ProjectToMember | null =
       await this.projectRepository.getProjectToMember(project, member);

--- a/backend/test/project/ws-common.ts
+++ b/backend/test/project/ws-common.ts
@@ -1,0 +1,95 @@
+export const emitJoinLanding = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('connect', () => {
+      socket.emit('joinLanding');
+      socket.off('connect');
+      res();
+    });
+  });
+};
+
+export const initLanding = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('landing', async (data) => {
+      const { action, content, domain } = data;
+      if (action !== 'init' || domain !== 'landing') {
+        res(await initLanding(socket));
+        return;
+      }
+      socket.off('landing');
+      res();
+    });
+  });
+};
+
+export const waitStatusMsg = (socket, memberId) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('landing', async (data) => {
+      const { action, content, domain } = data;
+      if (
+        action === 'update' &&
+        domain === 'member' &&
+        content.status === 'on' &&
+        content.id === memberId
+      ) {
+        socket.off('landing');
+        res();
+        return;
+      } else {
+        rej();
+      }
+    });
+  });
+};
+
+export const waitLandingAndStatusMsgAndReturnId = (
+  socket,
+  isInitLandingMsg: boolean,
+  isUpdateStatusMsg: boolean,
+) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('landing', async (data) => {
+      socket.off('landing');
+      const { action, content, domain } = data;
+      if (action === 'init' && domain === 'landing') {
+        if (!isUpdateStatusMsg) {
+          await waitLandingAndStatusMsgAndReturnId(socket, true, false);
+        }
+        res(content.myInfo.id);
+		return;
+      } else if (
+        action === 'update' &&
+        domain === 'member' &&
+        content.status === 'on'
+      ) {
+        if (!isInitLandingMsg) {
+          const memberId = await waitLandingAndStatusMsgAndReturnId(
+            socket,
+            false,
+            true,
+          );
+          res(memberId);
+          return;
+        }
+        res();
+      } else {
+        rej();
+      }
+    });
+  });
+};
+
+export const initLandingAndReturnId = (socket) => {
+  return new Promise<void>((res, rej) => {
+    socket.on('landing', async (data) => {
+      const { action, content, domain } = data;
+      if (action !== 'init' || domain !== 'landing') {
+        res(await initLanding(socket));
+        return;
+      }
+      socket.off('landing');
+      const id = content.myInfo.id;
+      res(id);
+    });
+  });
+};

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -40,6 +40,10 @@ describe('WS landing', () => {
         expect(content.project.subject).toBe(projectPayload.subject);
         expect(content.project.createdAt).toBeDefined();
         expect(content.myInfo).toBeDefined();
+		expect(content.myInfo.id).toBeDefined();
+		expect(content.myInfo.username).toBe(memberFixture.username);
+		expect(content.myInfo.imageUrl).toBe(memberFixture.github_image_url);
+		expect(content.myInfo.status).toBe('off');
         expect(content.member).toBeDefined();
         expect(content.sprint).toBeDefined();
         expect(content.memoList).toBeDefined();

--- a/backend/test/project/ws-update-member-status.e2e-spec.ts
+++ b/backend/test/project/ws-update-member-status.e2e-spec.ts
@@ -1,0 +1,103 @@
+import { Socket } from 'socket.io-client';
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  memberFixture,
+  projectPayload,
+  getProjectLinkId,
+  memberFixture2,
+  joinProject,
+} from 'test/setup';
+import {
+  emitJoinLanding,
+  waitLandingAndStatusMsgAndReturnId,
+  waitStatusMsg,
+} from './ws-common';
+
+describe('WS update member status', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  it('should return updated member status', async () => {
+    let socket1;
+    let socket2;
+    return new Promise<void>(async (resolve, reject) => {
+      // 회원1 회원가입 + 프로젝트 생성
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+      // 회원2 회원가입 + 프로젝트 참여
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      await joinProject(accessToken2, projectLinkId);
+
+      socket1 = connectServer(project.id, accessToken);
+      await emitJoinLanding(socket1);
+      const memberId = await waitLandingAndStatusMsgAndReturnId(
+        socket1,
+        false,
+        false,
+      );
+
+      socket2 = connectServer(project.id, accessToken2);
+
+      await emitJoinLanding(socket2);
+      const memberId2 = await waitLandingAndStatusMsgAndReturnId(
+        socket2,
+        false,
+        false,
+      );
+      await waitStatusMsg(socket1, memberId2);
+
+      const status = 'away';
+      const requestData = {
+        action: 'update',
+        content: {
+          id: memberId,
+          status,
+        },
+      };
+
+      socket1.emit('member', requestData);
+      socket1.on('error', (e) => {
+        reject(e);
+      });
+
+      await Promise.all([
+        expectUpdatedMemberStatus(socket1, status, memberId),
+        expectUpdatedMemberStatus(socket2, status, memberId),
+      ]);
+      resolve();
+    }).finally(() => {
+      socket1.close();
+      socket2.close();
+    });
+  });
+
+  const expectUpdatedMemberStatus = (socket, status, memberId) => {
+    return new Promise<void>((resolve) => {
+      socket.on('landing', async (data) => {
+        const { content, action, domain } = data;
+        if (domain === 'member' && action === 'update') {
+          expect(domain).toBe('member');
+          expect(action).toBe('update');
+          expect(content).toBeDefined();
+          expect(content.id).toBe(memberId);
+          expect(content.status).toBe(status);
+          socket.off('landing');
+          resolve();
+        }
+      });
+    });
+  };
+
+  //이미 접속중인 경우 update를 하지 않고 무시함
+  //데이터의 형식이 잘못됨
+});


### PR DESCRIPTION
## 🎟️ 태스크

[서버에서 프로젝트 구성원 상태 변경을 웹소켓으로 받고 전체 구성원에게 브로드캐스팅하는 API 구현 (백엔드)](https://plastic-toad-cb0.notion.site/API-647eaafb68d043f4b6a0dc92e5029e83?pvs=74)

## ✅ 작업 내용

- 프로젝트의 회원목록을 조회하는 레포지토리 메서드 구현
- 프로젝트의 회원목록을 조회하는 서비스 메서드 구현
- 회원상태 업데이트 API 구현
- 웹소켓 테스트에서 공통적으로 사용하는 메서드 분리
- 랜딩페이지 접속시 자신의 정보를 조회하는 테스트 추가
- 웹소켓 메모 테스트 수정
- 회원의 상태 변경 테스트 추가

## 🖊️ 구체적인 작업

### 프로젝트의 회원목록을 조회하는 레포지토리 메서드 구현
### 프로젝트의 회원목록을 조회하는 서비스 메서드 구현
- 프로젝트의 목록 조회 서비스 메서드에 대한 테스트 구현
- 프로젝트의 목록 조회 서비스 메서드 구현
### 회원상태 업데이트 API 구현
- 회원의 status를 Enum파일로 분리
- 랜딩페이지 접속시 회원관련 정보를 조회할 수 있게 구현
- 회원의 상태 업데이트에 대해 RequestDto 추가
- 회원상태 업데이트 API 컨트롤러 구현
  - 회원 접속시 자동으로 회원의 상태를 on으로 변경
  - 회원이 업데이트 메시지를 보내면, 회원의 상태를 변경함
### 웹소켓 테스트에서 공통적으로 사용하는 메서드 분리
- waitStatusMsg는 다른 회원 접속시 상태 변경 메시지를 기다리는 메서드임
- waitLandingAndStatusMsgAndReturnId는 최초 접속시 랜딩페이지 정보와 자신의 상태 변경 메시지를 기다리는 메서드임
- initLanding은 랜딩페이지 조회메시지를 제외하고는 무시하는 메서드임
### 랜딩페이지 접속시 자신의 정보를 조회하는 테스트 추가
### 웹소켓 메모 테스트 수정
- 접속시 회원 정보 업데이트를 자동으로 보내는 로직으로 수정되었기 때문에, 기존의 테스트가 실패함.
- 다시 테스트를 성공시키기 위해 기다리는 메시지 이외에는 무시하도록 수정
### 회원의 상태 변경 테스트 추가

## 🤔 고민 및 의논할 거리
    
- 랜딩페이지 접속의 응답으로 접속한 회원의 상태를 반영해서 응답을 생성해야 하는데, 작업의 크기도 커 보이고 테스트도 작성해야하기 때문에 이번 작업에 추가하면 크기가 크다고 생각했습니다. 따라서 이 부분의 태스크를 생성해놓았습니당
- 내일 웹소켓 테스트 관련 리팩토링을 진행할 예정입니다. 현재 테스트가 성공하기는 하지만 웹소켓의 메시지를 무시하는 부분, 웹소켓의 순서를 완전히 보장하는 부분이 섞여있어 코드의 일관성이 떨어지는 상태입니다. 따라서 이 부분을 앞으로 쉽게 사용할 수 있도록 리팩토링할 생각입니다.