### PR TITLE
feat: 외부링크 유효성검사/랜딩페이지 조회/삭제 API 구현

### DIFF
--- a/backend/src/project/dto/InitLandingResponse.dto.ts
+++ b/backend/src/project/dto/InitLandingResponse.dto.ts
@@ -1,4 +1,5 @@
 import { Member } from 'src/member/entity/member.entity';
+import { Link } from '../entity/link.entity.';
 import { Memo, memoColor } from '../entity/memo.entity';
 import { Project } from '../entity/project.entity';
 import { MemberStatus } from '../enum/MemberStatus.enum';
@@ -20,6 +21,20 @@ class MemoDto {
     dto.author = memoWithMember.member.username;
     dto.createdAt = memoWithMember.created_at;
     dto.color = memoWithMember.color;
+    return dto;
+  }
+}
+
+class LinkDto {
+  id: number;
+  url: string;
+  description: string;
+
+  static of(link: Link) {
+    const dto = new LinkDto();
+    dto.id = link.id;
+    dto.url = link.url;
+    dto.description = link.description;
     return dto;
   }
 }
@@ -60,7 +75,7 @@ class ProjectLandingPageContentDto {
   member: MemberInfo[];
   sprint: null;
   memoList: MemoDto[];
-  link: [];
+  linkList: LinkDto[];
   inviteLinkId: string;
 
   static of(
@@ -70,6 +85,7 @@ class ProjectLandingPageContentDto {
     projectSocketList: ClientSocket[],
     projectMemberList: Member[],
     memoListWithMember: Memo[],
+    linkList: Link[],
   ) {
     const dto = new ProjectLandingPageContentDto();
     dto.project = ProjectDto.of(project);
@@ -86,7 +102,10 @@ class ProjectLandingPageContentDto {
     dto.sprint = null;
     const memoList = memoListWithMember.map((memo) => MemoDto.of(memo));
     dto.memoList = memoList;
-    dto.link = [];
+
+    const linkDtoList = linkList.map((link) => LinkDto.of(link));
+    dto.linkList = linkDtoList;
+
     dto.inviteLinkId = project.inviteLinkId;
     return dto;
   }
@@ -104,6 +123,7 @@ export class InitLandingResponseDto {
     projectSocketList: ClientSocket[],
     projectMemberList: Member[],
     memoListWithMember: Memo[],
+    linkList: Link[],
   ) {
     const dto = new InitLandingResponseDto();
     dto.domain = 'landing';
@@ -115,6 +135,7 @@ export class InitLandingResponseDto {
       projectSocketList,
       projectMemberList,
       memoListWithMember,
+      linkList,
     );
     return dto;
   }

--- a/backend/src/project/dto/LinkCreateRequest.dto.ts
+++ b/backend/src/project/dto/LinkCreateRequest.dto.ts
@@ -1,11 +1,47 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsString, Matches, ValidateNested } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsString,
+  Length,
+  Matches,
+  registerDecorator,
+  ValidateNested,
+} from 'class-validator';
+
+function IsURL() {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'IsURL',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: { message: 'invalid url format' },
+      validator: {
+        validate(value: any) {
+          const URLPattern = new RegExp(
+            '^(https?:\\/\\/)' +
+              '((([a-z\\d가-힣]([a-z\\d가-힣-]*[a-z\\d가-힣])*)\\.?)+[a-z가-힣]{2,}|' +
+              '((\\d{1,3}\\.){3}\\d{1,3}))' +
+              '(\\:\\d+)?' +
+              '(\\/[-a-z\\d%_.~+가-힣]*)*' +
+              '(\\?[;&a-z\\d%_.~+=-가-힣]*)?' +
+              '(\\#[-a-z\\d_가-힣]*)?$',
+            'i',
+          );
+          return URLPattern.test(value);
+        },
+      },
+    });
+  };
+}
 
 class Link {
   @IsString()
+  @IsURL()
+  @Length(0, 255)
   url: string;
 
   @IsString()
+  @Length(0, 255)
   description: string;
 }
 

--- a/backend/src/project/dto/LinkDeleteRequest.dto.ts
+++ b/backend/src/project/dto/LinkDeleteRequest.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber, Matches, ValidateNested } from 'class-validator';
+
+class Link {
+  @IsNumber()
+  id: number;
+}
+
+export class LinkDeleteRequestDto {
+  @Matches(/^delete$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Link)
+  content: Link;
+}

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -96,4 +96,8 @@ export class ProjectRepository {
   createLink(link: Link): Promise<Link> {
     return this.linkRepository.save(link);
   }
+
+  getProjectLinkList(project: Project): Promise<Link[]> {
+    return this.linkRepository.find({ where: { project: { id: project.id } } });
+  }
 }

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -100,4 +100,12 @@ export class ProjectRepository {
   getProjectLinkList(project: Project): Promise<Link[]> {
     return this.linkRepository.find({ where: { project: { id: project.id } } });
   }
+
+  async deleteLink(project: Project, id: number): Promise<number> {
+    const result = await this.linkRepository.delete({
+      project: { id: project.id },
+      id,
+    });
+    return result.affected ? result.affected : 0;
+  }
 }

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -30,6 +30,7 @@ describe('ProjectService', () => {
             findMemoById: jest.fn(),
             getProjectMemberList: jest.fn(),
             createLink: jest.fn(),
+            getProjectLinkList: jest.fn(),
           },
         },
       ],
@@ -283,6 +284,23 @@ describe('ProjectService', () => {
       );
       expect(link.url).toBe(url);
       expect(link.description).toBe(description);
+    });
+  });
+
+  describe('Get project link list', () => {
+    it('should return linkList', async () => {
+      const [title, subject] = ['title', 'subject'];
+      const project = Project.of(title, subject);
+      const link = Link.of(project, 'url', 'description');
+      const newLinkList = [link];
+
+      jest
+        .spyOn(projectRepository, 'getProjectLinkList')
+        .mockResolvedValue(newLinkList);
+
+      const linkList = await projectService.getProjectLinkList(project);
+
+      expect(linkList).toEqual(newLinkList);
     });
   });
 });

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -31,6 +31,7 @@ describe('ProjectService', () => {
             getProjectMemberList: jest.fn(),
             createLink: jest.fn(),
             getProjectLinkList: jest.fn(),
+            deleteLink: jest.fn(),
           },
         },
       ],
@@ -301,6 +302,28 @@ describe('ProjectService', () => {
       const linkList = await projectService.getProjectLinkList(project);
 
       expect(linkList).toEqual(newLinkList);
+    });
+  });
+
+  describe('Delete link', () => {
+    const [title, subject] = ['title', 'subject'];
+    const project = Project.of(title, subject);
+    it('should return 1 when deleted a link', async () => {
+      jest.spyOn(projectRepository, 'deleteLink').mockResolvedValue(1);
+
+      const deletedLinkId = 1;
+      const result = await projectService.deleteLink(project, deletedLinkId);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return 0 when link is not found', async () => {
+      jest.spyOn(projectRepository, 'deleteLink').mockResolvedValue(0);
+
+      const notFoundLinkId = 1;
+      const result = await projectService.deleteLink(project, notFoundLinkId);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -89,7 +89,6 @@ export class ProjectService {
 
   async deleteLink(project: Project, linkId: number) {
     const result = await this.projectRepository.deleteLink(project, linkId);
-    if (result) return true;
-    else return false;
+    return result ? true : false;
   }
 }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -86,4 +86,10 @@ export class ProjectService {
   getProjectLinkList(project: Project) {
     return this.projectRepository.getProjectLinkList(project);
   }
+
+  async deleteLink(project: Project, linkId: number) {
+    const result = await this.projectRepository.deleteLink(project, linkId);
+    if (result) return true;
+    else return false;
+  }
 }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -82,4 +82,8 @@ export class ProjectService {
     const newLink = Link.of(project, url, description);
     return this.projectRepository.createLink(newLink);
   }
+
+  getProjectLinkList(project: Project) {
+    return this.projectRepository.getProjectLinkList(project);
+  }
 }

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -94,11 +94,13 @@ export class ProjectWebsocketGateway
 
   @SubscribeMessage('joinLanding')
   async handleJoinLandingEvent(@ConnectedSocket() client: ClientSocket) {
-    const [project, projectMemberList, memoListWithMember] = await Promise.all([
-      this.projectService.getProject(client.projectId),
-      this.projectService.getProjectMemberList(client.project),
-      this.projectService.getProjectMemoListWithMember(client.project.id),
-    ]);
+    const [project, projectMemberList, memoListWithMember, linkList] =
+      await Promise.all([
+        this.projectService.getProject(client.projectId),
+        this.projectService.getProjectMemberList(client.project),
+        this.projectService.getProjectMemoListWithMember(client.project.id),
+        this.projectService.getProjectLinkList(client.project),
+      ]);
     const projectSocketList: ClientSocket[] =
       (await client.nsp.fetchSockets()) as unknown as ClientSocket[];
 
@@ -117,6 +119,7 @@ export class ProjectWebsocketGateway
       projectSocketList,
       projectMemberList,
       memoListWithMember,
+      linkList,
     );
     client.emit('landing', response);
     client.join('landing');

--- a/backend/test/project/ws-link.e2e-spec.ts
+++ b/backend/test/project/ws-link.e2e-spec.ts
@@ -74,7 +74,7 @@ describe('WS link', () => {
 
     const expectCreateLink = (socket, url, description) => {
       return new Promise<void>((resolve, reject) => {
-        socket.on('landing', async (data) => {
+        socket.once('landing', async (data) => {
           const { content, action, domain } = data;
           expect(domain).toBe('link');
           expect(action).toBe('create');
@@ -82,7 +82,6 @@ describe('WS link', () => {
           expect(content?.id).toBeDefined();
           expect(content?.url).toBe(url);
           expect(content?.description).toBe(description);
-          socket.off('landing');
           resolve(content.id);
         });
       });
@@ -170,11 +169,10 @@ describe('WS link', () => {
     });
     const getCreateLinkMsg = (socket) => {
       return new Promise<void>((res) => {
-        socket.on('landing', (data) => {
+        socket.once('landing', (data) => {
           const { action, domain } = data;
           expect(domain).toBe('link');
           expect(action).toBe('create');
-          socket.off('landing');
           res();
         });
       });
@@ -241,7 +239,7 @@ describe('WS link', () => {
     });
     const expectCreateLinkAndReturnFirstLinkId = (socket, url, description) => {
       return new Promise<void>((resolve, reject) => {
-        socket.on('landing', async (data) => {
+        socket.once('landing', async (data) => {
           const { content, action, domain } = data;
           expect(domain).toBe('link');
           expect(action).toBe('create');
@@ -249,7 +247,6 @@ describe('WS link', () => {
           expect(content?.id).toBeDefined();
           expect(content?.url).toBe(url);
           expect(content?.description).toBe(description);
-          socket.off('landing');
           resolve(content.id);
         });
       });
@@ -257,12 +254,11 @@ describe('WS link', () => {
 
     const expectDeleteLink = (socket, linkId) => {
       return new Promise<void>((resolve, reject) => {
-        socket.on('landing', async (data) => {
+        socket.once('landing', async (data) => {
           const { content, action, domain } = data;
           expect(domain).toBe('link');
           expect(action).toBe('delete');
           expect(content?.id).toBe(linkId);
-          socket.off('landing');
           resolve();
         });
       });

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -178,11 +178,10 @@ describe('WS landing', () => {
 
 const getCreateMemoMsg = (socket) => {
   return new Promise<void>((res) => {
-    socket.on('landing', (data) => {
+    socket.once('landing', (data) => {
       const { action, domain } = data;
       expect(domain).toBe('memo');
       expect(action).toBe('create');
-      socket.off('landing');
       res();
     });
   });

--- a/backend/test/project/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-project-landing-page.e2e-spec.ts
@@ -75,7 +75,7 @@ describe('WS landing', () => {
         // else
         expect(content.sprint).toBeDefined();
         expect(content.memoList).toBeDefined();
-        expect(content.link).toBeDefined();
+        expect(content.linkList).toBeDefined();
         expect(content.inviteLinkId).toBeDefined();
 
         resolve();


### PR DESCRIPTION
## 🎟️ 태스크

[(백엔드) 외부 링크 추가 API에 대한 유효성 검사](https://plastic-toad-cb0.notion.site/API-7e11d9965c484ea6b7de2d2f9584d71d)
[(백엔드) 랜딩페이지 접속시 외부링크 정보 전송하기](https://plastic-toad-cb0.notion.site/0eb20353097044af9ba123e8302a8dab?pvs=74)
[(백엔드) 외부 링크 삭제 API 구현](https://plastic-toad-cb0.notion.site/API-19e8149a44d3400f8f21be70adb2c173)

## ✅ 작업 내용
- 외부 링크 추가 API에 대한 유효성 검사
- 랜딩페이지 접속시 외부링크 정보 전송하기
- 외부 링크 삭제 API 구현

## 🖊️ 구체적인 작업

### 외부 링크 추가 API에 대한 유효성 검사
- 유효하지 않은 URL에 대한 e2e 테스트 추가
- 검증로직 추가
### 랜딩페이지 접속시 외부링크 정보 전송하기
- 랜딩페이지 접속시 프로젝트의 링크 리스트를 반환하는지 확인하는 E2E테스트 추가
  - 프로퍼티 이름을 link에서 linkList로 변경
- 프로젝트의 링크를 반환하는 서비스, 레포지토리 구현
- 랜딩페이지 접속시 프로젝트의 링크 리스트를 반환하게 구현
  - initLandingDto에서 linkDto클래스 만들어 link의 데이터 형식을 만들도록 구현
  - 웹소켓 게이트웨이에서 접속시 link정보 함께 반환하도록 구현
### 외부 링크 삭제 API 구현
- 링크 삭제 E2E 테스트 추가
- 링크삭제 서비스, 레포지토리 구현
- 링크 삭제 API 구현
  - 웹소켓 게이트웨이에서 링크 삭제 요청시 삭제 후 브로드캐스팅하도록 구현
  - 링크삭제 요청 DTO 추가

## 🤔 고민 및 의논할 거리

- 유효한 URL임을 판단하는 로직이 컨트롤러에 들어가야할지 서비스에 들어가야할지 고민해보았고 컨트롤러에 넣기로 결정했습니다. 왜냐하면 컨트롤러(프레센테이션 계층)의 역할 중 하나가 입력을 처리하는것인데 유효성검사하고자 하는 URL은 클라이언트의 입력이기 때문입니다.
- 가장 고민이 되었던 부분은 유효한 URL을 판별하는게 비즈니스로직인가? 였습니다. 만약 비즈니스 로직이라면 서비스 계층에 들어가야 할 거라고 생각되었습니다.
- 그러나 URL을 판별하는것은 비즈니스로직이라고 보기 힘들다고 결정했습니다. 비즈니스 로직이라 함은 서비스가 하고자 하는 중요한 의사결정을 코드로 표현한 것입니다. 만약 URL을 특정 사이트(ex)레서 내 사이트 혹은 협약을 맺은 사이트)로 제한하거나 특정 사용자(ex)팀장)만 URL을 등록할 수 있다면 우리서비스가 하고자 중요한 의사결정이므로 비즈니스로직일 수 있습니다. 하지만 저희가 원하는것은 유효한 URL형식을 확인하는 정도이기 때문에 비즈니스로직이 아니라고 생각했습니다.
- 이러한 고민과 의사결정을 [태스크 문서](https://plastic-toad-cb0.notion.site/API-7e11d9965c484ea6b7de2d2f9584d71d)에 적어놓았습니다. 궁금하시면 한번 구경해주세용~