### PR TITLE
fix: unique 조건을 걸면 자동으로 index가 생성되므로 index 데코레이터 삭제

### DIFF
--- a/backend/src/member/entity/member.entity.ts
+++ b/backend/src/member/entity/member.entity.ts
@@ -5,7 +5,6 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
-  Index,
   OneToMany,
 } from 'typeorm';
 
@@ -14,7 +13,6 @@ export class Member {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
 
-  @Index()
   @Column({ type: 'int', unique: true, nullable: false })
   github_id: number;
 
@@ -24,7 +22,6 @@ export class Member {
   @Column({ type: 'varchar', length: 256, nullable: false })
   github_image_url: string;
 
-  @Index()
   @Column({ type: 'varchar', length: 39, unique: true, nullable: false })
   username: string;
 


### PR DESCRIPTION
## 🎟️ 개발일지

[DB 구조 설계](https://plastic-toad-cb0.notion.site/DB-4fb948d693ff4ddcb9d81cec23a790ec)

## ✅ 작업 내용
- unique 조건을 걸면 자동으로 index가 생성되므로 index 데코레이터 삭제


## 🤔 고민 및 의논할 거리
- 기존의 DB를 drop후 create할 때 인덱스 이름의 중복으로 테이블을 구성하는게 불가능한 문제가 발생했습니다. 문제의 원인은 unique 컬럼이며 index 제약조건이 동시에 걸려있는 member테이블의 github_id, username컬럼 각각이 같은 이름의 unique index와 index를 가지고 있어 인덱스 이름이 충돌해 문제가 발생한것으로 파악했습니다.
- 기존의 typeorm 코드입니다.
  ```
    @Index()
    @Column({ type: 'int', unique: true, nullable: false })
    github_id: number;
  ```
- 문제가 발생한 쿼리입니다.
  ```
  query failed: CREATE TABLE `member` (
    `id` int NOT NULL AUTO_INCREMENT,
    `github_id` int NOT NULL,
    `github_username` varchar(39) NOT NULL,
    `github_image_url` varchar(256) NOT NULL,
    `username` varchar(39) NOT NULL,
    `position` varchar(20) NOT NULL,
    `tech_stack` json NOT NULL,
    `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
    `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
    INDEX `IDX_f29502fbd8f92518bfc2544125` (`github_id`),
    INDEX `IDX_1945f9202fcfbce1b439b47b77` (`username`),
    UNIQUE INDEX `IDX_f29502fbd8f92518bfc2544125` (`github_id`),
    UNIQUE INDEX `IDX_1945f9202fcfbce1b439b47b77` (`username`),
    PRIMARY KEY (`id`)
  ) ENGINE=InnoDB;
  ```
- unique 인덱스와 일반 인덱스의 이름이 같은것은 typeorm의 버그로 보입니다.
- unique 조건을 걸었을때 unique index가 생성되는 것을 몰랐고, mysql공식문서를 보니 unique index가 일반 index와 동일하게 b-tree를 사용하기 때문에 일반 index를 사용하지 않아도 된다고 판단했습니다.
- 따라서 아래와 같이 unique 컬럼에 대해 index데코레이터를 사용하지 않도록 수정했습니다.
  ```
    @Column({ type: 'int', unique: true, nullable: false })
    github_id: number;
  ```
- 이에 대해 해결한 과정과 레퍼런스를 [개발일지](https://plastic-toad-cb0.notion.site/unique-index-6fe93bdefc134f69b95d8e71d29d350f?pvs=4)에 상세히 작성했습니다. 궁금하시면 봐주세용~