### PR TITLE
chore: 웹소켓 테스트에서 공통으로 사용하는 함수 분리

### DIFF
--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -60,7 +60,6 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
   @SubscribeMessage('joinLanding')
   async handleJoinLandingEvent(@ConnectedSocket() client: ClientSocket) {
     client.status = MemberStatus.ON;
-    client.join('landing');
     const [project, projectMemberList, memoListWithMember] = await Promise.all([
       this.projectService.getProject(client.projectId),
       this.projectService.getProjectMemberList(client.project),
@@ -73,7 +72,8 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
       memoListWithMember,
     );
     client.emit('landing', response);
-	this.sendMemberStatusUpdate(client);
+    this.sendMemberStatusUpdate(client);
+    client.join('landing');
   }
 
   @SubscribeMessage('memo')

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -72,8 +72,18 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
       memoListWithMember,
     );
     client.emit('landing', response);
-    this.sendMemberStatusUpdate(client);
     client.join('landing');
+    client.nsp
+      .to('landing')
+      .except(client.id)
+      .emit('landing', {
+        domain: 'member',
+        action: 'update',
+        content: {
+          id: client.member.id,
+          status: client.status,
+        },
+      });
   }
 
   @SubscribeMessage('memo')

--- a/backend/test/project/ws-update-member-status.e2e-spec.ts
+++ b/backend/test/project/ws-update-member-status.e2e-spec.ts
@@ -13,8 +13,9 @@ import {
 } from 'test/setup';
 import {
   emitJoinLanding,
-  waitLandingAndStatusMsgAndReturnId,
-  waitStatusMsg,
+  initLandingAndReturnId,
+  expectUpdatedMemberStatus,
+  handleConnectErrorWithReject,
 } from './ws-common';
 
 describe('WS update member status', () => {
@@ -39,22 +40,15 @@ describe('WS update member status', () => {
       await joinProject(accessToken2, projectLinkId);
 
       socket1 = connectServer(project.id, accessToken);
+	  handleConnectErrorWithReject(socket1, reject);
       await emitJoinLanding(socket1);
-      const memberId = await waitLandingAndStatusMsgAndReturnId(
-        socket1,
-        false,
-        false,
-      );
+      const memberId = await initLandingAndReturnId(socket1);
 
       socket2 = connectServer(project.id, accessToken2);
-
+	  handleConnectErrorWithReject(socket2, reject);
       await emitJoinLanding(socket2);
-      const memberId2 = await waitLandingAndStatusMsgAndReturnId(
-        socket2,
-        false,
-        false,
-      );
-      await waitStatusMsg(socket1, memberId2);
+      const memberId2 = await initLandingAndReturnId(socket2);
+      await expectUpdatedMemberStatus(socket1, 'on', memberId2);
 
       const status = 'away';
       const requestData = {
@@ -80,23 +74,6 @@ describe('WS update member status', () => {
       socket2.close();
     });
   });
-
-  const expectUpdatedMemberStatus = (socket, status, memberId) => {
-    return new Promise<void>((resolve) => {
-      socket.on('landing', async (data) => {
-        const { content, action, domain } = data;
-        if (domain === 'member' && action === 'update') {
-          expect(domain).toBe('member');
-          expect(action).toBe('update');
-          expect(content).toBeDefined();
-          expect(content.id).toBe(memberId);
-          expect(content.status).toBe(status);
-          socket.off('landing');
-          resolve();
-        }
-      });
-    });
-  };
 
   //이미 접속중인 경우 update를 하지 않고 무시함
   //데이터의 형식이 잘못됨

--- a/backend/test/project/ws-update-member-status.e2e-spec.ts
+++ b/backend/test/project/ws-update-member-status.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { Socket } from 'socket.io-client';
 import {
   app,
   appInit,
@@ -40,12 +39,12 @@ describe('WS update member status', () => {
       await joinProject(accessToken2, projectLinkId);
 
       socket1 = connectServer(project.id, accessToken);
-	  handleConnectErrorWithReject(socket1, reject);
+      handleConnectErrorWithReject(socket1, reject);
       await emitJoinLanding(socket1);
       const memberId = await initLandingAndReturnId(socket1);
 
       socket2 = connectServer(project.id, accessToken2);
-	  handleConnectErrorWithReject(socket2, reject);
+      handleConnectErrorWithReject(socket2, reject);
       await emitJoinLanding(socket2);
       const memberId2 = await initLandingAndReturnId(socket2);
       await expectUpdatedMemberStatus(socket1, 'on', memberId2);

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -96,7 +96,7 @@ export const getProjectLinkId = async (
     });
     socket.on('landing', (data) => {
       const { content } = data;
-      projectLinkId = projectLinkId = content.inviteLinkId;
+      projectLinkId = content.inviteLinkId;
       resolve();
     });
   });


### PR DESCRIPTION
## ✅ 작업 내용

- fix: 랜딩페이지 접속시 자기자신에게는 회원상태정보를 보내지 않도록 수정
- chore: 테스트에서 공통으로 사용하는 함수를 분리

## 🖊️ 구체적인 작업

### fix: 랜딩페이지 접속시 자기자신에게는 회원상태정보를 보내지 않도록 수정

### chore: 테스트에서 공통으로 사용하는 함수를 분리
- 공통으로 사용하는 함수를 분리
- 관심이 없는 메시지를 무시하는 테스트 함수 삭제

## 🤔 고민 및 의논할 거리
- 랜딩페이지 접속시 접속하는 유저가 자신의 상태변경 메시지를 받지 않도록 변경되면서, 복잡하게 순서가 보장되지 않는 메시지를 검증할 필요가 없어, 이 부분을 수정하고 테스트에 반영했습니다.
- 추후 순서가 보장되지 않는 여러개의 메시지를 검증할 필요가 있을때, 이전에 작성해 놓았던 테스트 로직을 활용하면 좋을 것 같습니다.
  - 아래와 같이 재귀적으로 확인합니다.

  ```typescript
  export const waitLandingAndStatusMsgAndReturnId = (
    socket: Socket,
    isInitLandingMsg: boolean,
    isUpdateStatusMsg: boolean,
  ) => {
    return new Promise<void>((resolve, reject) => {
      socket.on('landing', async (data) => {
        socket.off('landing');
        const { action, content, domain } = data;
        if (action === 'init' && domain === 'landing') {
          if (!isUpdateStatusMsg) {
            await waitLandingAndStatusMsgAndReturnId(socket, true, false);
          }
          resolve(content.myInfo.id);
          return;
        } else if (
          action === 'update' &&
          domain === 'member' &&
          content.status === 'on'
        ) {
          if (!isInitLandingMsg) {
            const memberId = await waitLandingAndStatusMsgAndReturnId(
              socket,
              false,
              true,
            );
            resolve(memberId);
            return;
          }
          resolve();
        } else {
          reject();
        }
      });
    });
  };
  ```