### PR TITLE
feat: 프로젝트 참여시 랜딩페이지에 접속한 회원에게 새로운 회원의 정보를 알리는 API 구현

### DIFF
--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -12,10 +12,14 @@ import { CreateProjectRequestDto } from './dto/CreateProjectRequest.dto';
 import { MemberRequest } from 'src/common/guard/authentication.guard';
 import { JoinProjectRequestDto } from './dto/JoinProjectRequest.dto';
 import { Response } from 'express';
+import { ProjectWebsocketGateway } from './websocket.gateway';
 
 @Controller('project')
 export class ProjectController {
-  constructor(private readonly projectService: ProjectService) {}
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly projectWebsocketGateway: ProjectWebsocketGateway,
+  ) {}
   @Get('/')
   async getProjectList(@Req() request: MemberRequest) {
     const projectList = await this.projectService.getProjectList(
@@ -63,6 +67,10 @@ export class ProjectController {
       return response.status(200).send({ projectId: project.id });
 
     await this.projectService.addMember(project, request.member);
+    this.projectWebsocketGateway.notifyJoinToConnectedMembers(
+      project.id,
+      request.member,
+    );
     return response.status(201).send();
   }
 }

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -204,7 +204,6 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
   }
 
   notifyJoinToConnectedMembers(projectId: number, member: Member) {
-    if (!this.namespaceMap.has(projectId)) return;
     const projectNamespace = this.namespaceMap.get(projectId);
     if (!projectNamespace) return;
     const requestMsg = {

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -8,7 +8,8 @@ import {
 } from '@nestjs/websockets';
 import { plainToClass } from 'class-transformer';
 import { validate } from 'class-validator';
-import { Server, Socket } from 'socket.io';
+import { Namespace, Socket } from 'socket.io';
+
 import { LesserJwtService } from 'src/lesser-jwt/lesser-jwt.service';
 import { Member } from 'src/member/entity/member.entity';
 import { Project } from './entity/project.entity';
@@ -39,13 +40,20 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
     private readonly lesserJwtService: LesserJwtService,
     private readonly memberRepository: MemberRepository,
     private readonly memberService: MemberService,
-  ) {}
+  ) {
+    this.namespaceMap = new Map();
+  }
 
-  afterInit(server: Server) {
-    server.use(async (client: ClientSocket, next) => {
+  namespaceMap: Map<number, Namespace>;
+
+  afterInit(parentNamespace: any) {
+    parentNamespace.use(async (client: ClientSocket, next) => {
       try {
         await this.authentication(client);
         await this.projectAuthorization(client);
+
+        if (!this.namespaceMap.has(client.projectId))
+          this.namespaceMap.set(client.projectId, client.nsp);
       } catch (error) {
         if (error.message === 'Failed to verify token: access')
           error.message = 'Expired:accessToken';
@@ -73,6 +81,7 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
     );
     client.emit('landing', response);
     client.join('landing');
+
     client.nsp
       .to('landing')
       .except(client.id)
@@ -192,6 +201,23 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
     if (status === client.status) return;
     client.status = status;
     this.sendMemberStatusUpdate(client);
+  }
+
+  notifyJoinToConnectedMembers(projectId: number, member: Member) {
+    if (!this.namespaceMap.has(projectId)) return;
+    const projectNamespace = this.namespaceMap.get(projectId);
+    if (!projectNamespace) return;
+    const requestMsg = {
+      domain: 'member',
+      action: 'create',
+      content: {
+        id: member.id,
+        username: member.username,
+        imageUrl: member.github_image_url,
+        status: 'off',
+      },
+    };
+    projectNamespace.to('landing').emit('landing', requestMsg);
   }
 
   private sendMemberStatusUpdate(client: ClientSocket) {

--- a/backend/test/project/ws-join-project.e2e-spec.ts
+++ b/backend/test/project/ws-join-project.e2e-spec.ts
@@ -1,0 +1,70 @@
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  memberFixture,
+  projectPayload,
+  getProjectLinkId,
+  memberFixture2,
+  joinProject,
+} from 'test/setup';
+import {
+  emitJoinLanding,
+  initLandingAndReturnId,
+  expectUpdatedMemberStatus,
+  handleConnectErrorWithReject,
+  handleErrorWithReject,
+  expectProjectJoinMsgAndReturnJoinedId,
+} from './ws-common';
+
+describe('WS join project', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  it('should return joined member', async () => {
+    let socket1;
+    let socket2;
+    return new Promise<void>(async (resolve, reject) => {
+      // 회원1 회원가입 + 프로젝트 생성
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+      //회원 1 웹소켓 연결
+      socket1 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket1, reject);
+      handleErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+      await initLandingAndReturnId(socket1);
+
+      // 회원2 회원가입 + 프로젝트 참여
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+
+      joinProject(accessToken2, projectLinkId);
+      const joinedMemberId = await expectProjectJoinMsgAndReturnJoinedId(
+        socket1,
+        memberFixture2.username,
+        memberFixture2.github_image_url,
+      );
+
+      socket2 = connectServer(project.id, accessToken2);
+      handleConnectErrorWithReject(socket2, reject);
+      handleErrorWithReject(socket1, reject);
+
+      await emitJoinLanding(socket2);
+      const memberId2 = await initLandingAndReturnId(socket2);
+      expect(memberId2).toBe(joinedMemberId);
+      await expectUpdatedMemberStatus(socket1, 'on', joinedMemberId);
+      resolve();
+    }).finally(() => {
+      socket1.close();
+      socket2.close();
+    });
+  });
+});

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -91,10 +91,10 @@ export const getProjectLinkId = async (
   let projectLinkId;
   const socket = connectServer(projectId, accessToken);
   await new Promise<void>((resolve) => {
-    socket.on('connect', () => {
+    socket.once('connect', () => {
       socket.emit('joinLanding');
     });
-    socket.on('landing', (data) => {
+    socket.once('landing', (data) => {
       const { content } = data;
       projectLinkId = content.inviteLinkId;
       resolve();


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 가입 API에서 랜딩페이지에 접속해있는 회원에게 프로젝트에 새로 추가된 회원정보 전송](https://plastic-toad-cb0.notion.site/API-e2631eb68ee347f0823265adedd9e914?pvs=74)

## ✅ 작업 내용

- 새로운 회원이 프로젝트 참여시 프로젝트의 랜딩페이지에 접속해 있는 회원에게 회원정보 업데이트 구현
- 프로젝트 참여시 프로젝트에 접속해 있는 회원에게 알리는 테스트 추가

## 🖊️ 구체적인 작업

### 새로운 회원이 프로젝트 참여시 프로젝트의 랜딩페이지에 접속해 있는 회원에게 회원정보 업데이트 구현
- 웹소켓 게이트웨이에 연결되어 있는 회원에게 새로운 회원이 프로젝트에 참여했음을 알리는 메서드 구현
- 프로젝트 참여 컨트롤러에 웹소켓 게이트웨이 로직 추가
### 프로젝트 참여시 프로젝트에 접속해 있는 회원에게 알리는 테스트 추가
- 프로젝트 참여 웹소켓 테스트 추가
- 테스트에서 웹소켓의 이벤트가 한번만 사용되도록 once로 변경

## 🤔 고민 및 의논할 거리
    
- dynamic 네임스페이스를 사용하는 경우 `@WebSocketServer()`로 접근할 수 있는 변수는 ParentNamespace 객체입니다. 이는 Namespace가 동적이라 여러개 있기 때문에, 클래스 자체에서 접근하는 변수는 Namespace를 여러개 가지고 있는 ParentNamespace가 되기 때문입니다.
- 그러나 ParentNamespace 타입의 경우 socket.io 라이브러리에서 export하지 않습니다. 따라서 이를 직접 사용하는것은 라이브러리의 의도와는 벗어난다고 생각해 직접 네임스페이스 Map을 만들었고, <프로젝트 이름, 네임스페이스>형태로 네임스페이스에 직접 접근할 수 있게 했습니다.
  ```
  export class ProjectWebsocketGateway implements OnGatewayInit {
    constructor(
      private readonly projectService: ProjectService,
      private readonly lesserJwtService: LesserJwtService,
      private readonly memberRepository: MemberRepository,
      private readonly memberService: MemberService,
    ) {
      this.namespaceMap = new Map();
    }
  
    namespaceMap: Map<number, Namespace>;
  ```

- socket.io에서 메시지가 왔을때 해당 메시지를 처리할 이벤트가 없을경우 메시지가 어딘가 쌓였다가, 이벤트를 등록하면 등록하는 시점에 메시지를 처리할 수 있을거라고 기대했습니다. 하지만 실제로는 이벤트가 없으면 메시지가 사라지고 다시 메시지를 처리할 수 없었습니다. 
  - joinProject에 await를 했기 때문에 프로젝트의 참여 request에 대한 response를 기다립니다. 서버는 이를 처리하는 과정에서 새로운 회원이 참여했음을 랜딩페이지에 접속해있는 회원에게 웹소켓통신으로 알리게 되는데, 이 시점에 이벤트가 등록이 되어 있지 않기때문에 메시지를 받을 수 없는 문제가 있었습니다.
   ```
        await joinProject(accessToken2, projectLinkId);
        const joinedMemberId = await expectProjectJoinMsgAndReturnJoinedId(
          socket1,
          memberFixture2.username,
          memberFixture2.github_image_url,
        );
  ```

- 아래와 같이 joinProject의 await를 없애 request를 보낸 후, 이벤트를 등록한 후 await를 하는것으로 메시지를 처리하기 전 이벤트의 등록을 보장해 해결했습니다.
  ```
        joinProject(accessToken2, projectLinkId);
        const joinedMemberId = await expectProjectJoinMsgAndReturnJoinedId(
          socket1,
          memberFixture2.username,
          memberFixture2.github_image_url,
        );
  ```