### PR TITLE
refactor : 서버에서 전달하는 데이터를 받아서 화면에 색상을 반영하는 코드 작성

### DIFF
--- a/frontend/src/components/landing/memo/MemoBlock.tsx
+++ b/frontend/src/components/landing/memo/MemoBlock.tsx
@@ -2,7 +2,6 @@ import MemoEditor from "./MemoEditor";
 import { LandingMemoDTO } from "../../../types/DTO/landingDTO";
 import { MemoColorStyle, MemoColorType } from "../../../types/common/landing";
 import useLandingMemo from "../../../hooks/common/landing/useLandingMemo";
-import { useEffect } from "react";
 
 interface MemoBlockProps extends LandingMemoDTO {
   emitMemoDeleteEvent: (id: number) => void;
@@ -30,10 +29,6 @@ const MemoBlock = ({
     handleTitleChange,
   } = useLandingMemo(title, content, color);
   const colorStyle = MemoColorStyle[memoColor];
-
-  useEffect(() => {
-    console.log(color);
-  }, [color]);
 
   return (
     <div

--- a/frontend/src/components/landing/memo/MemoBlock.tsx
+++ b/frontend/src/components/landing/memo/MemoBlock.tsx
@@ -2,6 +2,7 @@ import MemoEditor from "./MemoEditor";
 import { LandingMemoDTO } from "../../../types/DTO/landingDTO";
 import { MemoColorStyle, MemoColorType } from "../../../types/common/landing";
 import useLandingMemo from "../../../hooks/common/landing/useLandingMemo";
+import { useEffect } from "react";
 
 interface MemoBlockProps extends LandingMemoDTO {
   emitMemoDeleteEvent: (id: number) => void;
@@ -29,6 +30,10 @@ const MemoBlock = ({
     handleTitleChange,
   } = useLandingMemo(title, content, color);
   const colorStyle = MemoColorStyle[memoColor];
+
+  useEffect(() => {
+    console.log(color);
+  }, [color]);
 
   return (
     <div

--- a/frontend/src/hooks/common/landing/useLandingMemo.tsx
+++ b/frontend/src/hooks/common/landing/useLandingMemo.tsx
@@ -32,6 +32,10 @@ const useLandingMemo = (
   };
 
   useEffect(() => {
+    changeMemoColor(color);
+  }, [color]);
+
+  useEffect(() => {
     const handleClickOutside = ({ target }: MouseEvent) => {
       if (memoRef.current && !memoRef.current.contains(target as Node)) {
         closeEditor();

--- a/frontend/src/hooks/common/socket/useLandingSocket.ts
+++ b/frontend/src/hooks/common/socket/useLandingSocket.ts
@@ -59,8 +59,7 @@ const useLandingSocket = (socket: Socket) => {
         setMemoList((memoList: LandingMemoDTO[]) => {
           return memoList.map((memo: LandingMemoDTO) => {
             if (memo.id !== content.id) return memo;
-            memo.color = content.color;
-            return memo;
+            return { ...memo, color: content.color };
           });
         });
     }


### PR DESCRIPTION
## 🎟️ 태스크

[MemoList 색상변경 코드 리팩토링](https://www.notion.so/MemoList-df8a7eb15e184ff79b606d0b873ac739?pvs=4)

## ✅ 작업 내용

- 메모가 변경되면, 화면에 변경된 색상으로 반영되도록 수정
- 메모 전체 상태값에서 색상이 변경되게 되면, 해당 값을 메모 상태값에서 수정하는 코드 작성

## 🖊️ 구체적인 작업

### 메모가 변경되면, 화면에 변경된 색상으로 반영되도록 수정

- 기존 코드의 문제점 : 메모 전체 데이터에서 값을 받아 새롭게 메모의 색상 상태값을 만들어 관리
   - 따라서, 전체 메모가 변경되더라도 메모의 색상 상태값이 변경되지 않았기 때문에 색상이 변하지 않음
   - 메모의 색상 상태값을 별도로 관리해야 할 이유가 없음에도 해당 방식으로 설계한 실수로 인해 작동하지 않음
- 해당 방식을 개선하여, 현재는 메모의 색상이 모든 사용자에게 동시에 변경되도록 설계완료함 

### 드래그 앤 드롭

- 각 칸반보드 컴포넌트마다 wrapper를 적용해서 그룹화 했을 때 같은 그룹에 속한 태스크만 옮길 수 있도록 했습니다.
- 선택한 태스크의 배경 색을 변경해 선택되었음을 확실히 인지할 수 있도록 했습니다.
- 태스크 수정 api와 연결해 태스크를 드롭하면 실제 태스크의 상태가 변경될 수 있도록 했습니다.
- api 연결에는 `usePostTaskState`라는 커스텀 훅을 만들어 사용했습니다.

## 📸 결과 화면(선택)
![화면 기록 2024-06-04 오후 11 29 10](https://github.com/boostcampwm2023/web10-Lesser/assets/109324473/f84979ed-d412-486f-b33b-f92cba90e69f)
