### PR TITLE
feat: 백로그 페이지 컴포넌트 생성, 에픽 생성, 삭제, 수정 기능 구현

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -19,6 +19,7 @@ import PublicRoute from "./components/common/route/PublicRoute";
 import MainPage from "./pages/main/MainPage";
 import LandingPage from "./pages/landing/LandingPage";
 import InvitePage from "./pages/invite/InvitePage";
+import UncompletedStoryPage from "./pages/backlog/UncompletedStoryPage";
 
 type RouteType = "PRIVATE" | "PUBLIC";
 
@@ -74,7 +75,23 @@ const router = createBrowserRouter([
           element: <MainPage />,
           children: [
             { index: true, element: <LandingPage /> },
-            { path: ROUTER_URL.BACKLOG, element: <div>backlog Page</div> },
+            {
+              path: ROUTER_URL.BACKLOG.BASE,
+              children: [
+                {
+                  index: true,
+                  element: <UncompletedStoryPage />,
+                },
+                {
+                  path: ROUTER_URL.BACKLOG.EPIC,
+                  element: <div>backlog epic Page</div>,
+                },
+                {
+                  path: ROUTER_URL.BACKLOG.COMPLETED,
+                  element: <div>backlog completed story Page</div>,
+                },
+              ],
+            },
             { path: ROUTER_URL.SPRINT, element: <div>sprint Page</div> },
             { path: ROUTER_URL.SETTINGS, element: <div>setting Page</div> },
           ],

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -19,7 +19,8 @@ import PublicRoute from "./components/common/route/PublicRoute";
 import MainPage from "./pages/main/MainPage";
 import LandingPage from "./pages/landing/LandingPage";
 import InvitePage from "./pages/invite/InvitePage";
-import UncompletedStoryPage from "./pages/backlog/UncompletedStoryPage";
+import UnfinishedStoryPage from "./pages/backlog/UnfinishedStoryPage";
+import BacklogPage from "./pages/backlog/BacklogPage";
 
 type RouteType = "PRIVATE" | "PUBLIC";
 
@@ -80,7 +81,7 @@ const router = createBrowserRouter([
               children: [
                 {
                   index: true,
-                  element: <UncompletedStoryPage />,
+                  element: <UnfinishedStoryPage />,
                 },
                 {
                   path: ROUTER_URL.BACKLOG.EPIC,
@@ -91,6 +92,7 @@ const router = createBrowserRouter([
                   element: <div>backlog completed story Page</div>,
                 },
               ],
+              element: <BacklogPage />,
             },
             { path: ROUTER_URL.SPRINT, element: <div>sprint Page</div> },
             { path: ROUTER_URL.SETTINGS, element: <div>setting Page</div> },

--- a/frontend/src/assets/icons/check.svg
+++ b/frontend/src/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 6.5L8.625 18.5L3 13.0455" stroke="current" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/icons/closed.svg
+++ b/frontend/src/assets/icons/closed.svg
@@ -1,4 +1,4 @@
-<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M11.6362 11.636L24.3642 24.3639" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M11.6362 24.364L24.3642 11.6361" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.75781 8.25781L16.2431 16.7431" stroke="current" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.75781 16.7422L16.2431 8.25691" stroke="current" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/src/assets/icons/menu-kebab.svg
+++ b/frontend/src/assets/icons/menu-kebab.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 3.25C8.41421 3.25 8.75 2.91421 8.75 2.5C8.75 2.08579 8.41421 1.75 8 1.75C7.58579 1.75 7.25 2.08579 7.25 2.5C7.25 2.91421 7.58579 3.25 8 3.25Z" stroke="current" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 8.75C8.41421 8.75 8.75 8.41421 8.75 8C8.75 7.58579 8.41421 7.25 8 7.25C7.58579 7.25 7.25 7.58579 7.25 8C7.25 8.41421 7.58579 8.75 8 8.75Z" stroke="current" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 14.25C8.41421 14.25 8.75 13.9142 8.75 13.5C8.75 13.0858 8.41421 12.75 8 12.75C7.58579 12.75 7.25 13.0858 7.25 13.5C7.25 13.9142 7.58579 14.25 8 14.25Z" stroke="current" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/icons/plus.svg
+++ b/frontend/src/assets/icons/plus.svg
@@ -1,4 +1,4 @@
 <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 18H27" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M18 27V9" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 18H27" stroke="current" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 27V9" stroke="current" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/src/components/backlog/AssignedMemberDropdown.tsx
+++ b/frontend/src/components/backlog/AssignedMemberDropdown.tsx
@@ -1,0 +1,32 @@
+import useMemberStore from "../../stores/useMemberStore";
+import { LandingMemberDTO } from "../../types/DTO/landingDTO";
+
+interface AssignedMemberDropdownProps {
+  onOptionClick: (memberId: number) => void;
+}
+
+const AssignedMemberDropdown = ({
+  onOptionClick,
+}: AssignedMemberDropdownProps) => {
+  const myInfo = useMemberStore((state) => state.myInfo);
+  const partialMemberList = useMemberStore((state) => state.memberList);
+  const memberList = [myInfo, ...partialMemberList];
+
+  return (
+    <div className="rounded-md w-fit shadow-box">
+      <ul>
+        {...memberList.map((member: LandingMemberDTO) => (
+          <li
+            className="p-2 hover:cursor-pointer hover:bg-gray-100"
+            key={member.id}
+            onClick={() => onOptionClick(member.id)}
+          >
+            {member.username}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AssignedMemberDropdown;

--- a/frontend/src/components/backlog/BacklogHeader.tsx
+++ b/frontend/src/components/backlog/BacklogHeader.tsx
@@ -1,0 +1,35 @@
+import { useLocation } from "react-router-dom";
+import TabButton from "./TabButton";
+import { useMemo } from "react";
+import { TAB_TITLE } from "../../constants/backlog";
+import { BacklogPath } from "../../types/common/backlog";
+
+const BacklogHeader = () => {
+  const { pathname } = useLocation();
+  const lastPath: BacklogPath = useMemo(() => {
+    const path = pathname.split("/");
+    return path[path.length - 1] as BacklogPath;
+  }, [pathname]);
+
+  return (
+    <header className="flex items-baseline justify-between">
+      <div className="flex items-baseline gap-2">
+        <h1 className="text-m text-dark-green">{TAB_TITLE[lastPath]} 백로그</h1>
+        <p className="">우선순위 내림차순</p>
+      </div>
+      <div className="flex gap-1">
+        <TabButton title="스토리별" active={lastPath === "backlog"} link="" />
+        <span className="text-text-gray">/</span>
+        <TabButton title="에픽별" active={lastPath === "epic"} link="epic" />
+        <span className="text-text-gray">/</span>
+        <TabButton
+          title="완료된 스토리"
+          active={lastPath === "completed"}
+          link="completed"
+        />
+      </div>
+    </header>
+  );
+};
+
+export default BacklogHeader;

--- a/frontend/src/components/backlog/BacklogStatusChip.tsx
+++ b/frontend/src/components/backlog/BacklogStatusChip.tsx
@@ -1,0 +1,18 @@
+import { BACKLOG_STATUS_DISPLAY } from "../../constants/backlog";
+import { BacklogStatusType } from "../../types/DTO/backlogDTO";
+
+const BacklogStatusChip = ({
+  status = "시작전",
+}: {
+  status: BacklogStatusType;
+}) => {
+  const { bgColor, dotColor } = BACKLOG_STATUS_DISPLAY[status];
+  return (
+    <div className={`flex w-fit gap-1 px-2 items-center rounded-xl ${bgColor}`}>
+      <div className={`w-[10px] h-[10px] rounded-[50%] ${dotColor}`}></div>
+      <span>{status}</span>
+    </div>
+  );
+};
+
+export default BacklogStatusChip;

--- a/frontend/src/components/backlog/CategoryChip.tsx
+++ b/frontend/src/components/backlog/CategoryChip.tsx
@@ -1,0 +1,17 @@
+import { CATEGORY_COLOR } from "../../constants/backlog";
+import { EpicColor } from "../../types/DTO/backlogDTO";
+
+interface CategoryChipProps {
+  content: string;
+  bgColor: EpicColor;
+}
+
+const CategoryChip = ({ content, bgColor }: CategoryChipProps) => (
+  <div
+    className={`w-fit max-w-[4.5rem] rounded-md ${CATEGORY_COLOR[bgColor]} px-2 py-[2px]`}
+  >
+    {content}
+  </div>
+);
+
+export default CategoryChip;

--- a/frontend/src/components/backlog/CategoryDropdown.tsx
+++ b/frontend/src/components/backlog/CategoryDropdown.tsx
@@ -1,0 +1,30 @@
+import { BacklogStatusType } from "../../types/DTO/backlogDTO";
+import BacklogStatusChip from "./BacklogStatusChip";
+
+interface BacklogStatusDropdownProps {
+  onOptionClick: (status: BacklogStatusType) => void;
+}
+
+const BacklogStatusDropdown = ({
+  onOptionClick,
+}: BacklogStatusDropdownProps) => {
+  const statusList: BacklogStatusType[] = ["시작전", "진행중", "완료"];
+
+  return (
+    <div className="rounded-md w-fit shadow-box">
+      <ul>
+        {...statusList.map((status) => (
+          <li
+            className="p-2 hover:cursor-pointer hover:bg-gray-100"
+            key={status}
+            onClick={() => onOptionClick(status)}
+          >
+            <BacklogStatusChip status={status} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default BacklogStatusDropdown;

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -1,0 +1,59 @@
+import { ChangeEvent, useState } from "react";
+import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+import CategoryChip from "./CategoryChip";
+import TrashCan from "../../assets/icons/trash-can.svg?react";
+
+interface EpicDropdownProps {
+  selectedEpic?: EpicCategoryDTO;
+  epicList: EpicCategoryDTO[];
+}
+
+const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
+  const [value, setValue] = useState("");
+
+  const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    const { value } = target;
+
+    setValue(value);
+  };
+
+  return (
+    <div className="p-1 rounded-md w-72 shadow-box">
+      <div className="flex p-1 border-b-2">
+        {selectedEpic && (
+          <div className="min-w-[5rem]">
+            <CategoryChip
+              content={selectedEpic.name}
+              bgColor={selectedEpic.color}
+            />
+          </div>
+        )}
+        <input
+          className="w-full outline-none"
+          type="text"
+          placeholder={!selectedEpic ? "에픽" : ""}
+          value={value}
+          onChange={handleInputChange}
+        />
+      </div>
+      <ul className="pt-1">
+        {...epicList.map((epic) => (
+          <li
+            className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100"
+            key={epic.id}
+          >
+            <CategoryChip content={epic.name} bgColor={epic.color} />
+            <button
+              className="invisible px-1 group-hover:visible"
+              type="button"
+            >
+              <TrashCan width={20} height={20} fill="red" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default EpicDropdown;

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -1,7 +1,12 @@
 import { ChangeEvent, useState } from "react";
+import { useOutletContext } from "react-router-dom";
+import { Socket } from "socket.io-client";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import CategoryChip from "./CategoryChip";
-import TrashCan from "../../assets/icons/trash-can.svg?react";
+import useEpicEmitEvent from "../../hooks/pages/backlog/useEpicEmitEvent";
+import { CATEGORY_COLOR } from "../../constants/backlog";
+import getRandomNumber from "../../utils/getRandomNumber";
+import { BacklogCategoryColor } from "../../types/common/backlog";
 
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
@@ -9,12 +14,29 @@ interface EpicDropdownProps {
 }
 
 const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
+  const { socket }: { socket: Socket } = useOutletContext();
+  const { emitEpicCreateEvent } = useEpicEmitEvent(socket);
   const [value, setValue] = useState("");
 
   const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const { value } = target;
 
     setValue(value);
+  };
+
+  const handleEnterKeydown = (event: React.KeyboardEvent) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
+    if (event.key === "Enter" && value) {
+      setValue("");
+      const colors = Object.keys(CATEGORY_COLOR);
+      const color = colors[
+        getRandomNumber(0, colors.length - 1)
+      ] as BacklogCategoryColor;
+      emitEpicCreateEvent({ name: value, color });
+    }
   };
 
   return (
@@ -34,21 +56,16 @@ const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
           placeholder={!selectedEpic ? "에픽" : ""}
           value={value}
           onChange={handleInputChange}
+          onKeyDown={handleEnterKeydown}
         />
       </div>
       <ul className="pt-1">
         {...epicList.map((epic) => (
           <li
-            className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100"
+            className="flex justify-between px-1 py-1 rounded-md hover:cursor-pointer hover:bg-gray-100"
             key={epic.id}
           >
             <CategoryChip content={epic.name} bgColor={epic.color} />
-            <button
-              className="invisible px-1 group-hover:visible"
-              type="button"
-            >
-              <TrashCan width={20} height={20} fill="red" />
-            </button>
           </li>
         ))}
       </ul>

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -7,6 +7,7 @@ import useEpicEmitEvent from "../../hooks/pages/backlog/useEpicEmitEvent";
 import { CATEGORY_COLOR } from "../../constants/backlog";
 import getRandomNumber from "../../utils/getRandomNumber";
 import { BacklogCategoryColor } from "../../types/common/backlog";
+import EpicDropdownOption from "./EpicDropdownOption";
 
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
@@ -40,7 +41,7 @@ const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
   };
 
   return (
-    <div className="p-1 rounded-md w-72 shadow-box">
+    <div className="relative p-1 rounded-md w-72 shadow-box">
       <div className="flex p-1 border-b-2">
         {selectedEpic && (
           <div className="min-w-[5rem]">
@@ -61,12 +62,7 @@ const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
       </div>
       <ul className="pt-1">
         {...epicList.map((epic) => (
-          <li
-            className="flex justify-between px-1 py-1 rounded-md hover:cursor-pointer hover:bg-gray-100"
-            key={epic.id}
-          >
-            <CategoryChip content={epic.name} bgColor={epic.color} />
-          </li>
+          <EpicDropdownOption key={epic.id} epic={epic} />
         ))}
       </ul>
     </div>

--- a/frontend/src/components/backlog/EpicDropdownOption.tsx
+++ b/frontend/src/components/backlog/EpicDropdownOption.tsx
@@ -1,0 +1,47 @@
+import CategoryChip from "./CategoryChip";
+import MenuKebab from "../../assets/icons/menu-kebab.svg?react";
+import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
+import EpicUpdateBox from "./EpicUpdateBox";
+import { useRef } from "react";
+
+interface EpicDropdownOptionProps {
+  epic: EpicCategoryDTO;
+}
+
+const EpicDropdownOption = ({ epic }: EpicDropdownOptionProps) => {
+  const { open, handleOpen, handleClose } = useDropdownState();
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleMenuButtonClick = () => {
+    handleOpen();
+  };
+
+  return (
+    <>
+      <li
+        className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100"
+        key={epic.id}
+      >
+        <CategoryChip content={epic.name} bgColor={epic.color} />
+        <button
+          className="invisible px-1 rounded-md group-hover:visible hover:bg-gray-300"
+          type="button"
+          onClick={handleMenuButtonClick}
+          ref={buttonRef}
+        >
+          <MenuKebab width={20} height={20} stroke="#696969" />
+        </button>
+      </li>
+      {open && (
+        <EpicUpdateBox
+          epic={epic}
+          onBoxClose={handleClose}
+          buttonRef={buttonRef}
+        />
+      )}
+    </>
+  );
+};
+
+export default EpicDropdownOption;

--- a/frontend/src/components/backlog/EpicUpdateBox.tsx
+++ b/frontend/src/components/backlog/EpicUpdateBox.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from "react";
+import TrashCan from "../../assets/icons/trash-can.svg?react";
+import { CATEGORY_COLOR } from "../../constants/backlog";
+import { useModal } from "../../hooks/common/modal/useModal";
+import ConfirmModal from "../common/ConfirmModal";
+import { useOutletContext } from "react-router-dom";
+import { Socket } from "socket.io-client";
+import useEpicEmitEvent from "../../hooks/pages/backlog/useEpicEmitEvent";
+import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+import Check from "../../assets/icons/check.svg?react";
+import { BacklogCategoryColor } from "../../types/common/backlog";
+
+interface EpicUpdateBoxProps {
+  epic: EpicCategoryDTO;
+  onBoxClose: () => void;
+  buttonRef: React.MutableRefObject<HTMLButtonElement | null>;
+}
+
+const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
+  const { open, close } = useModal();
+  const { socket }: { socket: Socket } = useOutletContext();
+  const { emitEpicDeleteEvent, emitEpicUpdateEvent } = useEpicEmitEvent(socket);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const colorList = Object.entries(CATEGORY_COLOR);
+
+  const handleConfirmButtonClick = () => {
+    emitEpicDeleteEvent({ id: epic.id });
+    close();
+  };
+
+  const handleDeleteButtonClick = () => {
+    open(
+      <ConfirmModal
+        title="에픽을 삭제하시겠습니까?"
+        body="해당 에픽에 포함된 스토리도 모두 삭제됩니다."
+        confirmText="삭제"
+        cancelText="취소"
+        confirmColor="#E33535"
+        cancelColor="#C6C6C6"
+        onCancelButtonClick={close}
+        onConfirmButtonClick={handleConfirmButtonClick}
+      />
+    );
+  };
+
+  const handleEnterKeydown = (event: React.KeyboardEvent) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
+    if (event.key === "Enter" && inputRef.current?.value) {
+      emitEpicUpdateEvent({ id: epic.id, name: inputRef.current?.value });
+    }
+  };
+
+  const handleColorUpdate = (color: BacklogCategoryColor) => {
+    if (epic.color === color) {
+      return;
+    }
+
+    emitEpicUpdateEvent({ id: epic.id, color });
+  };
+
+  const handleOutsideClick = ({ target }: MouseEvent) => {
+    if (buttonRef.current && buttonRef.current.contains(target as Node)) {
+      return;
+    }
+    if (boxRef.current && !boxRef.current.contains(target as Node)) {
+      onBoxClose();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("click", handleOutsideClick);
+
+    return () => {
+      window.removeEventListener("click", handleOutsideClick);
+    };
+  }, []);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={boxRef}
+      className="absolute top-0 z-10 p-2 bg-white rounded-md left-3/4 w-fit shadow-box"
+    >
+      <p className="text-xxs text-text-gray">에픽 수정</p>
+      <input
+        className="p-1 mb-2 border-b rounded-sm border-b-text-gray focus:outline-none"
+        type="text"
+        ref={inputRef}
+        onKeyDown={handleEnterKeydown}
+      />
+      <ul>
+        {...colorList.map(([name, color]) => (
+          <li
+            key={color}
+            className="flex items-center gap-2 pl-1 pr-2 mb-1 rounded-md hover:cursor-pointer hover:bg-gray-100"
+            onClick={() => handleColorUpdate(name as BacklogCategoryColor)}
+          >
+            <div className={`w-5 h-5 rounded-md ${color}`}></div>
+            <span>{name}</span>
+            {epic.color === name && (
+              <Check
+                width={16}
+                height={16}
+                className="ml-auto"
+                stroke="black"
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+      <button
+        className="flex items-center w-full gap-2 mt-2 rounded-md hover:bg-red-50 text-error-red"
+        type="button"
+        onClick={handleDeleteButtonClick}
+      >
+        <TrashCan width={20} height={20} fill="red" />
+        <span>삭제</span>
+      </button>
+    </div>
+  );
+};
+
+export default EpicUpdateBox;

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -1,0 +1,46 @@
+import ChevronDown from "../../assets/icons/chevron-down.svg?react";
+import { BacklogStatusType } from "../../types/DTO/backlogDTO";
+import BacklogStatusChip from "./BacklogStatusChip";
+import CategoryChip from "./CategoryChip";
+
+interface StoryBlockProps {
+  epic: string;
+  title: string;
+  point: number;
+  progress: number;
+  status: BacklogStatusType;
+}
+
+const StoryBlock = ({
+  epic,
+  title,
+  point,
+  progress,
+  status,
+}: StoryBlockProps) => (
+  <div className="flex items-center gap-5 py-1 border-t border-b">
+    <div className="w-[5rem]">
+      <CategoryChip content={epic} bgColor="green" />
+    </div>
+    <div className="flex items-center gap-1 w-[38.75rem]">
+      <button
+        className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
+        type="button"
+      >
+        <ChevronDown width={16} height={16} fill="black" />
+      </button>
+      <p>{title}</p>
+    </div>
+    <div className="w-[4rem] text-right">
+      <p className="">{point} POINT</p>
+    </div>
+    <div className="w-[4rem] text-right">
+      <span>{progress}%</span>
+    </div>
+    <div className="w-[4rem]">
+      <BacklogStatusChip status={status} />
+    </div>
+  </div>
+);
+
+export default StoryBlock;

--- a/frontend/src/components/backlog/StoryCreateButton.tsx
+++ b/frontend/src/components/backlog/StoryCreateButton.tsx
@@ -1,0 +1,3 @@
+const StoryCreateButton = () => <div></div>;
+
+export default StoryCreateButton;

--- a/frontend/src/components/backlog/StoryCreateButton.tsx
+++ b/frontend/src/components/backlog/StoryCreateButton.tsx
@@ -1,3 +1,18 @@
-const StoryCreateButton = () => <div></div>;
+import Plus from "../../assets/icons/plus.svg?react";
+
+interface StoryCreateButtonProps {
+  onClick: () => void;
+}
+
+const StoryCreateButton = ({ onClick }: StoryCreateButtonProps) => (
+  <button
+    type="button"
+    className="flex items-center justify-center w-full gap-2 py-1 rounded-md bg-middle-green"
+    onClick={onClick}
+  >
+    <Plus width={24} height={24} stroke="white" />
+    <span className="text-white">Story 생성하기</span>
+  </button>
+);
 
 export default StoryCreateButton;

--- a/frontend/src/components/backlog/StoryCreateForm.tsx
+++ b/frontend/src/components/backlog/StoryCreateForm.tsx
@@ -1,0 +1,34 @@
+import Check from "../../assets/icons/check.svg?react";
+import Closed from "../../assets/icons/closed.svg?react";
+import CategoryChip from "./CategoryChip";
+
+const StoryCreateForm = () => (
+  <div className="flex items-center gap-5 py-1 border-t border-b">
+    <div className="w-[5rem]">
+      <CategoryChip content="프로젝트" bgColor="green" />
+    </div>
+    <input className="w-[38.75rem]" type="text" />
+    <div className="flex items-center ">
+      <input className="w-14" type="number" id="point-number" />
+      <label htmlFor="point-number" className="">
+        POINT
+      </label>
+    </div>
+    <div className="flex items-center gap-2">
+      <button
+        className="flex items-center justify-center w-6 h-6 rounded-md bg-confirm-green"
+        type="button"
+      >
+        <Check width={20} height={20} stroke="white" />
+      </button>
+      <button
+        className="flex items-center justify-center w-6 h-6 rounded-md bg-error-red"
+        type="button"
+      >
+        <Closed stroke="white" />
+      </button>
+    </div>
+  </div>
+);
+
+export default StoryCreateForm;

--- a/frontend/src/components/backlog/TabButton.tsx
+++ b/frontend/src/components/backlog/TabButton.tsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+interface TabButtonProps {
+  title: string;
+  active: boolean;
+  link: string;
+}
+
+const TabButton = ({ title, active, link }: TabButtonProps) => (
+  <Link to={link}>
+    <span className={`${active ? "text-middle-green" : "text-text-gray"}`}>
+      {title}
+    </span>
+  </Link>
+);
+
+export default TabButton;

--- a/frontend/src/components/backlog/TaskBlock.tsx
+++ b/frontend/src/components/backlog/TaskBlock.tsx
@@ -1,0 +1,33 @@
+import { TaskDTO } from "../../types/DTO/backlogDTO";
+import BacklogStatusChip from "./BacklogStatusChip";
+import CategoryChip from "./CategoryChip";
+
+const TaskBlock = ({
+  displayId,
+  title,
+  assignedMemberId,
+  expectedTime,
+  actualTime,
+  status,
+}: TaskDTO) => (
+  <div className="flex items-center justify-between py-1 border-b">
+    <p className="w-12">Task-{displayId}</p>
+    <p className="w-[25rem]">{title}</p>
+    <div className="w-12">
+      {assignedMemberId && (
+        <CategoryChip content={`${assignedMemberId}`} bgColor="green" />
+      )}
+    </div>
+    <div className="w-16 ">
+      <p className="max-w-full text-right">{expectedTime}</p>
+    </div>
+    <div className="w-16 ">
+      <p className="max-w-full text-right">{actualTime}</p>
+    </div>
+    <div className="w-[6.25rem]">
+      <BacklogStatusChip status={status} />
+    </div>
+  </div>
+);
+
+export default TaskBlock;

--- a/frontend/src/components/backlog/TaskContainer.tsx
+++ b/frontend/src/components/backlog/TaskContainer.tsx
@@ -1,0 +1,5 @@
+const TaskContainer = ({ children }: { children: React.ReactNode }) => (
+  <div className="w-[60.15rem] ml-auto">{children}</div>
+);
+
+export default TaskContainer;

--- a/frontend/src/components/backlog/TaskCreateButton.tsx
+++ b/frontend/src/components/backlog/TaskCreateButton.tsx
@@ -1,0 +1,15 @@
+import Plus from "../../assets/icons/plus.svg?react";
+
+const TaskCreateButton = () => (
+  <div className="py-1 border-b text-dark-gray">
+    <button
+      className="flex items-center justify-center w-full gap-1"
+      type="button"
+    >
+      <Plus width={24} height={24} stroke="#696969" />
+      <p>Task 생성하기</p>
+    </button>
+  </div>
+);
+
+export default TaskCreateButton;

--- a/frontend/src/components/backlog/TaskHeader.tsx
+++ b/frontend/src/components/backlog/TaskHeader.tsx
@@ -1,0 +1,12 @@
+const TaskHeader = () => (
+  <div className="flex items-center justify-between py-1 border-b text-dark-gray">
+    <p className="w-12">식별자</p>
+    <p className="w-[25rem]">태스크 이름</p>
+    <p className="w-12">담당자</p>
+    <p className="w-16">예상 시간</p>
+    <p className="w-16">실제 시간</p>
+    <p className="w-[6.25rem]">상태</p>
+  </div>
+);
+
+export default TaskHeader;

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,46 @@
+interface ConfirmModalProps {
+  title: string;
+  body: string;
+  confirmText: string;
+  cancelText: string;
+  confirmColor: string;
+  cancelColor: string;
+  onConfirmButtonClick: () => void;
+  onCancelButtonClick: () => void;
+}
+
+const ConfirmModal = ({
+  title,
+  body,
+  confirmText,
+  cancelText,
+  confirmColor,
+  cancelColor,
+  onConfirmButtonClick,
+  onCancelButtonClick,
+}: ConfirmModalProps) => (
+  <div className="fixed top-0 left-0 z-10 flex items-center justify-center w-screen h-screen bg-black bg-opacity-30">
+    <div className="flex flex-col gap-2 px-4 py-6 rounded-md w-[30rem] bg-white shadow-box">
+      <h1 className="text-m">{title}</h1>
+      <p>{body}</p>
+      <div className="flex items-center self-end gap-2 text-white">
+        <button
+          className={`w-fit py-1 px-2 rounded-md bg-[${cancelColor}]`}
+          onClick={onCancelButtonClick}
+          type="button"
+        >
+          {cancelText}
+        </button>
+        <button
+          className={`w-fit py-1 px-2 rounded-md bg-[${confirmColor}]`}
+          onClick={onConfirmButtonClick}
+          type="button"
+        >
+          {confirmText}
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default ConfirmModal;

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -28,6 +28,7 @@ const ConfirmModal = ({
           className={`w-fit py-1 px-2 rounded-md bg-[${cancelColor}]`}
           onClick={onCancelButtonClick}
           type="button"
+          style={{ backgroundColor: cancelColor }}
         >
           {cancelText}
         </button>
@@ -35,6 +36,7 @@ const ConfirmModal = ({
           className={`w-fit py-1 px-2 rounded-md bg-[${confirmColor}]`}
           onClick={onConfirmButtonClick}
           type="button"
+          style={{ backgroundColor: confirmColor }}
         >
           {confirmText}
         </button>

--- a/frontend/src/components/main/PageLinkIcons.tsx
+++ b/frontend/src/components/main/PageLinkIcons.tsx
@@ -6,35 +6,33 @@ import SettingIcon from "../../assets/icons/settings.svg?react";
 import { LINK_URL } from "../../constants/path";
 import { ProjectSidebarProps } from "../../types/common/main";
 
-const PageLinkIcons = ({ pathname, projectId }: ProjectSidebarProps) => {
-  return (
-    <div className="flex flex-col pl-[0.9375rem] pt-[1.5625rem] w-[5.3125rem] gap-5">
-      <PageIcon
-        Icon={LandingIcon}
-        activated={pathname === LINK_URL.MAIN(projectId)}
-        to={LINK_URL.MAIN(projectId)}
-        pageName="메인페이지"
-      />
-      <PageIcon
-        Icon={BacklogIcon}
-        activated={pathname === LINK_URL.BACKLOG(projectId)}
-        to={LINK_URL.BACKLOG(projectId)}
-        pageName="백로그"
-      />
-      <PageIcon
-        Icon={SprintIcon}
-        activated={pathname === LINK_URL.SPRINT(projectId)}
-        to={LINK_URL.SPRINT(projectId)}
-        pageName="스프린트"
-      />
-      <PageIcon
-        Icon={SettingIcon}
-        activated={pathname === LINK_URL.SETTINGS(projectId)}
-        to={LINK_URL.SETTINGS(projectId)}
-        pageName="프로젝트 설정"
-      />
-    </div>
-  );
-};
+const PageLinkIcons = ({ pathname, projectId }: ProjectSidebarProps) => (
+  <div className="flex flex-col pl-[0.9375rem] pt-[1.5625rem] w-[5.3125rem] gap-5">
+    <PageIcon
+      Icon={LandingIcon}
+      activated={pathname === LINK_URL.MAIN(projectId)}
+      to={LINK_URL.MAIN(projectId)}
+      pageName="메인페이지"
+    />
+    <PageIcon
+      Icon={BacklogIcon}
+      activated={pathname.split("/").includes("backlog")}
+      to={LINK_URL.BACKLOG(projectId)}
+      pageName="백로그"
+    />
+    <PageIcon
+      Icon={SprintIcon}
+      activated={pathname === LINK_URL.SPRINT(projectId)}
+      to={LINK_URL.SPRINT(projectId)}
+      pageName="스프린트"
+    />
+    <PageIcon
+      Icon={SettingIcon}
+      activated={pathname === LINK_URL.SETTINGS(projectId)}
+      to={LINK_URL.SETTINGS(projectId)}
+      pageName="프로젝트 설정"
+    />
+  </div>
+);
 
 export default PageLinkIcons;

--- a/frontend/src/constants/backlog.ts
+++ b/frontend/src/constants/backlog.ts
@@ -1,0 +1,30 @@
+export const BACKLOG_STATUS_DISPLAY = {
+  시작전: {
+    bgColor: "bg-[#E3E2E0]",
+    dotColor: "bg-[#91918E]",
+  },
+  진행중: {
+    bgColor: "bg-[#D3E5EF]",
+    dotColor: "bg-[#5B97BD]",
+  },
+  완료: {
+    bgColor: "bg-[#DBEDDB]",
+    dotColor: "bg-[#6C9B7D]",
+  },
+};
+
+export const CATEGORY_COLOR = {
+  red: "bg-[#FFE2DD]",
+  orange: "bg-[#FADEC9]",
+  yellow: "bg-[#FDECC8]",
+  green: "bg-[#DBEDDB]",
+  blue: "bg-[#D3E5EF]",
+  purple: "bg-[#E8DEEE]",
+  gray: "bg-[#E3E2E0]",
+};
+
+export const TAB_TITLE = {
+  backlog: "스토리별",
+  epic: "에픽별",
+  completed: "완료된 스토리",
+};

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -21,7 +21,11 @@ export const ROUTER_URL = {
   PROJECTS: "/projects",
   PROJECTS_CREATE: "projects/create",
   MAIN: "/projects/:projectId",
-  BACKLOG: "/projects/:projectId/backlog",
+  BACKLOG: {
+    BASE: "/projects/:projectId/backlog",
+    EPIC: "/projects/:projectId/backlog/epic",
+    COMPLETED: "/projects/:projectId/backlog/completed",
+  },
   SPRINT: "/projects/:projectId/sprint",
   SPRINT_CREATE: "/projects/:projectId/sprint/create",
   SETTINGS: "/projects/:projectId/settings",

--- a/frontend/src/hooks/common/dropdown/useDropdownState.ts
+++ b/frontend/src/hooks/common/dropdown/useDropdownState.ts
@@ -13,8 +13,6 @@ const useDropdownState = () => {
   };
 
   const handleOutsideClick = ({ target }: MouseEvent) => {
-    console.log(dropdownRef.current);
-
     if (dropdownRef.current && !dropdownRef.current.contains(target as Node)) {
       setOpen(false);
     }

--- a/frontend/src/hooks/common/dropdown/useDropdownState.ts
+++ b/frontend/src/hooks/common/dropdown/useDropdownState.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from "react";
+
+const useDropdownState = () => {
+  const [open, setOpen] = useState<boolean>(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleOutsideClick = ({ target }: MouseEvent) => {
+    console.log(dropdownRef.current);
+
+    if (dropdownRef.current && !dropdownRef.current.contains(target as Node)) {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("click", handleOutsideClick);
+
+    return () => {
+      window.removeEventListener("click", handleOutsideClick);
+    };
+  }, []);
+
+  return { open, dropdownRef, handleOpen, handleClose };
+};
+
+export default useDropdownState;

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { Socket } from "socket.io-client";
+import { BacklogDTO, EpicDTO } from "../../../types/DTO/backlogDTO";
+import {
+  BacklogSocketData,
+  BacklogSocketDomain,
+  BacklogSocketEpicAction,
+} from "../../../types/common/backlog";
+
+const useBacklogSocket = (socket: Socket) => {
+  const [backlog, setBacklog] = useState<BacklogDTO>({ epicList: [] });
+
+  const handleInitEvent = (content: { backlog: BacklogDTO }) => {
+    if (!Object.keys(content).length) {
+      return;
+    }
+    setBacklog(content.backlog);
+  };
+
+  const handleEpicEvent = (
+    action: BacklogSocketEpicAction,
+    content: EpicDTO
+  ) => {
+    switch (action) {
+      case BacklogSocketEpicAction.CREATE:
+        const newEpic = { ...content, storyList: [] };
+        setBacklog((prevBacklog) => ({
+          epicList: [...prevBacklog.epicList, newEpic],
+        }));
+        break;
+      case BacklogSocketEpicAction.DELETE:
+        setBacklog((prevBacklog) => ({
+          epicList: prevBacklog.epicList.filter(({ id }) => id !== content.id),
+        }));
+        break;
+      case BacklogSocketEpicAction.UPDATE:
+        setBacklog((prevBacklog) => ({
+          epicList: prevBacklog.epicList.map((epic) => {
+            if (epic.id === content.id) {
+              return { ...epic, ...content };
+            }
+            return epic;
+          }),
+        }));
+        break;
+    }
+  };
+
+  const handleOnBacklog = ({ domain, action, content }: BacklogSocketData) => {
+    switch (domain) {
+      case BacklogSocketDomain.BACKLOG:
+        handleInitEvent(content);
+        break;
+      case BacklogSocketDomain.EPIC:
+        handleEpicEvent(action, content);
+        break;
+    }
+  };
+
+  useEffect(() => {
+    socket.emit("joinBacklog");
+    socket.on("backlog", handleOnBacklog);
+
+    return () => {
+      socket.off("backlog", handleOnBacklog);
+    };
+  }, []);
+
+  return { backlog };
+};
+
+export default useBacklogSocket;

--- a/frontend/src/hooks/pages/backlog/useEpicEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useEpicEmitEvent.ts
@@ -1,0 +1,31 @@
+import { Socket } from "socket.io-client";
+import { BacklogCategoryColor } from "../../../types/common/backlog";
+
+const useEpicEmitEvent = (socket: Socket) => {
+  const emitEpicCreateEvent = (content: {
+    name: string;
+    color: BacklogCategoryColor;
+  }) => {
+    socket.emit("epic", { action: "create", content });
+  };
+
+  const emitEpicDeleteEvent = (content: { id: number }) => {
+    socket.emit("epic", { action: "delete", content });
+  };
+
+  const emitEpicUpdateEvent = (content: {
+    id: number;
+    name?: string;
+    color?: BacklogCategoryColor;
+  }) => {
+    socket.emit("epic", { action: "update", content });
+  };
+
+  return {
+    emitEpicCreateEvent,
+    emitEpicDeleteEvent,
+    emitEpicUpdateEvent,
+  };
+};
+
+export default useEpicEmitEvent;

--- a/frontend/src/pages/backlog/BacklogPage.tsx
+++ b/frontend/src/pages/backlog/BacklogPage.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import BacklogHeader from "../../components/backlog/BacklogHeader";
+
+const BacklogPage = () => (
+  <div>
+    <BacklogHeader />
+    <Outlet />
+  </div>
+);
+
+export default BacklogPage;

--- a/frontend/src/pages/backlog/BacklogPage.tsx
+++ b/frontend/src/pages/backlog/BacklogPage.tsx
@@ -1,11 +1,19 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useOutletContext } from "react-router-dom";
 import BacklogHeader from "../../components/backlog/BacklogHeader";
+import useBacklogSocket from "../../hooks/pages/backlog/useBacklogSocket";
+import { Socket } from "socket.io-client";
 
-const BacklogPage = () => (
-  <div>
-    <BacklogHeader />
-    <Outlet />
-  </div>
-);
+const BacklogPage = () => {
+  const { socket }: { socket: Socket } = useOutletContext();
+  const { backlog } = useBacklogSocket(socket);
+
+  return (
+    <div>
+      {JSON.stringify(backlog)}
+      <BacklogHeader />
+      <Outlet context={{ socket, backlog }} />
+    </div>
+  );
+};
 
 export default BacklogPage;

--- a/frontend/src/pages/backlog/UncompletedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UncompletedStoryPage.tsx
@@ -1,3 +1,0 @@
-const UncompletedStoryPage = () => <div>backlog Page</div>;
-
-export default UncompletedStoryPage;

--- a/frontend/src/pages/backlog/UncompletedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UncompletedStoryPage.tsx
@@ -1,0 +1,3 @@
+const UncompletedStoryPage = () => <div>backlog Page</div>;
+
+export default UncompletedStoryPage;

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -1,3 +1,17 @@
-const UnfinishedStoryPage = () => <div>UnfinishedStoryPage</div>;
+import EpicDropdown from "../../components/backlog/EpicDropdown";
+
+const UnfinishedStoryPage = () => (
+  <div>
+    UnfinishedStoryPage
+    <EpicDropdown
+      selectedEpic={{ id: 1, name: "프로젝트", color: "gray" }}
+      epicList={[
+        { id: 2, name: "백로그", color: "gray" },
+        { id: 3, name: "에픽", color: "green" },
+        { id: 4, name: "스토리", color: "red" },
+      ]}
+    />
+  </div>
+);
 
 export default UnfinishedStoryPage;

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -1,0 +1,3 @@
+const UnfinishedStoryPage = () => <div>UnfinishedStoryPage</div>;
+
+export default UnfinishedStoryPage;

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -1,17 +1,3 @@
-import EpicDropdown from "../../components/backlog/EpicDropdown";
-
-const UnfinishedStoryPage = () => (
-  <div>
-    UnfinishedStoryPage
-    <EpicDropdown
-      selectedEpic={{ id: 1, name: "프로젝트", color: "gray" }}
-      epicList={[
-        { id: 2, name: "백로그", color: "gray" },
-        { id: 3, name: "에픽", color: "green" },
-        { id: 4, name: "스토리", color: "red" },
-      ]}
-    />
-  </div>
-);
+const UnfinishedStoryPage = () => <div>UnfinishedStoryPage</div>;
 
 export default UnfinishedStoryPage;

--- a/frontend/src/types/DTO/backlogDTO.ts
+++ b/frontend/src/types/DTO/backlogDTO.ts
@@ -16,7 +16,7 @@ export interface TaskDTO {
   expectedTime: number | null;
   actualTime: number | null;
   status: BacklogStatusType;
-  assignedMemberId: number;
+  assignedMemberId: number | null;
 }
 
 export interface StoryDTO {
@@ -27,9 +27,12 @@ export interface StoryDTO {
   taskList: TaskDTO[];
 }
 
-export interface EpicDTO {
+export interface EpicCategoryDTO {
   id: number;
   name: string;
   color: EpicColor;
+}
+
+export interface EpicDTO extends EpicCategoryDTO {
   storyList: StoryDTO[];
 }

--- a/frontend/src/types/DTO/backlogDTO.ts
+++ b/frontend/src/types/DTO/backlogDTO.ts
@@ -36,3 +36,7 @@ export interface EpicCategoryDTO {
 export interface EpicDTO extends EpicCategoryDTO {
   storyList: StoryDTO[];
 }
+
+export interface BacklogDTO {
+  epicList: EpicDTO[];
+}

--- a/frontend/src/types/DTO/backlogDTO.ts
+++ b/frontend/src/types/DTO/backlogDTO.ts
@@ -1,0 +1,35 @@
+export type EpicColor =
+  | "yellow"
+  | "gray"
+  | "red"
+  | "purple"
+  | "blue"
+  | "green"
+  | "orange";
+
+export type BacklogStatusType = "시작전" | "진행중" | "완료";
+
+export interface TaskDTO {
+  id: number;
+  displayId: number;
+  title: string;
+  expectedTime: number | null;
+  actualTime: number | null;
+  status: BacklogStatusType;
+  assignedMemberId: number;
+}
+
+export interface StoryDTO {
+  id: number;
+  title: string;
+  point: number | null;
+  status: BacklogStatusType;
+  taskList: TaskDTO[];
+}
+
+export interface EpicDTO {
+  id: number;
+  name: string;
+  color: EpicColor;
+  storyList: StoryDTO[];
+}

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -1,0 +1,1 @@
+export type BacklogPath = "backlog" | "epic" | "completed";

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -1,1 +1,39 @@
+import { BacklogDTO, EpicDTO } from "../DTO/backlogDTO";
+
 export type BacklogPath = "backlog" | "epic" | "completed";
+
+export type BacklogCategoryColor =
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "purple"
+  | "gray";
+
+export enum BacklogSocketDomain {
+  BACKLOG = "backlog",
+  EPIC = "epic",
+  STORY = "story",
+  TASK = "task",
+}
+
+export enum BacklogSocketEpicAction {
+  CREATE = "create",
+  DELETE = "delete",
+  UPDATE = "update",
+}
+
+export interface BacklogSocketInitData {
+  domain: BacklogSocketDomain.BACKLOG;
+  action: "init";
+  content: { backlog: BacklogDTO };
+}
+
+export interface BacklogSocketEpicData {
+  domain: BacklogSocketDomain.EPIC;
+  action: BacklogSocketEpicAction;
+  content: EpicDTO;
+}
+
+export type BacklogSocketData = BacklogSocketInitData | BacklogSocketEpicData;

--- a/frontend/src/utils/getRandomNumber.ts
+++ b/frontend/src/utils/getRandomNumber.ts
@@ -1,0 +1,7 @@
+const getRandomNumber = (min: number, max: number) => {
+  const minCeiled = Math.ceil(min);
+  const maxFloored = Math.floor(max);
+  return Math.floor(Math.random() * (maxFloored - minCeiled + 1) + minCeiled);
+};
+
+export default getRandomNumber;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
         "dark-green-linear-to": "#4D6C52",
         "sidebar-linear-from": "#032809",
         "sidebar-linear-to": "#3C5826",
+        "confirm-green": "#14AE5C",
       },
       fontFamily: {
         pretendard: ["pretendard"],

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -23,6 +23,7 @@ export default {
         "sidebar-linear-from": "#032809",
         "sidebar-linear-to": "#3C5826",
         "confirm-green": "#14AE5C",
+        "confirm-blue": "#0191F2",
       },
       fontFamily: {
         pretendard: ["pretendard"],


### PR DESCRIPTION
## 🎟️ 태스크

- [백로그 페이지 퍼블리싱](https://plastic-toad-cb0.notion.site/300632bd15374a53ab812d7d62013bd0)
- [에픽 드롭다운 컴포넌트 생성](https://plastic-toad-cb0.notion.site/a47c0ec9a3f2471385f456e9d607a659)
- [에픽 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-327c4496a55b4d599df52b33b75b3d53)

## ✅ 작업 내용

- 전체적인 백로그 페이지 퍼블리싱
- 에픽 드롭다운 컴포넌트 생성
- 에픽 생성, 수정, 삭제 API 연동

## 🖊️ 구체적인 작업

### 에픽 드롭다운 컴포넌트

- 노션 디자인을 참고해 에픽 드롭다운을 만들었습니다. 해당 드롭다운에서 에픽을 생성할 수 있고, 각 에픽을 누르면 해당 에픽 수정 창이 나옵니다. 수정창에서는 해당 에픽의 색과 이름을 수정할 수 있고, 삭제할 수 있습니다. 삭제할 때는 하위 스토리도 모두 삭제되기 때문에 모달을 띄워 확인 후 삭제되도록 했습니다.
- 에픽은 에픽 리스트에 정보가 담겨서 오며 하위 데이터로 스토리가 존재합니다. 에픽 카테고리만 따로 받지 않기 때문에 Landing 페이지처럼 각 컴포넌트에서 데이터를 처리하는 형식이 아닌 백로그 페이지에서 처리하고 이를 가공해 에픽 드롭다운으로 넘겨주는 방식으로 코드를 작성헸습니다.
- 이벤트 emit 기능까지 한 훅에 넣으면 코드가 길어지고, 추후 스토리와 태스크 기능도 추가하기 위해서는 분리를 하는 편이 좋다고 판단해 따로 훅을 만들었습니다.