### PR TITLE
feat: 프로젝트의 인원이 10명 이상일때, 새로운 인원이 참여하지 못하게하는 API 구현

### DIFF
--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -1,5 +1,6 @@
 import {
   Body,
+  ConflictException,
   Controller,
   Get,
   NotFoundException,
@@ -66,7 +67,13 @@ export class ProjectController {
     if (isProjectMember)
       return response.status(200).send({ projectId: project.id });
 
-    await this.projectService.addMember(project, request.member);
+    try {
+      await this.projectService.addMember(project, request.member);
+    } catch (err) {
+      if (err.message === 'Project is full')
+        throw new ConflictException('Project is full');
+      throw err;
+    }
     this.projectWebsocketGateway.notifyJoinToConnectedMembers(
       project.id,
       request.member,

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -70,8 +70,8 @@ export class ProjectController {
     try {
       await this.projectService.addMember(project, request.member);
     } catch (err) {
-      if (err.message === 'Project is full')
-        throw new ConflictException('Project is full');
+      if (err.message === 'Project reached its maximum member capacity')
+        throw new ConflictException('Project reached its maximum member capacity');
       throw err;
     }
     this.projectWebsocketGateway.notifyJoinToConnectedMembers(

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -100,6 +100,10 @@ describe('ProjectService', () => {
         .spyOn(projectRepository, 'getProjectToMember')
         .mockResolvedValue(null);
 
+      jest
+        .spyOn(projectRepository, 'getProjectMemberList')
+        .mockResolvedValue([]);
+
       await projectService.addMember(project, member);
 
       expect(projectRepository.addProjectMember).toHaveBeenCalledWith(
@@ -113,9 +117,23 @@ describe('ProjectService', () => {
         .spyOn(projectRepository, 'getProjectToMember')
         .mockResolvedValue(ProjectToMember.of(project, member));
 
+      jest
+        .spyOn(projectRepository, 'getProjectMemberList')
+        .mockResolvedValue([member]);
+
       await expect(
         async () => await projectService.addMember(project, member),
       ).rejects.toThrow('already joined member');
+    });
+
+    it('should throw when Project is full', async () => {
+      jest
+        .spyOn(projectRepository, 'getProjectMemberList')
+        .mockResolvedValue(new Array(10).fill(member));
+
+      await expect(
+        async () => await projectService.addMember(project, member),
+      ).rejects.toThrow('Project is full');
     });
   });
 

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -126,14 +126,14 @@ describe('ProjectService', () => {
       ).rejects.toThrow('already joined member');
     });
 
-    it('should throw when Project is full', async () => {
+    it('should throw when Project reached its maximum member capacity', async () => {
       jest
         .spyOn(projectRepository, 'getProjectMemberList')
         .mockResolvedValue(new Array(10).fill(member));
 
       await expect(
         async () => await projectService.addMember(project, member),
-      ).rejects.toThrow('Project is full');
+      ).rejects.toThrow('Project reached its maximum member capacity');
     });
   });
 

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -29,7 +29,7 @@ export class ProjectService {
     if (isProjectMember) throw new Error('already joined member');
 
     if ((await this.getProjectMemberList(project)).length >= 10)
-      throw new Error('Project is full');
+      throw new Error('Project reached its maximum member capacity');
 
     await this.projectRepository.addProjectMember(project, member);
   }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -28,6 +28,9 @@ export class ProjectService {
     const isProjectMember = await this.isProjectMember(project, member);
     if (isProjectMember) throw new Error('already joined member');
 
+    if ((await this.getProjectMemberList(project)).length >= 10)
+      throw new Error('Project is full');
+
     await this.projectRepository.addProjectMember(project, member);
   }
 

--- a/backend/test/project/join-project.e2e-spec.ts
+++ b/backend/test/project/join-project.e2e-spec.ts
@@ -126,11 +126,10 @@ describe('Join Project', () => {
     expect(response.status).toBe(404);
   });
 
-  it('should return 409 when project is full', async () => {
+  it('should return 409 when Project reached its maximum member capacity', async () => {
     const MAX_CAPACITY = 10;
     const memberList = [];
 
-    //Promise.all로 리팩토링
     for (let i = 0; i < MAX_CAPACITY; i++) {
       const member = {
         ...memberFixture,
@@ -173,6 +172,6 @@ describe('Join Project', () => {
       .send({ inviteLinkId: projectLinkId });
 
     expect(response.status).toBe(409);
-    expect(response.body.message).toBe('Project is full');
+    expect(response.body.message).toBe('Project reached its maximum member capacity');
   });
 });

--- a/backend/test/project/join-project.e2e-spec.ts
+++ b/backend/test/project/join-project.e2e-spec.ts
@@ -125,4 +125,54 @@ describe('Join Project', () => {
 
     expect(response.status).toBe(404);
   });
+
+  it('should return 409 when project is full', async () => {
+    const MAX_CAPACITY = 10;
+    const memberList = [];
+
+    //Promise.all로 리팩토링
+    for (let i = 0; i < MAX_CAPACITY; i++) {
+      const member = {
+        ...memberFixture,
+        github_id: i,
+        username: `username${i}`,
+      };
+      const { accessToken } = await createMember(member, app);
+      memberList.push({ member, accessToken });
+    }
+
+    const { id: projectId } = await createProject(
+      memberList[0].accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(
+      memberList[0].accessToken,
+      projectId,
+    );
+    for (let i = 1; i < MAX_CAPACITY; i++) {
+      await request(app.getHttpServer())
+        .post('/api/project/join')
+        .set('Authorization', `Bearer ${memberList[i].accessToken}`)
+        .send({ inviteLinkId: projectLinkId });
+    }
+
+    const exceedMemberFixture = {
+      ...memberFixture,
+      github_id: MAX_CAPACITY + 1,
+      username: `username${MAX_CAPACITY + 1}`,
+    };
+    const { accessToken: exceedMemberAccessToken } = await createMember(
+      exceedMemberFixture,
+      app,
+    );
+
+    const response = await request(app.getHttpServer())
+      .post('/api/project/join')
+      .set('Authorization', `Bearer ${exceedMemberAccessToken}`)
+      .send({ inviteLinkId: projectLinkId });
+
+    expect(response.status).toBe(409);
+    expect(response.body.message).toBe('Project is full');
+  });
 });


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트의 총 인원을 10명으로 제한하는 로직(백)](https://plastic-toad-cb0.notion.site/10-dd837dc887314cfc81fd90883bc1556f?pvs=74)

## ✅ 작업 내용

- 프로젝트의 인원이 10명 이상일때, 새로운 인원이 참여하지 못하게하는 서비스 로직 구현
  - 서비스 테스트 추가
- 서비스의 throw를 catch해 Conflict로 throw하는 컨트롤러 로직 구현
- 10명 이상 참여시 401반환을 테스트하는 E2E 테스트 추가