### PR TITLE
fix: 에픽 옵션 메뉴를 클릭하면 드롭다운이 닫히는 문제 해결

### DIFF
--- a/frontend/src/components/backlog/EpicDropdownOption.tsx
+++ b/frontend/src/components/backlog/EpicDropdownOption.tsx
@@ -3,7 +3,7 @@ import MenuKebab from "../../assets/icons/menu-kebab.svg?react";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
 import EpicUpdateBox from "./EpicUpdateBox";
-import { useRef } from "react";
+import { MouseEvent, useRef } from "react";
 
 interface EpicDropdownOptionProps {
   epic: EpicCategoryDTO;
@@ -13,7 +13,8 @@ const EpicDropdownOption = ({ epic }: EpicDropdownOptionProps) => {
   const { open, handleOpen, handleClose } = useDropdownState();
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-  const handleMenuButtonClick = () => {
+  const handleMenuButtonClick = (event: MouseEvent) => {
+    event.stopPropagation();
     handleOpen();
   };
 


### PR DESCRIPTION
## 🎟️ 태스크

## ✅ 작업 내용

- 에픽 드롭다운에서 메뉴 클릭 시 드롭다운이 닫히는 문제 해결

## 🖊️ 구체적인 작업

### 에픽 드롭다운에서 메뉴 클릭 시 드롭다운이 닫히는 문제 해결

- 이벤트 전파를 막는 방식으로 해결했습니다.
