### PR TITLE
feat: 10명 이상 프로젝트 에러 처리

### DIFF
--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -22,6 +22,10 @@ const InvitePage = () => {
         alert("이미 참여한 프로젝트입니다.");
         navigate(`/projects/${response.data.projectId}`);
         break;
+      case 409:
+        alert("정원 초과로 참여할 수 없습니다.");
+        navigate(`/projects`);
+        break;
     }
   };
 


### PR DESCRIPTION
## 🎟️ 태스크

[클라이언트에서 참여하기 버튼을 눌렀을 때 10명 프로젝트인 경우 에러 처리](https://plastic-toad-cb0.notion.site/10-4f3d7014866642e3b06d958c885a5793)

## ✅ 작업 내용

- 10명 이상 프로젝트 에러 처리

## 🖊️ 구체적인 작업

### 10명 이상 프로젝트 에러 처리
- 10명 이상인 프로젝트에 참여하려 할 경우 alert를 띄우고 프로젝트 페이지로 이동하도록 했습니다.

