### PR TITLE
feat: 스토리별 백로그 조회, 스토리 추가 기능 구현

### DIFF
--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -12,9 +12,14 @@ import EpicDropdownOption from "./EpicDropdownOption";
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
   epicList: EpicCategoryDTO[];
+  onEpicSelect: (epicId: number) => void;
 }
 
-const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
+const EpicDropdown = ({
+  selectedEpic,
+  epicList,
+  onEpicSelect,
+}: EpicDropdownProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitEpicCreateEvent } = useEpicEmitEvent(socket);
   const [value, setValue] = useState("");
@@ -40,8 +45,12 @@ const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
     }
   };
 
+  const handleEpicSelect = (epicId: number) => {
+    onEpicSelect(epicId);
+  };
+
   return (
-    <div className="relative p-1 rounded-md w-72 shadow-box">
+    <div className="absolute p-1 bg-white rounded-md w-72 shadow-box">
       <div className="flex p-1 border-b-2">
         {selectedEpic && (
           <div className="min-w-[5rem]">
@@ -62,7 +71,9 @@ const EpicDropdown = ({ selectedEpic, epicList }: EpicDropdownProps) => {
       </div>
       <ul className="pt-1">
         {...epicList.map((epic) => (
-          <EpicDropdownOption key={epic.id} epic={epic} />
+          <li key={epic.id} onClick={() => handleEpicSelect(epic.id)}>
+            <EpicDropdownOption key={epic.id} epic={epic} />
+          </li>
         ))}
       </ul>
     </div>

--- a/frontend/src/components/backlog/EpicDropdownOption.tsx
+++ b/frontend/src/components/backlog/EpicDropdownOption.tsx
@@ -19,10 +19,7 @@ const EpicDropdownOption = ({ epic }: EpicDropdownOptionProps) => {
 
   return (
     <>
-      <li
-        className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100"
-        key={epic.id}
-      >
+      <div className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100">
         <CategoryChip content={epic.name} bgColor={epic.color} />
         <button
           className="invisible px-1 rounded-md group-hover:visible hover:bg-gray-300"
@@ -32,7 +29,7 @@ const EpicDropdownOption = ({ epic }: EpicDropdownOptionProps) => {
         >
           <MenuKebab width={20} height={20} stroke="#696969" />
         </button>
-      </li>
+      </div>
       {open && (
         <EpicUpdateBox
           epic={epic}

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -15,6 +15,7 @@ interface StoryBlockProps {
   progress: number;
   status: BacklogStatusType;
   children: React.ReactNode;
+  taskExist: boolean;
 }
 
 const StoryBlock = ({
@@ -23,6 +24,7 @@ const StoryBlock = ({
   point,
   progress,
   status,
+  taskExist,
   children,
 }: StoryBlockProps) => {
   const { showDetail, handleShowDetail } = useShowDetail();
@@ -40,9 +42,17 @@ const StoryBlock = ({
             onClick={() => handleShowDetail(!showDetail)}
           >
             {showDetail ? (
-              <ChevronDown width={16} height={16} fill="black" />
+              <ChevronDown
+                width={16}
+                height={16}
+                fill={taskExist ? "black" : "#C5C5C5"}
+              />
             ) : (
-              <ChevronRight width={16} height={16} fill="black" />
+              <ChevronRight
+                width={16}
+                height={16}
+                fill={taskExist ? "black" : "#C5C5C5"}
+              />
             )}
           </button>
           <p>{title}</p>

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -1,14 +1,20 @@
-import ChevronDown from "../../assets/icons/chevron-down.svg?react";
+import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import { BacklogStatusType } from "../../types/DTO/backlogDTO";
 import BacklogStatusChip from "./BacklogStatusChip";
 import CategoryChip from "./CategoryChip";
+import TaskCreateButton from "./TaskCreateButton";
+import ChevronDown from "../../assets/icons/chevron-down.svg?react";
+import ChevronRight from "../../assets/icons/chevron-right.svg?react";
+import TaskContainer from "./TaskContainer";
+import TaskHeader from "./TaskHeader";
 
 interface StoryBlockProps {
   epic: string;
   title: string;
-  point: number;
+  point: number | null;
   progress: number;
   status: BacklogStatusType;
+  children: React.ReactNode;
 }
 
 const StoryBlock = ({
@@ -17,30 +23,49 @@ const StoryBlock = ({
   point,
   progress,
   status,
-}: StoryBlockProps) => (
-  <div className="flex items-center gap-5 py-1 border-t border-b">
-    <div className="w-[5rem]">
-      <CategoryChip content={epic} bgColor="green" />
-    </div>
-    <div className="flex items-center gap-1 w-[38.75rem]">
-      <button
-        className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
-        type="button"
-      >
-        <ChevronDown width={16} height={16} fill="black" />
-      </button>
-      <p>{title}</p>
-    </div>
-    <div className="w-[4rem] text-right">
-      <p className="">{point} POINT</p>
-    </div>
-    <div className="w-[4rem] text-right">
-      <span>{progress}%</span>
-    </div>
-    <div className="w-[4rem]">
-      <BacklogStatusChip status={status} />
-    </div>
-  </div>
-);
+  children,
+}: StoryBlockProps) => {
+  const { showDetail, handleShowDetail } = useShowDetail();
+
+  return (
+    <>
+      <div className="flex items-center py-1 border-t border-b">
+        <div className="w-[5rem] mr-5">
+          <CategoryChip content={epic} bgColor="green" />
+        </div>
+        <div className="flex items-center gap-1 w-[40.9rem] mr-4">
+          <button
+            className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
+            type="button"
+            onClick={() => handleShowDetail(!showDetail)}
+          >
+            {showDetail ? (
+              <ChevronDown width={16} height={16} fill="black" />
+            ) : (
+              <ChevronRight width={16} height={16} fill="black" />
+            )}
+          </button>
+          <p>{title}</p>
+        </div>
+        <div className="w-[4rem] mr-[2.76rem] text-right">
+          <p className="">{point} POINT</p>
+        </div>
+        <div className="w-[4rem] mr-[2.76rem] text-right">
+          <span>{progress}%</span>
+        </div>
+        <div className="w-[6.25rem]">
+          <BacklogStatusChip status={status} />
+        </div>
+      </div>
+      {showDetail && (
+        <TaskContainer>
+          <TaskHeader />
+          {children}
+          <TaskCreateButton />
+        </TaskContainer>
+      )}
+    </>
+  );
+};
 
 export default StoryBlock;

--- a/frontend/src/components/backlog/StoryCreateForm.tsx
+++ b/frontend/src/components/backlog/StoryCreateForm.tsx
@@ -1,34 +1,142 @@
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
 import Check from "../../assets/icons/check.svg?react";
 import Closed from "../../assets/icons/closed.svg?react";
 import CategoryChip from "./CategoryChip";
+import { StoryForm } from "../../types/common/backlog";
+import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
+import { Socket } from "socket.io-client";
+import { useOutletContext } from "react-router-dom";
+// import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
+import EpicDropdown from "./EpicDropdown";
+import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
 
-const StoryCreateForm = () => (
-  <div className="flex items-center gap-5 py-1 border-t border-b">
-    <div className="w-[5rem]">
-      <CategoryChip content="프로젝트" bgColor="green" />
-    </div>
-    <input className="w-[38.75rem]" type="text" />
-    <div className="flex items-center ">
-      <input className="w-14" type="number" id="point-number" />
-      <label htmlFor="point-number" className="">
-        POINT
-      </label>
-    </div>
-    <div className="flex items-center gap-2">
-      <button
-        className="flex items-center justify-center w-6 h-6 rounded-md bg-confirm-green"
-        type="button"
+interface StoryCreateFormProps {
+  onCloseClick: () => void;
+  epicList: EpicCategoryDTO[];
+}
+
+const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
+  const { socket }: { socket: Socket } = useOutletContext();
+  const [{ title, point, epicId, status }, setStoryFormData] =
+    useState<StoryForm>({
+      title: "",
+      point: undefined,
+      status: "시작전",
+      epicId: undefined,
+    });
+  const { open, handleClose, handleOpen, dropdownRef } = useDropdownState();
+  const { emitStoryCreateEvent } = useStoryEmitEvent(socket);
+
+  const handleTitleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    const { value } = target;
+    setStoryFormData({ title: value, point, epicId, status });
+  };
+
+  const handlePointChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    const { value } = target;
+    setStoryFormData({ title, point: Number(value), epicId, status });
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (epicId === undefined) {
+      alert("에픽을 지정해주세요.");
+      return;
+    }
+
+    if (!title) {
+      alert("제목을 입력해주세요.");
+      return;
+    }
+
+    if (point === undefined) {
+      alert("포인트를 입력해주세요.");
+      return;
+    }
+
+    emitStoryCreateEvent({ title, status, epicId, point });
+    onCloseClick();
+  };
+
+  const handleEpicChange = (selectedEpicId: number) => {
+    setStoryFormData({ title, status, point, epicId: selectedEpicId });
+    handleClose();
+  };
+
+  const handleEpicColumnClick = () => {
+    if (!open) {
+      handleOpen();
+    }
+  };
+
+  const selectedEpic = useMemo(
+    () => epicList.filter(({ id }) => id === epicId)[0],
+    [epicId]
+  );
+  return (
+    <form
+      className="flex items-center w-full py-1 border-t border-b"
+      onSubmit={handleSubmit}
+    >
+      <div
+        className="w-[5rem] min-h-[1.75rem] bg-light-gray rounded-md mr-7 hover:cursor-pointer relative"
+        onClick={handleEpicColumnClick}
+        ref={dropdownRef}
       >
-        <Check width={20} height={20} stroke="white" />
-      </button>
-      <button
-        className="flex items-center justify-center w-6 h-6 rounded-md bg-error-red"
-        type="button"
-      >
-        <Closed stroke="white" />
-      </button>
-    </div>
-  </div>
-);
+        {epicId && (
+          <CategoryChip
+            content={selectedEpic.name}
+            bgColor={selectedEpic.color}
+          />
+        )}
+        {open && (
+          <EpicDropdown
+            selectedEpic={selectedEpic}
+            epicList={epicList}
+            onEpicSelect={handleEpicChange}
+          />
+        )}
+      </div>
+      <input
+        className="w-[34.7rem] h-[1.75rem] mr-[1.5rem] bg-light-gray rounded-md focus:outline-none"
+        type="text"
+        value={title}
+        onChange={handleTitleChange}
+      />
+      <div className="flex items-center mr-[2.8rem] ">
+        <input
+          className="w-24 h-[1.75rem] mr-1 text-right rounded-md bg-light-gray no-arrows focus:outline-none"
+          type="number"
+          id="point-number"
+          value={point}
+          onChange={handlePointChange}
+        />
+        <label htmlFor="point-number" className="">
+          POINT
+        </label>
+      </div>
+      <div className="w-[4rem] mr-[2.76rem] text-right">
+        <span>0%</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          className="flex items-center justify-center w-6 h-6 rounded-md bg-confirm-green"
+          type="button"
+          onClick={handleSubmit}
+        >
+          <Check width={20} height={20} stroke="white" />
+        </button>
+        <button
+          className="flex items-center justify-center w-6 h-6 rounded-md bg-error-red"
+          type="button"
+          onClick={onCloseClick}
+        >
+          <Closed stroke="white" />
+        </button>
+      </div>
+    </form>
+  );
+};
 
 export default StoryCreateForm;

--- a/frontend/src/components/backlog/TaskBlock.tsx
+++ b/frontend/src/components/backlog/TaskBlock.tsx
@@ -11,7 +11,7 @@ const TaskBlock = ({
   status,
 }: TaskDTO) => (
   <div className="flex items-center justify-between py-1 border-b">
-    <p className="w-12">Task-{displayId}</p>
+    <p className="w-[4rem]">Task-{displayId}</p>
     <p className="w-[25rem]">{title}</p>
     <div className="w-12">
       {assignedMemberId && (

--- a/frontend/src/components/backlog/TaskCreateButton.tsx
+++ b/frontend/src/components/backlog/TaskCreateButton.tsx
@@ -1,7 +1,7 @@
 import Plus from "../../assets/icons/plus.svg?react";
 
 const TaskCreateButton = () => (
-  <div className="py-1 border-b text-dark-gray">
+  <div className="py-1 text-dark-gray">
     <button
       className="flex items-center justify-center w-full gap-1"
       type="button"

--- a/frontend/src/components/backlog/TaskHeader.tsx
+++ b/frontend/src/components/backlog/TaskHeader.tsx
@@ -1,6 +1,6 @@
 const TaskHeader = () => (
   <div className="flex items-center justify-between py-1 border-b text-dark-gray">
-    <p className="w-12">식별자</p>
+    <p className="w-[4rem]">식별자</p>
     <p className="w-[25rem]">태스크 이름</p>
     <p className="w-12">담당자</p>
     <p className="w-16">예상 시간</p>

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { Socket } from "socket.io-client";
-import { BacklogDTO, EpicDTO } from "../../../types/DTO/backlogDTO";
+import { BacklogDTO, EpicDTO, StoryDTO } from "../../../types/DTO/backlogDTO";
 import {
   BacklogSocketData,
   BacklogSocketDomain,
   BacklogSocketEpicAction,
+  BacklogSocketStoryAction,
 } from "../../../types/common/backlog";
 
 const useBacklogSocket = (socket: Socket) => {
@@ -46,6 +47,27 @@ const useBacklogSocket = (socket: Socket) => {
     }
   };
 
+  const handleStoryEvent = (
+    action: BacklogSocketStoryAction,
+    content: StoryDTO
+  ) => {
+    switch (action) {
+      case BacklogSocketStoryAction.CREATE:
+        setBacklog((prevBacklog) => {
+          const newEpicList = prevBacklog.epicList.map((epic) => {
+            if (epic.id === content.epicId) {
+              const newStoryList = [...epic.storyList, content];
+              return { ...epic, storyList: newStoryList };
+            }
+
+            return epic;
+          });
+          return { epicList: newEpicList };
+        });
+        break;
+    }
+  };
+
   const handleOnBacklog = ({ domain, action, content }: BacklogSocketData) => {
     switch (domain) {
       case BacklogSocketDomain.BACKLOG:
@@ -53,6 +75,9 @@ const useBacklogSocket = (socket: Socket) => {
         break;
       case BacklogSocketDomain.EPIC:
         handleEpicEvent(action, content);
+        break;
+      case BacklogSocketDomain.STORY:
+        handleStoryEvent(action, content);
         break;
     }
   };

--- a/frontend/src/hooks/pages/backlog/useShowDetail.ts
+++ b/frontend/src/hooks/pages/backlog/useShowDetail.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+const useShowDetail = () => {
+  const [showDetail, setShowDetail] = useState(false);
+
+  const handleShowDetail = (showing: boolean) => {
+    setShowDetail(showing);
+  };
+
+  return { showDetail, handleShowDetail };
+};
+
+export default useShowDetail;

--- a/frontend/src/hooks/pages/backlog/useStoryEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useStoryEmitEvent.ts
@@ -1,0 +1,27 @@
+import { Socket } from "socket.io-client";
+import { StoryForm } from "../../../types/common/backlog";
+import { BacklogStatusType } from "../../../types/DTO/backlogDTO";
+
+const useStoryEmitEvent = (socket: Socket) => {
+  const emitStoryCreateEvent = (content: StoryForm) => {
+    socket.emit("story", { action: "create", content });
+  };
+
+  const emitStoryDeleteEvent = (content: { id: number }) => {
+    socket.emit("story", { action: "delete", content });
+  };
+
+  const emitStoryUpdateEvent = (content: {
+    id: number;
+    title?: string;
+    status?: BacklogStatusType;
+    epicId?: number;
+    point?: number;
+  }) => {
+    socket.emit("story", { action: "update", content });
+  };
+
+  return { emitStoryCreateEvent, emitStoryDeleteEvent, emitStoryUpdateEvent };
+};
+
+export default useStoryEmitEvent;

--- a/frontend/src/pages/backlog/BacklogPage.tsx
+++ b/frontend/src/pages/backlog/BacklogPage.tsx
@@ -8,8 +8,7 @@ const BacklogPage = () => {
   const { backlog } = useBacklogSocket(socket);
 
   return (
-    <div>
-      {JSON.stringify(backlog)}
+    <div className="w-full h-full">
       <BacklogHeader />
       <Outlet context={{ socket, backlog }} />
     </div>

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -13,18 +13,32 @@ const UnfinishedStoryPage = () => {
   const { showDetail, handleShowDetail } = useShowDetail();
   const storyList = useMemo(
     () => changeEpicListToStoryList(backlog.epicList),
-    []
+    [backlog.epicList]
+  );
+  const epicCategoryList = useMemo(
+    () => backlog.epicList.map(({ id, name, color }) => ({ id, name, color })),
+    [backlog.epicList]
   );
 
   return (
-    <div>
-      {...storyList.map(({ epic, title, point, status, taskList }) => (
-        <StoryBlock {...{ title, point, status }} epic={epic.name} progress={2}>
-          {...taskList.map((task) => <TaskBlock {...task} />)}
-        </StoryBlock>
-      ))}
+    <div className="flex flex-col items-center gap-4">
+      <div className="w-full border-b">
+        {...storyList.map(({ epic, title, point, status, taskList }) => (
+          <StoryBlock
+            {...{ title, point, status }}
+            epic={epic.name}
+            progress={2}
+            taskExist={taskList.length > 0}
+          >
+            {...taskList.map((task) => <TaskBlock {...task} />)}
+          </StoryBlock>
+        ))}
+      </div>
       {showDetail ? (
-        <StoryCreateForm onCloseClick={() => handleShowDetail(false)} />
+        <StoryCreateForm
+          epicList={epicCategoryList}
+          onCloseClick={() => handleShowDetail(false)}
+        />
       ) : (
         <StoryCreateButton onClick={() => handleShowDetail(true)} />
       )}

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -1,3 +1,35 @@
-const UnfinishedStoryPage = () => <div>UnfinishedStoryPage</div>;
+import { useOutletContext } from "react-router-dom";
+import { BacklogDTO } from "../../types/DTO/backlogDTO";
+import StoryCreateButton from "../../components/backlog/StoryCreateButton";
+import StoryCreateForm from "../../components/backlog/StoryCreateForm";
+import { useMemo } from "react";
+import changeEpicListToStoryList from "../../utils/changeEpicListToStoryList";
+import StoryBlock from "../../components/backlog/StoryBlock";
+import TaskBlock from "../../components/backlog/TaskBlock";
+import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
+
+const UnfinishedStoryPage = () => {
+  const { backlog }: { backlog: BacklogDTO } = useOutletContext();
+  const { showDetail, handleShowDetail } = useShowDetail();
+  const storyList = useMemo(
+    () => changeEpicListToStoryList(backlog.epicList),
+    []
+  );
+
+  return (
+    <div>
+      {...storyList.map(({ epic, title, point, status, taskList }) => (
+        <StoryBlock {...{ title, point, status }} epic={epic.name} progress={2}>
+          {...taskList.map((task) => <TaskBlock {...task} />)}
+        </StoryBlock>
+      ))}
+      {showDetail ? (
+        <StoryCreateForm onCloseClick={() => handleShowDetail(false)} />
+      ) : (
+        <StoryCreateButton onClick={() => handleShowDetail(true)} />
+      )}
+    </div>
+  );
+};
 
 export default UnfinishedStoryPage;

--- a/frontend/src/types/DTO/backlogDTO.ts
+++ b/frontend/src/types/DTO/backlogDTO.ts
@@ -25,6 +25,7 @@ export interface StoryDTO {
   point: number | null;
   status: BacklogStatusType;
   taskList: TaskDTO[];
+  epicId: number;
 }
 
 export interface EpicCategoryDTO {

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -1,4 +1,9 @@
-import { BacklogDTO, EpicDTO } from "../DTO/backlogDTO";
+import {
+  BacklogDTO,
+  EpicCategoryDTO,
+  EpicDTO,
+  StoryDTO,
+} from "../DTO/backlogDTO";
 
 export type BacklogPath = "backlog" | "epic" | "completed";
 
@@ -10,6 +15,10 @@ export type BacklogCategoryColor =
   | "blue"
   | "purple"
   | "gray";
+
+export interface UnfinishedStory extends StoryDTO {
+  epic: EpicCategoryDTO;
+}
 
 export enum BacklogSocketDomain {
   BACKLOG = "backlog",

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -20,6 +20,13 @@ export interface UnfinishedStory extends StoryDTO {
   epic: EpicCategoryDTO;
 }
 
+export interface StoryForm {
+  epicId: number | undefined;
+  title: string;
+  point: number | undefined;
+  status: "시작전";
+}
+
 export enum BacklogSocketDomain {
   BACKLOG = "backlog",
   EPIC = "epic",
@@ -28,6 +35,12 @@ export enum BacklogSocketDomain {
 }
 
 export enum BacklogSocketEpicAction {
+  CREATE = "create",
+  DELETE = "delete",
+  UPDATE = "update",
+}
+
+export enum BacklogSocketStoryAction {
   CREATE = "create",
   DELETE = "delete",
   UPDATE = "update",
@@ -45,4 +58,13 @@ export interface BacklogSocketEpicData {
   content: EpicDTO;
 }
 
-export type BacklogSocketData = BacklogSocketInitData | BacklogSocketEpicData;
+export interface BacklogSocketStoryData {
+  domain: BacklogSocketDomain.STORY;
+  action: BacklogSocketStoryAction;
+  content: StoryDTO;
+}
+
+export type BacklogSocketData =
+  | BacklogSocketInitData
+  | BacklogSocketEpicData
+  | BacklogSocketStoryData;

--- a/frontend/src/utils/changeEpicListToStoryList.ts
+++ b/frontend/src/utils/changeEpicListToStoryList.ts
@@ -1,0 +1,16 @@
+import { UnfinishedStory } from "../types/common/backlog";
+import { EpicDTO } from "../types/DTO/backlogDTO";
+
+const changeEpicListToStoryList = (epicList: EpicDTO[]) => {
+  const newStoryList: UnfinishedStory[] = [];
+  epicList.forEach(({ id, name, color, storyList }) => {
+    storyList.forEach((story) => {
+      const newStory = { ...story, epic: { id, name, color } };
+      newStoryList.push(newStory);
+    });
+  });
+
+  return newStoryList;
+};
+
+export default changeEpicListToStoryList;

--- a/frontend/src/utils/changeEpicListToStoryList.ts
+++ b/frontend/src/utils/changeEpicListToStoryList.ts
@@ -6,6 +6,9 @@ const changeEpicListToStoryList = (epicList: EpicDTO[]) => {
   epicList.forEach(({ id, name, color, storyList }) => {
     storyList.forEach((story) => {
       const newStory = { ...story, epic: { id, name, color } };
+      if (!newStory.taskList) {
+        newStory.taskList = [];
+      }
       newStoryList.push(newStory);
     });
   });

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -47,5 +47,21 @@ export default {
       },
     },
   },
-  plugins: [require("tailwind-scrollbar-hide"), require("tailwind-scrollbar")],
+  plugins: [
+    require("tailwind-scrollbar-hide"),
+    require("tailwind-scrollbar"),
+    function ({ addUtilities }) {
+      addUtilities({
+        ".no-arrows": {
+          "&::-webkit-inner-spin-button, &::-webkit-outer-spin-button": {
+            "-webkit-appearance": "none",
+            margin: "0",
+          },
+          "&[type=number]": {
+            "-moz-appearance": "textfield",
+          },
+        },
+      });
+    },
+  ],
 };


### PR DESCRIPTION
## 🎟️ 태스크

[스토리 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-5b983a7e2ac84de2b4062377717f617c)

## ✅ 작업 내용

- 스토리별 백로그 조회 페이지 컴포넌트 배치
- 스토리 추가 기능 구현

## 🖊️ 구체적인 작업

### 스토리 추가 기능 구현
- 반드시 입력되어야 하는 필드가 입력되지 않았을 때 alert를 띄워 입력이 필요함을 알도록 했습니다.
- 프롭스 드릴링을 줄이기 위해 children을 사용해서 TaskList를 StoryList의 children으로 배치했습니다.

## 🤔 고민 및 의논할 거리

- 백로그와 관련된 컴포넌트가 많아졌는데 이를 어떤 폴더 구조를 통해 효율적으로 관리할 수 있을지 고민이 됩니다. Epic, Story, Task, 공용 컴포넌트로 나누는 게 좋을지 잘 모르겠네요. 좀 더 생각해봐야 할 것 같습니다.
- 관심사 및 책임에 따라 컴포넌트를 나누려고 했는데 어느 정도까지 관심사 분리를 해야 할지 나름의 기준이 필요할 것 같습니다. 컴포넌트가 많아지더라도 컴포넌트 내 구조를 더 명확하게 파악할 수 있도록 좀 더 작게 분리하는 것이 좋을지 고민이 필요합니다.
