### PR TITLE
feat: 최초 랜딩페이지 접속시 본인을 포함한 프로젝트 멤버들의 접속 상태 정보를 응답하도록 구현

### DIFF
--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -22,7 +22,7 @@ import { MemoColorUpdateRequestDto } from './dto/MemoColorUpdateRequest.dto';
 import { MemberUpdateRequestDto } from './dto/MemberUpdateRequest.dto';
 import { MemberStatus } from './enum/MemberStatus.enum';
 
-interface ClientSocket extends Socket {
+export interface ClientSocket extends Socket {
   projectId?: number;
   project: Project;
   member: Member;
@@ -65,9 +65,14 @@ export class ProjectWebsocketGateway implements OnGatewayInit {
       this.projectService.getProjectMemberList(client.project),
       this.projectService.getProjectMemoListWithMember(client.project.id),
     ]);
+    const projectSocketList: ClientSocket[] =
+      (await client.nsp.fetchSockets()) as unknown as ClientSocket[];
+
     const response = InitLandingResponseDto.of(
       project,
       client.member,
+      MemberStatus.ON,
+      projectSocketList,
       projectMemberList,
       memoListWithMember,
     );

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -5,7 +5,11 @@ import {
   connectServer,
   createMember,
   createProject,
+  getMemberByAccessToken,
+  getProjectLinkId,
+  joinProject,
   memberFixture,
+  memberFixture2,
   projectPayload,
 } from 'test/setup';
 import {
@@ -15,53 +19,118 @@ import {
 } from './ws-common';
 
 describe('WS landing', () => {
-  let socket: Socket;
-
   beforeEach(async () => {
     await app.close();
     await appInit();
     await app.listen(3000);
   });
 
-  afterEach(async () => {
-    socket.close();
-  });
+  it('should return project landing page data', async () => {
+    let socket1: Socket;
+    let socket2: Socket;
 
-  it('should return project data', async () => {
-    const accessToken = (await createMember(memberFixture, app)).accessToken;
-    const project = await createProject(accessToken, projectPayload, app);
-    socket = connectServer(project.id, accessToken);
+    return new Promise<void>(async (resolve, reject) => {
+      const accessToken1 = (await createMember(memberFixture, app)).accessToken;
+      const member1 = await getMemberByAccessToken(accessToken1);
+      const project = await createProject(accessToken1, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken1, project.id);
 
-    return new Promise<void>((resolve, reject) => {
-      socket.on('connect', () => {
-        socket.emit('joinLanding');
-      });
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      const member2 = await getMemberByAccessToken(accessToken2);
+      await joinProject(accessToken2, projectLinkId);
 
-      handleConnectErrorWithReject(socket, reject);
+      socket1 = connectServer(project.id, accessToken1);
+      handleConnectErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+      await initLanding(socket1);
 
-      socket.on('landing', (data) => {
+      socket2 = connectServer(project.id, accessToken2);
+      handleConnectErrorWithReject(socket2, reject);
+      socket2.emit('joinLanding');
+      socket2.on('error', (e) => reject(e));
+
+      socket2.on('landing', (data) => {
         const { action, domain, content } = data;
         expect(domain).toBe('landing');
         expect(action).toBe('init');
+
+        // project
         expect(content.project.title).toBe(projectPayload.title);
         expect(content.project.subject).toBe(projectPayload.subject);
         expect(content.project.createdAt).toBeDefined();
-        expect(content.myInfo).toBeDefined();
-        expect(content.myInfo.id).toBeDefined();
-        expect(content.myInfo.username).toBe(memberFixture.username);
-        expect(content.myInfo.imageUrl).toBe(memberFixture.github_image_url);
-        expect(content.myInfo.status).toBe('off');
-        expect(content.member).toBeDefined();
+
+        // myInfo
+        expect(content.myInfo.id).toBe(member2.id);
+        expect(content.myInfo.username).toBe(member2.username);
+        expect(content.myInfo.imageUrl).toBe(member2.github_image_url);
+        expect(content.myInfo.status).toBe('on');
+
+        // member
+        expect(content.member[0].id).toBe(member1.id);
+        expect(content.member[0].username).toBe(member1.username);
+        expect(content.member[0].imageUrl).toBe(member1.github_image_url);
+        expect(content.member[0].status).toBe('on');
+
+        // else
         expect(content.sprint).toBeDefined();
         expect(content.memoList).toBeDefined();
         expect(content.link).toBeDefined();
         expect(content.inviteLinkId).toBeDefined();
+
         resolve();
       });
+    }).finally(() => {
+      socket1.close();
+      socket2.close();
+    });
+  });
+
+  it('should return other member status as off when the other member socket is closed', async () => {
+    let socket1: Socket;
+    let socket2: Socket;
+
+    return new Promise<void>(async (resolve, reject) => {
+      const accessToken1 = (await createMember(memberFixture, app)).accessToken;
+      const member1 = await getMemberByAccessToken(accessToken1);
+      const project = await createProject(accessToken1, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken1, project.id);
+
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      const member2 = await getMemberByAccessToken(accessToken2);
+      await joinProject(accessToken2, projectLinkId);
+
+      socket1 = connectServer(project.id, accessToken1);
+      handleConnectErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+      await initLanding(socket1);
+
+      socket2 = connectServer(project.id, accessToken2);
+      handleConnectErrorWithReject(socket2, reject);
+      socket2.emit('joinLanding');
+      socket2.on('error', (e) => reject(e));
+
+      // socket1 접속 종료
+      socket1.close();
+
+      socket2.on('landing', (data) => {
+        const { content } = data;
+        expect(content.member[0].id).toBe(member1.id);
+        expect(content.member[0].username).toBe(member1.username);
+        expect(content.member[0].imageUrl).toBe(member1.github_image_url);
+        expect(content.member[0].status).toBe('off');
+
+        resolve();
+      });
+    }).finally(() => {
+      socket2.close();
     });
   });
 
   it('should return created memoList in landing page data when project member has already created memo', async () => {
+    let socket: Socket;
+
     return await new Promise<void>(async (resolve, reject) => {
       const accessToken = (await createMember(memberFixture, app)).accessToken;
       const project = await createProject(accessToken, projectPayload, app);
@@ -101,6 +170,8 @@ describe('WS landing', () => {
           resolve();
         }
       });
+    }).finally(() => {
+      socket.close();
     });
   });
 });

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -9,10 +9,12 @@ import { Project } from 'src/project/entity/project.entity';
 import { CreateProjectRequestDto } from 'src/project/dto/CreateProjectRequest.dto';
 import { io } from 'socket.io-client';
 import { Member } from 'src/member/entity/member.entity';
+import { MemberService } from 'src/member/service/member.service';
 
 export let app: INestApplication;
 export let githubApiService: GithubApiService;
 export let lesserJwtService: LesserJwtService;
+export let memberService: MemberService;
 export let dataSource: DataSource;
 export const jwtTokenPattern =
   /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/;
@@ -66,6 +68,15 @@ export const createMember = async (
   const [, refreshToken] =
     signupResponse.header['set-cookie'][0].match(/refreshToken=([^;]+)/);
   return { accessToken: signupResponse.body.accessToken, refreshToken };
+};
+
+export const getMemberByAccessToken = async (
+  accessToken: string,
+): Promise<Member> => {
+  const {
+    sub: { id },
+  } = await lesserJwtService.getPayload(accessToken, 'access');
+  return await memberService.getMember(id);
 };
 
 export const createProject = async (
@@ -138,6 +149,7 @@ export const appInit = async () => {
     .compile();
   githubApiService = moduleFixture.get<GithubApiService>(GithubApiService);
   lesserJwtService = moduleFixture.get<LesserJwtService>(LesserJwtService);
+  memberService = moduleFixture.get<MemberService>(MemberService);
 
   app = moduleFixture.createNestApplication();
   app.setGlobalPrefix('api');


### PR DESCRIPTION
## 🎟️ 태스크

[최초 랜딩페이지 접속시 본인을 포함한 프로젝트 멤버들의 접속 상태 정보를 응답하도록 구현](https://plastic-toad-cb0.notion.site/5f639bb4c8aa4deb9bc34464e66f1e6f?pvs=74)

## ✅ 작업 내용


- [feat: E2E 테스트에서 access token으로 member 객체를 받아오는 메서드 추가](https://github.com/boostcampwm2023/web10-Lesser/commit/fa81b978e4bd6b5833836777bd69c779ff22759b)
- [feat: 최초 랜딩페이지 접속시 본인을 포함한 프로젝트 멤버들의 접속 상태 정보를 응답하도록 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/214b874e506c25ce592b65fa10c0365670b61a8c)
- [test: 랜딩페이지 데이터 중 멤버 접속 상태 정보 관련 E2E 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/f062bd0cdcc30f1b69528209545e8fdc4bfad680)

## 🖊️ 구체적인 작업

### E2E 테스트에서 access token으로 member 객체를 받아오는 메서드 추가
- E2E 테스트 중 데이터베이스에 저장된 회원의 정보를 용이하게 사용할 수 있도록 추가하였습니다.

### 최초 랜딩페이지 접속시 본인을 포함한 프로젝트 멤버들의 접속 상태 정보를 응답하도록 구현
- 접속한 본인의 접속 상태 정보(myInfo) 및 프로젝트 멤버들의 접속 상태 정보를 projectSocketList 각각의 소켓에 저장된 접속 상태 정보를 이용해 반환
  - fetchSockets() 메서드를 통해 프로젝트 네임스페이스에 연결된 소켓 정보(projectSocketList)를 획득
  - projectMemberList 각각에 대응되는 소켓을 projectSocketList에서 찾고 member id가 대응되는 소켓이 있으면 소켓에 저장된 status를 응답한다.
  - 대응되는 소켓이 없으면 status를 off로 응답한다.

###  랜딩페이지 데이터 중 멤버 접속 상태 정보 관련 E2E 테스트 작성
- member1이 소켓 접속한 상태에서 member2가 랜딩페이지 접속시 member2는 landing 이벤트에 대해 받은 메시지의 content에서 다음 속성들을 포함하도록 테스트한다.
  - myInfo 속성은 member2의 id, username, iamgeUrl, status를 포함한다.
  - member 속성은 member1의 id, username, iamgeUrl, status를 포함한다.
- member1 소켓 종료시 member2의 랜딩페이지에서 member1의 상태는 off로 나타난다.