### PR TITLE
fix: 외부 링크 추가, 삭제 기능 오류 수정

### DIFF
--- a/frontend/src/components/common/ProfileImage.tsx
+++ b/frontend/src/components/common/ProfileImage.tsx
@@ -1,12 +1,16 @@
-const ProfileImage = ({ imageUrl, pxSize }: { imageUrl: string; pxSize: number }) => {
-  return (
-    <div
-      className="ml-[0.46875rem] rounded-full overflow-hidden"
-      style={{ height: pxSize, width: pxSize }}
-    >
-      <img src={imageUrl} alt="프로필 이미지 사진" />
-    </div>
-  );
-};
+const ProfileImage = ({
+  imageUrl,
+  pxSize,
+}: {
+  imageUrl: string;
+  pxSize: number;
+}) => (
+  <div
+    className="ml-[0.46875rem] rounded-full overflow-hidden flex justify-center items-center"
+    style={{ height: pxSize, width: pxSize }}
+  >
+    <img src={imageUrl} alt="프로필 이미지 사진" />
+  </div>
+);
 
 export default ProfileImage;

--- a/frontend/src/components/landing/link/LandingLinkBlock.tsx
+++ b/frontend/src/components/landing/link/LandingLinkBlock.tsx
@@ -1,6 +1,8 @@
 import { LandingLinkDTO } from "../../../types/DTO/landingDTO";
 import ProfileImage from "../../common/ProfileImage";
 import TrashCan from "../../../assets/icons/trash-can.svg?react";
+import getLinkType from "../../../utils/getLinkType";
+import { LINK_LOGO_URL } from "../../../constants/landing";
 
 interface LandingLinkBlockProps extends LandingLinkDTO {
   emitLinkDeleteEvent: ({ id }: { id: number }) => void;
@@ -12,7 +14,7 @@ const LandingLinkBlock = ({
   url,
   emitLinkDeleteEvent,
 }: LandingLinkBlockProps) => {
-  const linkLogoUrl = `${new URL(url).origin}/favicon.ico`;
+  const linkLogoUrl = LINK_LOGO_URL[getLinkType(url)];
 
   const handleDeleteClick = () => {
     emitLinkDeleteEvent({ id });
@@ -26,7 +28,10 @@ const LandingLinkBlock = ({
         target="_blank"
       >
         <ProfileImage imageUrl={linkLogoUrl} pxSize={40} />
-        <p className="text-xs font-bold truncate text-dark-green">
+        <p
+          title={description}
+          className="max-w-[8.5rem] overflow-hidden text-xs font-bold truncate whitespace-nowrap text-ellipsis text-dark-green"
+        >
           {description}
         </p>
       </a>

--- a/frontend/src/hooks/common/landing/useLandingLinkSocket.ts
+++ b/frontend/src/hooks/common/landing/useLandingLinkSocket.ts
@@ -20,10 +20,12 @@ const useLandingLinkSocket = (socket: Socket) => {
   ) => {
     switch (action) {
       case LandingSocketLinkAction.CREATE:
-        setLinkList([...linkList, content]);
+        setLinkList((prevLinkList) => [...prevLinkList, content]);
         break;
       case LandingSocketLinkAction.DELETE:
-        setLinkList(linkList.filter(({ id }) => id !== content.id));
+        setLinkList((prevLinkList) =>
+          prevLinkList.filter(({ id }) => id !== content.id)
+        );
         break;
     }
   };


### PR DESCRIPTION
## 🎟️ 태스크

[링크 추가, 삭제 오류 수정](https://plastic-toad-cb0.notion.site/379011230ff04464a634c1473605c543)

## ✅ 작업 내용

- 외부 링크 오류 수정

## 🖊️ 구체적인 작업

### 외부 링크 오류 수정

- 외부 링크를 추가할 때 이미 추가된 링크가 사라지는 문제, 외부 링크를 삭제할 때 모든 링크가 사라지는 문제를 해결했습니다.
- 외부 링크 이미지가 제대로 보이도록 수정했으며, 미리 정해 놓은 사이트가 아니면 클립 아이콘이 보이도록 수정했습니다.
- 링크 이름이 길어도 링크 크기가 유지되고 대신 말줄임 표시가 되도록 수정했습니다.