### PR TITLE
feat: 접속 상태 변경과 관련한 로직 추가 구현

### DIFF
--- a/backend/test/project/ws-update-member-status.e2e-spec.ts
+++ b/backend/test/project/ws-update-member-status.e2e-spec.ts
@@ -15,7 +15,10 @@ import {
   initLandingAndReturnId,
   expectUpdatedMemberStatus,
   handleConnectErrorWithReject,
+  handleErrorWithReject,
+  initLanding,
 } from './ws-common';
+import { Socket } from 'socket.io-client';
 
 describe('WS update member status', () => {
   beforeEach(async () => {
@@ -76,4 +79,134 @@ describe('WS update member status', () => {
 
   //이미 접속중인 경우 update를 하지 않고 무시함
   //데이터의 형식이 잘못됨
+
+  it('should broadcast member status as off when socket is disconnected', () => {
+    let socket1;
+    let socket2;
+    return new Promise<void>(async (resolve, reject) => {
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      await joinProject(accessToken2, projectLinkId);
+
+      socket1 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket1, reject);
+      handleErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+
+      socket2 = connectServer(project.id, accessToken2);
+      handleConnectErrorWithReject(socket2, reject);
+      await emitJoinLanding(socket2);
+      const memberId2 = await initLandingAndReturnId(socket2);
+      await expectUpdatedMemberStatus(socket1, 'on', memberId2);
+
+      socket2.close();
+
+      await expectUpdatedMemberStatus(socket1, 'off', memberId2);
+      resolve();
+    }).finally(() => {
+      socket1.close();
+    });
+  });
+
+  it('should return updated member status when connected to another socket as same member', () => {
+    let socket1;
+    let socket2;
+    return new Promise<void>(async (resolve, reject) => {
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+
+      socket1 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket1, reject);
+      handleErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+      const memberId = await initLandingAndReturnId(socket1);
+
+      const status = 'away';
+      const requestData = {
+        action: 'update',
+        content: {
+          id: memberId,
+          status,
+        },
+      };
+
+      socket1.emit('member', requestData);
+      await expectUpdatedMemberStatus(socket1, status, memberId);
+
+      socket2 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket2, reject);
+      handleErrorWithReject(socket2, reject);
+      await emitJoinLanding(socket2);
+      await expectLandingMyStatus(socket2, status);
+
+      resolve();
+    }).finally(() => {
+      socket1.close();
+      socket2.close();
+    });
+  });
+
+  it('should reflect the status changed by the same member on a different socket to the current socket', () => {
+    let socket1;
+    let socket2;
+    let socket3;
+    return new Promise<void>(async (resolve, reject) => {
+      const accessToken = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken, projectPayload, app);
+
+      socket1 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket1, reject);
+      handleErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+      const memberId = await initLandingAndReturnId(socket1);
+
+      socket2 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket2, reject);
+      handleErrorWithReject(socket2, reject);
+      await emitJoinLanding(socket2);
+      await initLanding(socket2);
+
+      const status = 'away';
+      const requestData = {
+        action: 'update',
+        content: {
+          id: memberId,
+          status,
+        },
+      };
+
+      socket1.emit('member', requestData);
+      await expectUpdatedMemberStatus(socket1, status, memberId);
+      await expectUpdatedMemberStatus(socket2, status, memberId);
+
+      socket1.close();
+
+      socket3 = connectServer(project.id, accessToken);
+      handleConnectErrorWithReject(socket3, reject);
+      handleErrorWithReject(socket3, reject);
+      await emitJoinLanding(socket3);
+      await expectLandingMyStatus(socket3, status);
+
+      resolve();
+    }).finally(() => {
+      socket2.close();
+      socket3.close();
+    });
+  });
 });
+
+const expectLandingMyStatus = (socket: Socket, expectedStatus: string) => {
+  return new Promise<void>((resolve, reject) => {
+    socket.once('landing', async (data) => {
+      const { action, domain, content } = data;
+      if (action === 'init' && domain === 'landing') {
+        expect(content.myInfo.status).toBe(expectedStatus);
+        resolve();
+      } else reject();
+    });
+  });
+};


### PR DESCRIPTION
## 🎟️ 태스크

[접속 상태 변경 예시 구체화, E2E 테스트 작성](https://plastic-toad-cb0.notion.site/E2E-a5c34f0aba1144abb1617fa42047af8b?pvs=74)

## ✅ 작업 내용

- [접속 상태 변경과 관련한 로직 추가 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/b807fad6eabdc741b1e054bf61142e770281eef4)[접속 상태 변경과 관련한 로직 추가 구현](https://github.com/boostcampwm2023/web10-Lesser/commit/b807fad6eabdc741b1e054bf61142e770281eef4)
- [접속 상태 변경과 관련한 E2E 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/54f69486230f0ed52648da9f7deb345bee0c9ed6)[접속 상태 변경과 관련한 E2E 테스트 작성](https://github.com/boostcampwm2023/web10-Lesser/commit/54f69486230f0ed52648da9f7deb345bee0c9ed6)

## 🖊️ 구체적인 작업


### 접속 상태 변경과 관련한 로직 추가 구현
- 소켓 disconnect시 네임스페이스에 포함된 다른 소켓들에게 off 상태를 전달하는 로직 구현(handleDisconnect)
  - 다만, 같은 회원의 다른 소켓이 연결되어 있는 상태라면 off 상태를 전달하지 않는다.
- 프로젝트 랜딩페이지 조인시(joinLanding) 네임스페이스에 연결된 소켓 중 같은 회원의 소켓이 있는지 확인하고, 있다면 해당 소켓의 상태를 현재 소켓에 반영하는 로직 구현
- 회원 접속 상태 변경시 해당 소켓과 동일한 회원의 다른 소켓들에 저장된 status도 변경하는 로직 구현


### 접속 상태 변경과 관련한 E2E 테스트 작성

- 소켓이 연결 해제되면 멤버 상태를 off로 브로드캐스팅하는 테스트
- 같은 회원이 다른 소켓을 연결하면, 이전 소켓에서 변경한 접속 상태를 받아오는지 테스트
- 같은 회원의 다른 소켓이 변경한 상태가 현 소켓에 반영되는지 테스트