### PR TITLE
feat: 스토리 생성, 수정, 삭제 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { MemberRepository } from './member/repository/member.repository';
 import { Memo } from './project/entity/memo.entity';
 import { Link } from './project/entity/link.entity.';
 import { Epic } from './project/entity/epic.entity';
+import { Story } from './project/entity/story.entity';
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { Epic } from './project/entity/epic.entity';
           Memo,
           Link,
           Epic,
+          Story,
         ],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),

--- a/backend/src/project/dto/epic/EpicDeleteRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicDeleteRequest.dto.ts
@@ -1,8 +1,8 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsNumber, Matches, ValidateNested } from 'class-validator';
+import { IsInt, IsNotEmpty, Matches, ValidateNested } from 'class-validator';
 
 class Epic {
-  @IsNumber()
+  @IsInt()
   id: number;
 }
 

--- a/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import {
   IsEnum,
   IsNotEmpty,
-  IsNumber,
+  IsInt,
   IsOptional,
   IsString,
   Matches,
@@ -12,7 +12,7 @@ import { EpicColor } from 'src/project/entity/epic.entity';
 
 class Epic {
   @IsNotEmpty()
-  @IsNumber()
+  @IsInt()
   id: number;
 
   @IsOptional()

--- a/backend/src/project/dto/link/LinkDeleteRequest.dto.ts
+++ b/backend/src/project/dto/link/LinkDeleteRequest.dto.ts
@@ -1,8 +1,8 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsNumber, Matches, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsInt, Matches, ValidateNested } from 'class-validator';
 
 class Link {
-  @IsNumber()
+  @IsInt()
   id: number;
 }
 

--- a/backend/src/project/dto/member/MemberUpdateRequest.dto.ts
+++ b/backend/src/project/dto/member/MemberUpdateRequest.dto.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import {
   IsEnum,
   IsNotEmpty,
-  IsNumber,
+  IsInt,
   IsOptional,
   IsString,
   Matches,
@@ -11,7 +11,7 @@ import {
 import { MemberStatus } from '../../enum/MemberStatus.enum';
 
 class Content {
-  @IsNumber()
+  @IsInt()
   id: number;
 
   @IsString()

--- a/backend/src/project/dto/memo/MemoColorUpdateRequest.dto.ts
+++ b/backend/src/project/dto/memo/MemoColorUpdateRequest.dto.ts
@@ -2,14 +2,14 @@ import { Type } from 'class-transformer';
 import {
   IsEnum,
   IsNotEmpty,
-  IsNumber,
+  IsInt,
   Matches,
   ValidateNested,
 } from 'class-validator';
 import { memoColor } from '../../entity/memo.entity';
 
 class Content {
-  @IsNumber()
+  @IsInt()
   id: number;
 
   @IsEnum(memoColor)

--- a/backend/src/project/dto/memo/MemoDeleteRequest.dto.ts
+++ b/backend/src/project/dto/memo/MemoDeleteRequest.dto.ts
@@ -1,8 +1,8 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsNumber, Matches, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsInt, Matches, ValidateNested } from 'class-validator';
 
 class MemoId {
-  @IsNumber()
+  @IsInt()
   id: number;
 }
 

--- a/backend/src/project/dto/story/StoryCreateNotify.dto.ts
+++ b/backend/src/project/dto/story/StoryCreateNotify.dto.ts
@@ -1,0 +1,31 @@
+import { Story, StoryStatus } from 'src/project/entity/story.entity';
+class StoryDto {
+  id: number;
+  title: string;
+  point: number;
+  status: StoryStatus;
+  epicId: number;
+  static of(story: Story) {
+    const dto = new StoryDto();
+    dto.id = story.id;
+    dto.title = story.title;
+    dto.point = story.point;
+    dto.status = story.status;
+    dto.epicId = story.epicId;
+    return dto;
+  }
+}
+
+export class StoryCreateNotifyDto {
+  domain: string;
+  action: string;
+  content: StoryDto;
+
+  static of(story: Story) {
+    const dto = new StoryCreateNotifyDto();
+    dto.domain = 'story';
+    dto.action = 'create';
+    dto.content = StoryDto.of(story);
+    return dto;
+  }
+}

--- a/backend/src/project/dto/story/StoryCreateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryCreateRequest.dto.ts
@@ -1,0 +1,34 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { StoryStatus } from 'src/project/entity/story.entity';
+
+class Story {
+  @IsString()
+  title: string;
+
+  @IsInt()
+  point: number;
+
+  @IsEnum(StoryStatus)
+  status: StoryStatus;
+
+  @IsInt()
+  epicId: number;
+}
+
+export class StoryCreateRequestDto {
+  @Matches(/^create$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Story)
+  content: Story;
+}

--- a/backend/src/project/dto/story/StoryDeleteNotify.dto.ts
+++ b/backend/src/project/dto/story/StoryDeleteNotify.dto.ts
@@ -1,0 +1,22 @@
+class Story {
+  id: number;
+  static of(id: number) {
+    const dto = new Story();
+    dto.id = id;
+    return dto;
+  }
+}
+
+export class StoryDeleteNotifyDto {
+  domain: string;
+  action: string;
+  content: Story;
+
+  static of(id: number) {
+    const dto = new StoryDeleteNotifyDto();
+    dto.domain = 'story';
+    dto.action = 'delete';
+    dto.content = Story.of(id);
+    return dto;
+  }
+}

--- a/backend/src/project/dto/story/StoryDeleteRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryDeleteRequest.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, Matches, ValidateNested } from 'class-validator';
+
+class Story {
+  @IsInt()
+  id: number;
+}
+
+export class StoryDeleteRequestDto {
+  @Matches(/^delete$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Story)
+  content: Story;
+}

--- a/backend/src/project/dto/story/StoryUpdateNotify.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateNotify.dto.ts
@@ -1,0 +1,45 @@
+import { StoryStatus } from 'src/project/entity/story.entity';
+
+class Story {
+  id: number;
+  epicId?: number;
+  title?: string;
+  point?: number;
+  status?: StoryStatus;
+
+  static of(
+    id: number,
+    epicId: number | undefined,
+    title: string | undefined,
+    point: number | undefined,
+    status: StoryStatus | undefined,
+  ) {
+    const dto = new Story();
+    dto.id = id;
+    if (title) dto.title = title;
+    if (point) dto.point = point;
+    if (status) dto.status = status;
+    if (epicId) dto.epicId = epicId;
+    return dto;
+  }
+}
+
+export class StoryUpdateNotifyDto {
+  domain: string;
+  action: string;
+  content: Story;
+
+  static of(
+    id: number,
+    epicId: number | undefined,
+    title: string | undefined,
+    point: number | undefined,
+    status: StoryStatus | undefined,
+  ) {
+    const dto = new StoryUpdateNotifyDto();
+    dto.domain = 'story';
+    dto.action = 'update';
+    dto.content = Story.of(id, epicId, title, point, status);
+    return dto;
+  }
+}

--- a/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
@@ -1,0 +1,42 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { StoryStatus } from 'src/project/entity/story.entity';
+
+class Story {
+  @IsInt()
+  id: number;
+
+  @IsOptional()
+  @IsInt()
+  epicId?: number;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsInt()
+  point?: number;
+
+  @IsOptional()
+  @IsEnum(StoryStatus)
+  status?: StoryStatus;
+}
+
+export class StoryUpdateRequestDto {
+  @Matches(/^update$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Story)
+  content: Story;
+}

--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Epic } from './epic.entity';
+import { Project } from './project.entity';
+
+export enum StoryStatus {
+  NotStarted = '시작전',
+  InProgress = '진행중',
+  Completed = '완료',
+}
+
+@Entity()
+export class Story {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  id: number;
+
+  @Column({ type: 'int', name: 'project_id' })
+  projectId: number;
+
+  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @Column({ type: 'int', name: 'epic_id' })
+  epicId: number;
+
+  @ManyToOne(() => Epic, (epic) => epic.id, { nullable: false })
+  @JoinColumn({ name: 'epic_id' })
+  epic: Epic;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  title: string;
+
+  @Column({ type: 'int', nullable: false })
+  point: number;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  status: StoryStatus;
+
+  static of(
+    project: Project,
+    epicId: number,
+    title: string,
+    point: number,
+    status: StoryStatus,
+  ) {
+    const newStory = new Story();
+    newStory.project = project;
+    newStory.epicId = epicId;
+    newStory.title = title;
+    newStory.point = point;
+    newStory.status = status;
+    return newStory;
+  }
+}

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -18,6 +18,8 @@ import { WsProjectLinkController } from './ws-controller/ws-project-link.control
 import { WsProjectController } from './ws-controller/ws-project.controller';
 import { WsProjectEpicController } from './ws-controller/ws-project-epic.controller';
 import { Epic } from './entity/epic.entity';
+import { Story } from './entity/story.entity';
+import { WsProjectStoryController } from './ws-controller/ws-project-story.controller';
 
 @Module({
   imports: [
@@ -29,6 +31,7 @@ import { Epic } from './entity/epic.entity';
       Memo,
       Link,
       Epic,
+	  Story
     ]),
   ],
   controllers: [ProjectController],
@@ -43,6 +46,7 @@ import { Epic } from './entity/epic.entity';
     WsProjectLinkController,
     WsProjectController,
     WsProjectEpicController,
+	WsProjectStoryController,
   ],
 })
 export class ProjectModule {}

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -8,6 +8,7 @@ import { Memo, memoColor } from './entity/memo.entity';
 import { MemberRepository } from 'src/member/repository/member.repository';
 import { Link } from './entity/link.entity.';
 import { Epic, EpicColor } from './entity/epic.entity';
+import { Story, StoryStatus } from './entity/story.entity';
 
 @Injectable()
 export class ProjectRepository {
@@ -24,6 +25,8 @@ export class ProjectRepository {
     private readonly linkRepository: Repository<Link>,
     @InjectRepository(Epic)
     private readonly epicRepository: Repository<Epic>,
+    @InjectRepository(Story)
+    private readonly storyRepository: Repository<Story>,
   ) {}
 
   create(project: Project): Promise<Project> {
@@ -140,6 +143,54 @@ export class ProjectRepository {
     }
 
     const result = await this.epicRepository.update(
+      { id, project: { id: project.id } },
+      updateData,
+    );
+    return !!result.affected;
+  }
+
+  getEpicById(project: Project, id: number) {
+    return this.epicRepository.findOne({
+      where: { id: id, projectId: project.id },
+    });
+  }
+
+  createStory(story: Story): Promise<Story> {
+    return this.storyRepository.save(story);
+  }
+
+  async deleteStory(project: Project, storyId: number): Promise<number> {
+    const result = await this.storyRepository.delete({
+      project: { id: project.id },
+      id: storyId,
+    });
+    return result.affected ? result.affected : 0;
+  }
+
+  async updateStory(
+    project: Project,
+    id: number,
+    epicId: number | undefined,
+    title: string | undefined,
+    point: number | undefined,
+    status: StoryStatus | undefined,
+  ): Promise<boolean> {
+    const updateData: any = {};
+
+    if (epicId !== undefined) {
+      updateData.epicId = epicId;
+    }
+    if (title !== undefined) {
+      updateData.title = title;
+    }
+    if (point !== undefined) {
+      updateData.point = point;
+    }
+    if (status !== undefined) {
+      updateData.status = status;
+    }
+
+    const result = await this.storyRepository.update(
       { id, project: { id: project.id } },
       updateData,
     );

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -6,6 +6,7 @@ import { ProjectToMember } from '../entity/project-member.entity';
 import { Memo, memoColor } from '../entity/memo.entity';
 import { Link } from '../entity/link.entity.';
 import { Epic, EpicColor } from '../entity/epic.entity';
+import { Story, StoryStatus } from '../entity/story.entity';
 
 @Injectable()
 export class ProjectService {
@@ -110,5 +111,45 @@ export class ProjectService {
     color?: EpicColor,
   ): Promise<boolean> {
     return this.projectRepository.updateEpic(project, id, name, color);
+  }
+
+  createStory(
+    project: Project,
+    epicId: number,
+    title: string,
+    point: number,
+    status: StoryStatus,
+  ) {
+    const epic = this.projectRepository.getEpicById(project, epicId);
+    if (!epic) throw new Error('epic id is not found');
+    const newStory = Story.of(project, epicId, title, point, status);
+    return this.projectRepository.createStory(newStory);
+  }
+
+  async deleteStory(project: Project, storyId: number) {
+    const result = await this.projectRepository.deleteStory(project, storyId);
+    return result ? true : false;
+  }
+
+  updateStory(
+    project: Project,
+    id: number,
+    epicId: number | undefined,
+    title: string | undefined,
+    point: number | undefined,
+    status: StoryStatus | undefined,
+  ): Promise<boolean> {
+    if (epicId !== undefined) {
+      const epic = this.projectRepository.getEpicById(project, epicId);
+      if (!epic) throw new Error('epic id is not found');
+    }
+    return this.projectRepository.updateStory(
+      project,
+      id,
+      epicId,
+      title,
+      point,
+      status,
+    );
   }
 }

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -19,6 +19,7 @@ import { WsProjectLinkController } from './ws-controller/ws-project-link.control
 import { WsProjectController } from './ws-controller/ws-project.controller';
 import { ClientSocket } from './type/ClientSocket.type';
 import { WsProjectEpicController } from './ws-controller/ws-project-epic.controller';
+import { WsProjectStoryController } from './ws-controller/ws-project-story.controller';
 
 @WebSocketGateway({
   namespace: /project-\d+/,
@@ -36,6 +37,7 @@ export class ProjectWebsocketGateway
     private readonly wsProjectLinkController: WsProjectLinkController,
     private readonly wsProjectController: WsProjectController,
     private readonly wsProjectEpicController: WsProjectEpicController,
+    private readonly wsProjectStoryController: WsProjectStoryController,
   ) {
     this.namespaceMap = new Map();
   }
@@ -142,6 +144,21 @@ export class ProjectWebsocketGateway
       this.wsProjectEpicController.deleteEpic(client, data);
     } else if (data.action === 'update') {
       this.wsProjectEpicController.updateEpic(client, data);
+    }
+  }
+
+  @SubscribeMessage('story')
+  async handleStoryEvent(
+    @ConnectedSocket() client: ClientSocket,
+    @MessageBody() data: any,
+  ) {
+    if (data.action === 'create') {
+      this.wsProjectStoryController.createStory(client, data);
+    } else if (data.action === 'delete') {
+      this.wsProjectStoryController.deleteStory(client, data);
+    }
+    else if (data.action === 'update') {
+      this.wsProjectStoryController.updateStory(client, data);
     }
   }
 

--- a/backend/src/project/ws-controller/ws-project-story.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-story.controller.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { plainToClass } from 'class-transformer';
+import { validate } from 'class-validator';
+import { StoryCreateNotifyDto } from '../dto/story/StoryCreateNotify.dto';
+import { StoryCreateRequestDto } from '../dto/story/StoryCreateRequest.dto';
+import { StoryDeleteNotifyDto } from '../dto/story/StoryDeleteNotify.dto';
+import { StoryDeleteRequestDto } from '../dto/story/StoryDeleteRequest.dto';
+import { StoryUpdateNotifyDto } from '../dto/story/StoryUpdateNotify.dto';
+import { StoryUpdateRequestDto } from '../dto/story/StoryUpdateRequest.dto';
+import { ProjectService } from '../service/project.service';
+import { ClientSocket } from '../type/ClientSocket.type';
+import { getRecursiveErrorMsgList } from '../util/validation.util';
+
+@Injectable()
+export class WsProjectStoryController {
+  constructor(private readonly projectService: ProjectService) {}
+  async createStory(client: ClientSocket, data: any) {
+    const errors = await validate(plainToClass(StoryCreateRequestDto, data));
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+    const { content } = data as StoryCreateRequestDto;
+    const createdStory = await this.projectService.createStory(
+      client.project,
+      content.epicId,
+      content.title,
+      content.point,
+      content.status,
+    );
+    client.nsp
+      .to('backlog')
+      .emit('backlog', StoryCreateNotifyDto.of(createdStory));
+  }
+
+  async deleteStory(client: ClientSocket, data: any) {
+    const errors = await validate(plainToClass(StoryDeleteRequestDto, data));
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+    const { content } = data as StoryDeleteRequestDto;
+    const isDeleted = await this.projectService.deleteStory(
+      client.project,
+      content.id,
+    );
+    if (isDeleted) {
+      client.nsp
+        .to('backlog')
+        .emit('backlog', StoryDeleteNotifyDto.of(content.id));
+    }
+  }
+
+  async updateStory(client: ClientSocket, data: any) {
+    const errors = await validate(plainToClass(StoryUpdateRequestDto, data));
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+    const { content } = data as StoryUpdateRequestDto;
+    const isUpdated = await this.projectService.updateStory(
+      client.project,
+      content.id,
+      content.epicId,
+      content.title,
+      content.point,
+      content.status,
+    );
+
+    if (isUpdated) {
+      client.nsp
+        .to('backlog')
+        .emit(
+          'backlog',
+          StoryUpdateNotifyDto.of(
+            content.id,
+            content.epicId,
+            content.title,
+            content.point,
+            content.status,
+          ),
+        );
+    }
+  }
+}

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -1,0 +1,197 @@
+import { Socket } from 'socket.io-client';
+import { app, appInit } from 'test/setup';
+import {
+  getMemberJoinedLandingPage,
+  getTwoMemberJoinedLandingPage,
+} from '../ws-common';
+
+describe('WS story', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  describe('story create', () => {
+    it('should return created story data', async () => {
+      const [socket1, socket2] = await getTwoMemberJoinedLandingPage();
+      socket1.emit('joinBacklog');
+      socket2.emit('joinBacklog');
+      await Promise.all([initBacklog(socket1), initBacklog(socket2)]);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket1.emit('epic', requestData);
+      const [epicId] = await Promise.all([
+        getEpicId(socket1),
+        getEpicId(socket2),
+      ]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket1.emit('story', requestData);
+      await Promise.all([
+        expectCreateStory(socket1, epicId, title, point),
+        expectCreateStory(socket2, epicId, title, point),
+      ]);
+
+      socket1.close();
+      socket2.close();
+    });
+
+    const expectCreateStory = (socket, epicId, title, point) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('story');
+          expect(action).toBe('create');
+          expect(content?.id).toBeDefined();
+          expect(content?.epicId).toBe(epicId);
+          expect(content?.title).toBe(title);
+          expect(content?.point).toBe(point);
+          resolve();
+        });
+      });
+    };
+  });
+
+  describe('story delete', () => {
+    it('should return deleted story data', async () => {
+      const socket = await getMemberJoinedLandingPage();
+      socket.emit('joinBacklog');
+      await initBacklog(socket);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket.emit('epic', requestData);
+      const [epicId] = await Promise.all([getEpicId(socket)]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket.emit('story', requestData);
+      const storyId = await getStoryId(socket);
+      requestData = {
+        action: 'delete',
+        content: { id: storyId },
+      };
+      socket.emit('story', requestData);
+      await expectDeleteStory(socket, storyId);
+
+      socket.close();
+    });
+
+    const expectDeleteStory = (socket, id) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('story');
+          expect(action).toBe('delete');
+          expect(content?.id).toBe(id);
+          resolve();
+        });
+      });
+    };
+  });
+
+  describe('story update', () => {
+    it('should return updated story data when update color', async () => {
+      const socket = await getMemberJoinedLandingPage();
+      socket.emit('joinBacklog');
+      await initBacklog(socket);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket.emit('epic', requestData);
+      const [epicId] = await Promise.all([getEpicId(socket)]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket.emit('story', requestData);
+      const storyId = await getStoryId(socket);
+
+      const newTitle = '뉴타이틀';
+      requestData = {
+        action: 'update',
+        content: { id: storyId, title: newTitle },
+      };
+      socket.emit('story', requestData);
+      await expectTitleUpdateStory(socket, storyId, newTitle);
+
+      socket.close();
+    });
+
+    const expectTitleUpdateStory = (socket, id, title) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          console.log(data);
+          const { content, action, domain } = data;
+          expect(domain).toBe('story');
+          expect(action).toBe('update');
+          expect(content?.id).toBe(id);
+          expect(content?.title).toBe(title);
+          resolve();
+        });
+      });
+    };
+  });
+});
+
+const initBacklog = async (socket: Socket) => {
+  return await new Promise<void>((resolve, reject) => {
+    socket.once('backlog', (data) => {
+      const { action, domain } = data;
+      if (action === 'init' && domain === 'backlog') {
+        resolve();
+      } else reject();
+    });
+  });
+};
+
+const getStoryId = (socket) => {
+  return new Promise((resolve) => {
+    socket.once('backlog', async (data) => {
+      const { content, action, domain } = data;
+      if (domain === 'story' && action === 'create') {
+        resolve(content.id);
+      }
+    });
+  });
+};
+
+const getEpicId = (socket) => {
+  return new Promise((resolve) => {
+    socket.once('backlog', async (data) => {
+      const { content, action, domain } = data;
+      if (domain === 'epic' && action === 'create') {
+        resolve(content.id);
+      }
+    });
+  });
+};


### PR DESCRIPTION
## 🎟️ 태스크

[스토리 생성, 수정, 삭제 API 구현(백엔드)](https://plastic-toad-cb0.notion.site/API-156056a4f8004585aa40f03a32c17906?pvs=74)

## ✅ 작업 내용

- 스토리 생성, 삭제, 업데이트를 구현하기 위해 스토리 엔티티, 레포지토리, 서비스 작성
- 스토리 생성, 삭제, 업데이트 게이트웨이, 컨트롤러, DTO작성
- 스토리 생성, 삭제, 업데이트 E2E 테스트 작성
- id의 유효성 검사 데코레이터를 IsNumber에서 IsInt로 변경

## 🖊️ 구체적인 작업

### 스토리 생성, 삭제, 업데이트를 구현하기 위해 스토리 엔티티, 레포지토리, 서비스 작성
- 스토리 엔티티 작성
- 스토리을 모듈에 추가
- 스토리 create, delete, update 레포지토리, 서비스 메서드 작성
### 스토리 생성, 삭제, 업데이트 게이트웨이, 컨트롤러, DTO작성
- 스토리 이벤트를 처리하는 게이트웨이 로직 추가
- 스토리 생성, 삭제, 업데이트를 처리하는 컨트롤러 추가
- 스토리 생성, 삭제, 업데이트에 대해 요청/응답을 확인/생성하는 request, notify DTO 추가
### 스토리 생성, 삭제, 업데이트 E2E 테스트 작성
### id의 유효성 검사 데코레이터를 IsNumber에서 IsInt로 변경
IsNumber 데코레이터는 소수또한 유효하게 처리하기 때문에 Id 프로퍼티의 유효성 검사 데코레이터를 IsInt로 변경