### PR TITLE
feat: 프로젝트 외부 링크 추가 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,6 +28,7 @@ import { ErrorExceptionFilter } from './common/exception-filter/exception.filter
 import { AuthenticationGuard } from './common/guard/authentication.guard';
 import { MemberRepository } from './member/repository/member.repository';
 import { Memo } from './project/entity/memo.entity';
+import { Link } from './project/entity/link.entity.';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { Memo } from './project/entity/memo.entity';
           Project,
           ProjectToMember,
           Memo,
+          Link,
         ],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),

--- a/backend/src/project/dto/LinkCreateRequest.dto.ts
+++ b/backend/src/project/dto/LinkCreateRequest.dto.ts
@@ -1,0 +1,20 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsString, Matches, ValidateNested } from 'class-validator';
+
+class Link {
+  @IsString()
+  url: string;
+
+  @IsString()
+  description: string;
+}
+
+export class LinkCreateRequestDto {
+  @Matches(/^create$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Link)
+  content: Link;
+}

--- a/backend/src/project/entity/link.entity..ts
+++ b/backend/src/project/entity/link.entity..ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity()
+export class Link {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  id: number;
+
+  @Column({ type: 'int', name: 'project_id' })
+  projectId: number;
+
+  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  url: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  description: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  static of(project: Project, url: string, description: string) {
+    const newLink = new Link();
+    newLink.project = project;
+    newLink.url = url;
+    newLink.description = description;
+    return newLink;
+  }
+}

--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -8,6 +8,7 @@ import {
   Generated,
   JoinColumn,
 } from 'typeorm';
+import { Link } from './link.entity.';
 import { Memo } from './memo.entity';
 import { ProjectToMember } from './project-member.entity';
 
@@ -40,6 +41,9 @@ export class Project {
 
   @OneToMany(() => Memo, (memo) => memo.id)
   memoList: Memo[];
+
+  @OneToMany(() => Link, (link) => link.id)
+  linkList: Link[];
 
   static of(title: string, subject: string) {
     const newProject = new Project();

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -11,11 +11,12 @@ import { MemberRepository } from 'src/member/repository/member.repository';
 import { ProjectWebsocketGateway } from './websocket.gateway';
 import { Memo } from './entity/memo.entity';
 import { MemberService } from 'src/member/service/member.service';
+import { Link } from './entity/link.entity.';
 
 @Module({
   imports: [
     LesserJwtModule,
-    TypeOrmModule.forFeature([Project, ProjectToMember, Member, Memo]),
+    TypeOrmModule.forFeature([Project, ProjectToMember, Member, Memo, Link]),
   ],
   controllers: [ProjectController],
   providers: [

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -6,6 +6,7 @@ import { ProjectToMember } from './entity/project-member.entity';
 import { Member } from 'src/member/entity/member.entity';
 import { Memo, memoColor } from './entity/memo.entity';
 import { MemberRepository } from 'src/member/repository/member.repository';
+import { Link } from './entity/link.entity.';
 
 @Injectable()
 export class ProjectRepository {
@@ -18,6 +19,8 @@ export class ProjectRepository {
     private readonly memberRepository: Repository<Member>,
     @InjectRepository(Memo)
     private readonly memoRepository: Repository<Memo>,
+    @InjectRepository(Link)
+    private readonly linkRepository: Repository<Link>,
   ) {}
 
   create(project: Project): Promise<Project> {
@@ -88,5 +91,9 @@ export class ProjectRepository {
     return this.memoRepository.findOne({
       where: { id },
     });
+  }
+
+  createLink(link: Link): Promise<Link> {
+    return this.linkRepository.save(link);
   }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -5,6 +5,7 @@ import { Member } from 'src/member/entity/member.entity';
 import { Project } from '../entity/project.entity';
 import { ProjectToMember } from '../entity/project-member.entity';
 import { Memo, memoColor } from '../entity/memo.entity';
+import { Link } from '../entity/link.entity.';
 
 describe('ProjectService', () => {
   let projectService: ProjectService;
@@ -28,6 +29,7 @@ describe('ProjectService', () => {
             updateMemoColor: jest.fn(),
             findMemoById: jest.fn(),
             getProjectMemberList: jest.fn(),
+            createLink: jest.fn(),
           },
         },
       ],
@@ -261,6 +263,26 @@ describe('ProjectService', () => {
         async () =>
           await projectService.updateMemoColor(myProject, memo.id, color),
       ).rejects.toThrow('project does not have this memo');
+    });
+  });
+
+  describe('Create link', () => {
+    const [title, subject] = ['title', 'subject'];
+    const project = Project.of(title, subject);
+    it('should return created link', async () => {
+      const url = 'url';
+      const description = 'description';
+      jest
+        .spyOn(projectRepository, 'createLink')
+        .mockResolvedValue(Link.of(project, url, description));
+
+      const link: Link = await projectService.createLink(
+        project,
+        url,
+        description,
+      );
+      expect(link.url).toBe(url);
+      expect(link.description).toBe(description);
     });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -4,6 +4,7 @@ import { Member } from 'src/member/entity/member.entity';
 import { Project } from '../entity/project.entity';
 import { ProjectToMember } from '../entity/project-member.entity';
 import { Memo, memoColor } from '../entity/memo.entity';
+import { Link } from '../entity/link.entity.';
 
 @Injectable()
 export class ProjectService {
@@ -75,5 +76,10 @@ export class ProjectService {
       throw new Error('project does not have this memo');
     await this.projectRepository.updateMemoColor(id, color);
     return true;
+  }
+
+  createLink(project: Project, url: string, description: string) {
+    const newLink = Link.of(project, url, description);
+    return this.projectRepository.createLink(newLink);
   }
 }

--- a/backend/test/project/ws-link.e2e-spec.ts
+++ b/backend/test/project/ws-link.e2e-spec.ts
@@ -1,0 +1,91 @@
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  joinProject,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import {
+  emitJoinLanding,
+  expectUpdatedMemberStatus,
+  handleConnectErrorWithReject,
+  handleErrorWithReject,
+  initLanding,
+  initLandingAndReturnId,
+} from './ws-common';
+
+describe('WS link', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+  describe('link create', () => {
+    it('should return created link data when received create link request', async () => {
+      let socket1;
+      let socket2;
+      return new Promise<void>(async (resolve, reject) => {
+        // 회원1 회원가입 + 프로젝트 생성
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+        // 회원2 회원가입 + 프로젝트 참여
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
+
+        socket1 = connectServer(project.id, accessToken);
+        handleConnectErrorWithReject(socket1, reject);
+        handleErrorWithReject(socket1, reject);
+        await emitJoinLanding(socket1);
+        await initLanding(socket1);
+
+        socket2 = connectServer(project.id, accessToken2);
+        handleConnectErrorWithReject(socket2, reject);
+        handleErrorWithReject(socket2, reject);
+        await emitJoinLanding(socket2);
+        const memberId2 = await initLandingAndReturnId(socket2);
+        await expectUpdatedMemberStatus(socket1, 'on', memberId2);
+
+        const url = '유효한 url';
+        const description = '피그마';
+        const requestData = {
+          action: 'create',
+          content: { url, description },
+        };
+        socket1.emit('link', requestData);
+        await Promise.all([
+          expectCreateLink(socket1, url, description),
+          expectCreateLink(socket2, url, description),
+        ]);
+        resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
+      });
+    });
+
+    const expectCreateLink = (socket, url, description) => {
+      return new Promise<void>((resolve, reject) => {
+        socket.on('landing', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('link');
+          expect(action).toBe('create');
+          expect(content?.description).toBe(description);
+          expect(content?.id).toBeDefined();
+          expect(content?.url).toBe(url);
+          expect(content?.description).toBe(description);
+          socket.off('landing');
+          resolve();
+        });
+      });
+    };
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[(백엔드) 외부 링크 추가 API 구현](https://plastic-toad-cb0.notion.site/API-6375a39cf9794a78a158e5bf922308db?pvs=74)

## ✅ 작업 내용

- 프로젝트 외부 링크 추가 API 구현

## 🖊️ 구체적인 작업

### 프로젝트 외부링크 추가 API 테스트 추가
### 프로젝트 외부링크 엔티티 추가
- 프로젝트 외부링크 엔티티 추가
- 링크 엔티티를 TypeOrm, NestJS 모듈에 등록
### 프로젝트 링크 추가 서비스 구현
- 프로젝트 링크 추가 레포지토리 메서드 구현
- 프로젝트 링크 추가 서비스 메서드 구현
### 프로젝트 링크추가 API 컨트롤러 구현
- 웹소켓 게이트웨이에 프로젝트 링크추가 API 구현
- DTO추가


## 🤔 고민 및 의논할 거리
    
- 커밋을 다 한 후에 필요없는 import가 들어가 있는것을 확인했습니다. 아직 깃허브에 올리기 전이었기 때문에 이를 수정하는 새로운 커밋을 만들기 보다는 기존의 커밋을 수정하고자 했습니다. 직전의 커밋이 아니었기 때문에 git commit --amend로는 수정이 불가능해 rebase로 해결했는데 이 과정을 [개발일지 - 과거의 특정 커밋에 현재 변경사항을 적용하는 방법](https://plastic-toad-cb0.notion.site/e883c67abd654bca9fc8a68a77f78c92)에 상세히 작성해 놓았습니다~