### PR TITLE
refactor: 프로젝트 생성 페이지 애니메이션 리팩토링

### DIFF
--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -9,7 +9,12 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
   const { title, currentSprint } = project;
   return (
     <div className="w-[21.25rem] p-9 bg-gradient-to-bl from-white-transparent to-95% bg-middle-green">
-      <p className="mb-[1.125rem] text-xl font-bold text-white">{title}</p>
+      <p
+        title={title}
+        className="overflow-hidden text-xl font-bold text-white text-ellipsis whitespace-nowrap"
+      >
+        {title}
+      </p>
       <div className="h-[3.9rem]">
         <p className="mb-2.5 text-xs font-bold text-white">
           {currentSprint && currentSprint.title}
@@ -27,16 +32,18 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
             <div className="flex flex-col items-center gap-3 font-bold text-middle-green">
               <p className="text-m">
                 <span className="text-[2.25rem]">
-                  {currentSprint.progressPercentage.toString().padStart(2, '0')}
-                </span>%
+                  {currentSprint.progressPercentage.toString().padStart(2, "0")}
+                </span>
+                %
               </p>
               <p>진행률</p>
             </div>
             <div className="flex flex-col items-center gap-3 font-bold text-middle-green">
               <p className="text-m">
                 <span className="text-[2.25rem]">
-                  {currentSprint.myTasksLeft.toString().padStart(2, '0')}
-                </span>건
+                  {currentSprint.myTasksLeft.toString().padStart(2, "0")}
+                </span>
+                건
               </p>
               <p>내 업무</p>
             </div>

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -73,9 +73,8 @@ const ProjectCreateInput = ({
       className={`w-[100%] flex flex-col justify-end gap-[4.375rem] h-[${HEIGHT}%]`}
     >
       <div
-        className={`transition-all ease-in-out duration-1000 ${
-          targetStepIsCurrentStep ? `mb-[${MB}%]` : "mb-[-15%]"
-        }`}
+        className={`transition-all ease-in-out duration-1000`}
+        style={{ marginBottom: targetStepIsCurrentStep ? `${MB}%` : "-15%" }}
       >
         <label
           className="text-3xl font-semibold text-dark-gray"

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -65,6 +65,10 @@ const ProjectCreateInput = ({
   useEffect(() => {
     if (!targetStepIsCurrentStep) {
       inputRef.current?.blur();
+    } else {
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 1000);
     }
   }, [targetStepIsCurrentStep]);
 

--- a/frontend/src/components/projects/ProjectCreateInput.tsx
+++ b/frontend/src/components/projects/ProjectCreateInput.tsx
@@ -1,60 +1,55 @@
-import { useRef, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 import NextStepButton from "../common/NextStepButton";
 import {
   MAX_INPUT_LENGTH,
   PROJECT_NAME_INPUT_ID,
 } from "../../constants/projects";
-import { Step } from "../../types/common/common";
 
 interface ProjectCreateInputProps {
   elementId: string;
+  inputValue: string;
+  onInputValueChange: (value: string) => void;
   targetStepIsCurrentStep: boolean;
-  setCurrentStep: React.Dispatch<React.SetStateAction<Step>>;
   onNextButtonClick: () => void;
+  changeWheelDownActive: (active: boolean) => void;
   label: string;
-  inputRef: React.MutableRefObject<string>;
   buttonContent: string;
-  containerHeight: number;
 }
 
 const ProjectCreateInput = ({
   elementId,
+  inputValue,
+  onInputValueChange,
   targetStepIsCurrentStep,
   onNextButtonClick,
+  changeWheelDownActive,
   label,
-  inputRef,
   buttonContent,
-  containerHeight,
 }: ProjectCreateInputProps) => {
   const [valid, setValid] = useState<boolean | null>(null);
-  const inputElement = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const targetStepIsProjectName = elementId === PROJECT_NAME_INPUT_ID;
+  const HEIGHT = targetStepIsProjectName ? 100 : 90;
+  const MB = targetStepIsProjectName ? 30 : 20;
 
-  const handleInputChange = () => {
-    const value = inputElement.current?.value.trim();
+  const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    const { value } = target;
+    onInputValueChange(value);
 
     if (value && value.length <= MAX_INPUT_LENGTH) {
       setValid(true);
+      changeWheelDownActive(true);
       return;
     }
 
     if (!value) {
       setValid(null);
+      changeWheelDownActive(false);
       return;
     }
 
     setValid(false);
-  };
-
-  const handleNextButtonClick = () => {
-    const value = inputElement.current?.value.trim();
-
-    if (value && inputElement.current) {
-      inputElement.current.value = value;
-      inputRef.current = value;
-    }
-
-    onNextButtonClick();
+    changeWheelDownActive(false);
   };
 
   const handleEnterDown = (event: React.KeyboardEvent) => {
@@ -63,17 +58,25 @@ const ProjectCreateInput = ({
     }
 
     if (event.key === "Enter" && valid) {
-      handleNextButtonClick();
+      onNextButtonClick();
     }
   };
 
+  useEffect(() => {
+    if (!targetStepIsCurrentStep) {
+      inputRef.current?.blur();
+    }
+  }, [targetStepIsCurrentStep]);
+
   return (
     <div
-      className={`flex gap-[4.375rem] h-[${containerHeight}%] ${
-        targetStepIsCurrentStep ? "items-center" : "items-end"
-      }`}
+      className={`w-[100%] flex flex-col justify-end gap-[4.375rem] h-[${HEIGHT}%]`}
     >
-      <div className="w-[80%]">
+      <div
+        className={`transition-all ease-in-out duration-1000 ${
+          targetStepIsCurrentStep ? `mb-[${MB}%]` : "mb-[-15%]"
+        }`}
+      >
         <label
           className="text-3xl font-semibold text-dark-gray"
           htmlFor={elementId}
@@ -82,7 +85,6 @@ const ProjectCreateInput = ({
         </label>
         <br />
         <div
-          id={`${elementId}-input-box`}
           className={`${
             targetStepIsProjectName ? "flex" : "w-[525px] flex flex-col"
           }`}
@@ -92,7 +94,8 @@ const ProjectCreateInput = ({
               type="text"
               name={elementId}
               id={elementId}
-              ref={inputElement}
+              value={inputValue}
+              ref={inputRef}
               autoComplete="off"
               onChange={handleInputChange}
               onKeyDown={handleEnterDown}
@@ -112,17 +115,19 @@ const ProjectCreateInput = ({
               </p>
             )}
           </div>
-          <p className="self-start mt-3 ml-[2px] text-3xl font-semibold w-fit text-dark-gray">
+          <p className="self-end mt-3 ml-[2px] text-3xl font-semibold w-fit text-dark-gray">
             입니다
           </p>
         </div>
       </div>
-      <div className="min-w-[6.875rem] self-end">
-        {valid && targetStepIsCurrentStep && (
-          <NextStepButton onNextButtonClick={handleNextButtonClick}>
-            {buttonContent}
-          </NextStepButton>
-        )}
+      <div
+        className={`self-end ${
+          valid && targetStepIsCurrentStep ? "visible" : "invisible"
+        }`}
+      >
+        <NextStepButton {...{ onNextButtonClick }}>
+          {buttonContent}
+        </NextStepButton>
       </div>
     </div>
   );

--- a/frontend/src/components/projects/ProjectCreateMainSection.tsx
+++ b/frontend/src/components/projects/ProjectCreateMainSection.tsx
@@ -1,105 +1,94 @@
-import { useEffect, useRef } from "react";
+import { WheelEvent } from "react";
 import ProjectCreateInput from "./ProjectCreateInput";
 import {
-  PROJECT_CREATE_STEP,
+  CREATE_PROJECT_MAX_STEP_NUMBER,
+  CREATE_PROJECT_STEP_NUMBER,
   PROJECT_NAME_INPUT_ID,
   PROJECT_SUBJECT_INPUT_ID,
 } from "../../constants/projects";
-import { Step } from "../../types/common/common";
-import usePostCreateProject from "../../hooks/queries/project/usePostCreateProject";
+import CreateMainSection from "../common/CreateMainSection";
+import useDebounce from "../../hooks/common/useDebounce";
+import useWheelDownActive from "../../hooks/common/useWheelDownActive";
+import useCreateProjectForm from "../../hooks/pages/project/useCreateProjectForm";
 
 interface ProjectCreateMainSectionProps {
-  currentStep: Step;
-  setCurrentStep: React.Dispatch<React.SetStateAction<Step>>;
+  currentStepNumber: number;
+  onGoNextStep: () => void;
+  onGoPrevStep: () => void;
 }
 
 const ProjectCreateMainSection = ({
-  currentStep,
-  setCurrentStep,
+  currentStepNumber,
+  onGoNextStep,
+  onGoPrevStep,
 }: ProjectCreateMainSectionProps) => {
-  const projectTitleRef = useRef<string>("");
-  const projectSubjectRef = useRef<string>("");
-  const mutation = usePostCreateProject();
+  const {
+    projectData,
+    handleTitleChange,
+    handleSubjectChange,
+    handleCreateButtonClick,
+  } = useCreateProjectForm();
+  const { wheelDownActive, changeWheelDownActive } = useWheelDownActive();
+  const debounce = useDebounce();
 
-  const handlePrevStepAreaClick = () => {
-    setCurrentStep((prevStep) => {
-      if (prevStep.NUMBER === PROJECT_CREATE_STEP.STEP2.NUMBER) {
-        return PROJECT_CREATE_STEP.STEP1;
+  const handleGoPrevStep = () => {
+    if (currentStepNumber > 1) {
+      onGoPrevStep();
+    }
+  };
+
+  const handleGoNextStep = () => {
+    if (currentStepNumber < CREATE_PROJECT_MAX_STEP_NUMBER) {
+      onGoNextStep();
+    }
+  };
+
+  const handleWheelUpDown = (event: WheelEvent) => {
+    const direction: "UP" | "DOWN" = event.deltaY > 0 ? "DOWN" : "UP";
+
+    debounce(100, () => {
+      if (direction === "UP") {
+        handleGoPrevStep();
+        return;
       }
 
-      return prevStep;
+      if (wheelDownActive) {
+        handleGoNextStep();
+      }
     });
   };
-
-  const handleCreateButtonClick = async () => {
-    mutation.mutate({
-      title: projectTitleRef.current,
-      subject: projectSubjectRef.current,
-    });
-  };
-
-  const handleNextButtonClick = () => {
-    setCurrentStep(PROJECT_CREATE_STEP.STEP2);
-  };
-
-  useEffect(() => {
-    const projectTitleInputElement = document.getElementById(
-      PROJECT_NAME_INPUT_ID
-    );
-    const projectTitleInputBox = document.getElementById(
-      `${PROJECT_NAME_INPUT_ID}-input-box`
-    );
-
-    switch (currentStep.NUMBER) {
-      case PROJECT_CREATE_STEP.STEP1.NUMBER:
-        projectTitleInputElement?.focus();
-        projectTitleInputElement?.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
-        break;
-
-      case PROJECT_CREATE_STEP.STEP2.NUMBER:
-        document.getElementById(PROJECT_SUBJECT_INPUT_ID)?.focus();
-        projectTitleInputBox?.scrollIntoView({
-          behavior: "smooth",
-          block: "start",
-        });
-        break;
-    }
-  }, [currentStep.NUMBER]);
 
   return (
-    <main className="relative ml-10 pl-7 min-w-[720px] h-[40.5rem]">
-      <div
-        className={`absolute top-0 bg-gradient-to-b from-white to-90% min-w-[90%] min-h-[9.25rem] z-10 ${
-          currentStep.NUMBER > 1 && "hover:cursor-pointer hover:to-0%"
-        }`}
-        onClick={handlePrevStepAreaClick}
-      ></div>
-      <section className="h-[100%] overflow-y-hidden">
-        <ProjectCreateInput
-          inputRef={projectTitleRef}
-          targetStepIsCurrentStep={currentStep === PROJECT_CREATE_STEP.STEP1}
-          setCurrentStep={setCurrentStep}
-          onNextButtonClick={handleNextButtonClick}
-          elementId={PROJECT_NAME_INPUT_ID}
-          label="우리가 수행할 프로젝트의 이름은"
-          buttonContent="Next"
-          containerHeight={100}
-        />
-        <ProjectCreateInput
-          inputRef={projectSubjectRef}
-          targetStepIsCurrentStep={currentStep === PROJECT_CREATE_STEP.STEP2}
-          setCurrentStep={setCurrentStep}
-          onNextButtonClick={handleCreateButtonClick}
-          elementId={PROJECT_SUBJECT_INPUT_ID}
-          label="우리가 수행할 프로젝트의 주제는"
-          buttonContent="생성하기"
-          containerHeight={90}
-        />
-      </section>
-    </main>
+    <CreateMainSection
+      {...{ currentStepNumber }}
+      onGoPrevStep={handleGoPrevStep}
+      onWheelUpDown={handleWheelUpDown}
+    >
+      <ProjectCreateInput
+        targetStepIsCurrentStep={
+          currentStepNumber === CREATE_PROJECT_STEP_NUMBER.STEP1
+        }
+        inputValue={projectData.title}
+        onInputValueChange={handleTitleChange}
+        onNextButtonClick={handleGoNextStep}
+        elementId={PROJECT_NAME_INPUT_ID}
+        label="우리가 수행할 프로젝트의 이름은"
+        buttonContent="Next"
+        changeWheelDownActive={changeWheelDownActive}
+      />
+      <ProjectCreateInput
+        targetStepIsCurrentStep={
+          currentStepNumber === CREATE_PROJECT_STEP_NUMBER.STEP2
+        }
+        inputValue={projectData.subject}
+        onInputValueChange={handleSubjectChange}
+        onNextButtonClick={handleCreateButtonClick}
+        elementId={PROJECT_SUBJECT_INPUT_ID}
+        label="우리가 수행할 프로젝트의 주제는"
+        buttonContent="생성하기"
+        changeWheelDownActive={changeWheelDownActive}
+      />
+    </CreateMainSection>
   );
 };
 

--- a/frontend/src/components/projects/ProjectCreateSideBar.tsx
+++ b/frontend/src/components/projects/ProjectCreateSideBar.tsx
@@ -1,10 +1,12 @@
-import { Step } from "../../types/common/common";
-
 interface ProjectCreateSideBarProps {
-  currentStep: Step;
+  currentStepNumber: number;
+  currentStepName: string;
 }
 
-const ProjectCreateSideBar = ({ currentStep }: ProjectCreateSideBarProps) => (
+const ProjectCreateSideBar = ({
+  currentStepNumber,
+  currentStepName,
+}: ProjectCreateSideBarProps) => (
   <div className="w-[24.75rem] h-[40.5rem] bg-gradient-to-bl from-white-transparent to-70% bg-middle-green px-12 shadow-box">
     <h2 className="mt-40 text-4xl font-black text-white">
       프로젝트
@@ -19,8 +21,8 @@ const ProjectCreateSideBar = ({ currentStep }: ProjectCreateSideBarProps) => (
       생성해보세요
     </p>
     <div className="text-white w-[18.5rem] h-[6.75rem] p-5 text-lg rounded-2xl mt-32 bg-white bg-opacity-20">
-      <p className="opacity-80">회원 가입 {currentStep.NUMBER}단계</p>
-      <p className="mt-2 font-bold">{currentStep.NAME}</p>
+      <p className="opacity-80">회원 가입 {currentStepNumber}단계</p>
+      <p className="mt-2 font-bold">{currentStepName}</p>
     </div>
   </div>
 );

--- a/frontend/src/constants/projects.ts
+++ b/frontend/src/constants/projects.ts
@@ -2,10 +2,18 @@ export const PROJECT_SORT_OPTION = { UPDATE: "업데이트 순", RECENT: "최신
 
 export const DEFAULT_MEMBER = JSON.stringify({ username: "", imageURL: "" });
 
-export const PROJECT_CREATE_STEP = {
-  STEP1: { NUMBER: 1, NAME: "프로젝트 이름 입력" },
-  STEP2: { NUMBER: 2, NAME: "프로젝트 주제 입력" },
+export const CREATE_PROJECT_STEP_NUMBER = {
+  STEP1: 1,
+  STEP2: 2,
 };
+
+export const CREATE_PROJECT_STEP_TEXT = [
+  "",
+  "프로젝트 이름 입력",
+  "프로젝트 주제 입력",
+];
+
+export const CREATE_PROJECT_MAX_STEP_NUMBER = 2;
 
 export const PROJECT_NAME_INPUT_ID = "projectName";
 

--- a/frontend/src/hooks/pages/project/useCreateProjectForm.ts
+++ b/frontend/src/hooks/pages/project/useCreateProjectForm.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import usePostCreateProject from "../../queries/project/usePostCreateProject";
+
+const useCreateProjectForm = () => {
+  const [projectData, setProjectData] = useState({
+    title: "",
+    subject: "",
+  });
+  const mutation = usePostCreateProject();
+
+  const handleTitleChange = (title: string) => {
+    setProjectData({ ...projectData, title });
+  };
+
+  const handleSubjectChange = (subject: string) => {
+    setProjectData({ ...projectData, subject });
+  };
+
+  const handleCreateButtonClick = async () => {
+    mutation.mutate(projectData);
+  };
+
+  return {
+    projectData,
+    handleTitleChange,
+    handleSubjectChange,
+    handleCreateButtonClick,
+  };
+};
+
+export default useCreateProjectForm;

--- a/frontend/src/pages/projects/ProjectCreatePage.tsx
+++ b/frontend/src/pages/projects/ProjectCreatePage.tsx
@@ -3,20 +3,34 @@ import {
   ProjectCreateMainSection,
   ProjectCreateSideBar,
 } from "../../components/projects";
-import { PROJECT_CREATE_STEP } from "../../constants/projects";
-import { Step } from "../../types/common/common";
+import {
+  CREATE_PROJECT_STEP_NUMBER,
+  CREATE_PROJECT_STEP_TEXT,
+} from "../../constants/projects";
 
 const ProjectCreatePage = () => {
-  const [currentStep, setCurrentStep] = useState<Step>(
-    PROJECT_CREATE_STEP.STEP1
+  const [currentStepNumber, setCurrentStepNumber] = useState(
+    CREATE_PROJECT_STEP_NUMBER.STEP1
   );
+
+  const handleGoNextStep = () => {
+    setCurrentStepNumber((prev) => prev + 1);
+  };
+
+  const handleGoPrevStep = () => {
+    setCurrentStepNumber((prev) => prev - 1);
+  };
 
   return (
     <div className="flex justify-center items-center min-w-[76rem] h-[100vh] gap-15">
-      <ProjectCreateSideBar currentStep={currentStep} />
+      <ProjectCreateSideBar
+        currentStepNumber={currentStepNumber}
+        currentStepName={CREATE_PROJECT_STEP_TEXT[currentStepNumber]}
+      />
       <ProjectCreateMainSection
-        currentStep={currentStep}
-        setCurrentStep={setCurrentStep}
+        {...{ currentStepNumber }}
+        onGoNextStep={handleGoNextStep}
+        onGoPrevStep={handleGoPrevStep}
       />
     </div>
   );


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 생성 페이지 애니메이션 수정 및 휠 이벤트 적용](https://plastic-toad-cb0.notion.site/858d54246a684d2eb33290637ce0557c)

## ✅ 작업 내용

- 프로젝트 생성 페이지 애니메이션 수정
- 프로젝트 생성 페이지 휠 이벤트 적용
- 프로젝트 카드 제목에 말줄임 적용

## 🖊️ 구체적인 작업

### 프로젝트 생성 페이지 리팩토링

- 회원가입 페이지에 적용한 것처럼 프로젝트 생성 페이지 애니메이션도 css를 통해 실행되도록 수정했습니다.
- ref를 사용할 만큼 무거운 페이지가 아니라 생각했기 때문에 더 확실히 관리하고자 사용자 입력을 ref가 아닌 state로 관리하도록 변경했습니다. 
- 프로젝트 생성 페이지에는 현재 텍스트 입력만 존재하기 때문에 입력하기 편하도록 각 단계가 되었을 때 focus 될 수 있게 했습니다.
