### PR TITLE
feat: 태스크 생성, 수정, 삭제 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { Memo } from './project/entity/memo.entity';
 import { Link } from './project/entity/link.entity.';
 import { Epic } from './project/entity/epic.entity';
 import { Story } from './project/entity/story.entity';
+import { Task } from './project/entity/task.entity';
 
 @Module({
   imports: [
@@ -53,6 +54,7 @@ import { Story } from './project/entity/story.entity';
           Link,
           Epic,
           Story,
+		  Task
         ],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),

--- a/backend/src/project/dto/task/TaskCreateNotify.dto.ts
+++ b/backend/src/project/dto/task/TaskCreateNotify.dto.ts
@@ -1,0 +1,37 @@
+import { Task, TaskStatus } from 'src/project/entity/task.entity';
+class TaskDto {
+  id: number;
+  displayId: number;
+  title: string;
+  expectedTime: number|null;
+  actualTime: number|null;
+  status: TaskStatus;
+  assignedMemberId: number|null;
+  storyId: number;
+  static of(task: Task) {
+    const dto = new TaskDto();
+    dto.id = task.id;
+	dto.displayId = task.displayId;
+    dto.title = task.title;
+    dto.expectedTime = task.expectedTime;
+    dto.actualTime = task.actualTime;
+    dto.status = task.status;
+    dto.assignedMemberId = task.assignedMemberId;
+    dto.storyId = task.storyId;
+    return dto;
+  }
+}
+
+export class TaskCreateNotifyDto {
+  domain: string;
+  action: string;
+  content: TaskDto;
+
+  static of(task: Task) {
+    const dto = new TaskCreateNotifyDto();
+    dto.domain = 'task';
+    dto.action = 'create';
+    dto.content = TaskDto.of(task);
+    return dto;
+  }
+}

--- a/backend/src/project/dto/task/TaskCreateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskCreateRequest.dto.ts
@@ -1,0 +1,74 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Length,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { TaskStatus } from 'src/project/entity/task.entity';
+
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+
+export function IsOneDecimalPlace(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'IsOneDecimalPlace',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          const decimalPattern = /^\d+(\.\d{1})?$/;
+          return (
+            typeof value === 'number' && decimalPattern.test(value.toString())
+          );
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a number with exactly one decimal place`;
+        },
+      },
+    });
+  };
+}
+
+class Task {
+  @IsString()
+  @Length(0, 100, { message: 'Title must be 100 characters or less' })
+  title: string;
+
+  @IsOptional()
+  @IsOneDecimalPlace()
+  expectedTime: number;
+
+  @IsOptional()
+  @IsOneDecimalPlace()
+  actualTime: number;
+
+  @IsEnum(TaskStatus)
+  status: TaskStatus;
+
+  @IsOptional()
+  @IsInt()
+  assignedMemberId: number;
+
+  @IsInt()
+  storyId: number;
+}
+
+export class TaskCreateRequestDto {
+  @Matches(/^create$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Task)
+  content: Task;
+}

--- a/backend/src/project/dto/task/TaskDeleteNotify.dto.ts
+++ b/backend/src/project/dto/task/TaskDeleteNotify.dto.ts
@@ -1,0 +1,22 @@
+class Task {
+  id: number;
+  static of(id: number) {
+    const dto = new Task();
+    dto.id = id;
+    return dto;
+  }
+}
+
+export class TaskDeleteNotifyDto {
+  domain: string;
+  action: string;
+  content: Task;
+
+  static of(id: number) {
+    const dto = new TaskDeleteNotifyDto();
+    dto.domain = 'task';
+    dto.action = 'delete';
+    dto.content = Task.of(id);
+    return dto;
+  }
+}

--- a/backend/src/project/dto/task/TaskDeleteRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskDeleteRequest.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, Matches, ValidateNested } from 'class-validator';
+
+class Task {
+  @IsInt()
+  id: number;
+}
+
+export class TaskDeleteRequestDto {
+  @Matches(/^delete$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Task)
+  content: Task;
+}

--- a/backend/src/project/dto/task/TaskUpdateNotify.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateNotify.dto.ts
@@ -1,0 +1,61 @@
+import { TaskStatus } from 'src/project/entity/task.entity';
+
+class Task {
+  id: number;
+  storyId?: number;
+  title?: string;
+  expectedTime?: number;
+  actualTime?: number;
+  status?: TaskStatus;
+  assignedMemberId?: number;
+
+  static of(
+    id: number,
+    storyId: number | undefined,
+    title: string | undefined,
+    expectedTime: number | undefined,
+    actualTime: number | undefined,
+    status: TaskStatus | undefined,
+    assignedMemberId: number | undefined,
+  ) {
+    const dto = new Task();
+    dto.id = id;
+    if (storyId) dto.storyId = storyId;
+    if (title) dto.title = title;
+    if (expectedTime) dto.expectedTime = expectedTime;
+    if (actualTime) dto.actualTime = actualTime;
+    if (status) dto.status = status;
+    if (assignedMemberId) dto.assignedMemberId = assignedMemberId;
+    return dto;
+  }
+}
+
+export class TaskUpdateNotifyDto {
+  domain: string;
+  action: string;
+  content: Task;
+
+  static of(
+    id: number,
+    storyId: number | undefined,
+    title: string | undefined,
+    expectedTime: number | undefined,
+    actualTime: number | undefined,
+    status: TaskStatus | undefined,
+    assignedMemberId: number | undefined,
+  ) {
+    const dto = new TaskUpdateNotifyDto();
+    dto.domain = 'task';
+    dto.action = 'update';
+    dto.content = Task.of(
+      id,
+      storyId,
+      title,
+      expectedTime,
+      actualTime,
+      status,
+      assignedMemberId,
+    );
+    return dto;
+  }
+}

--- a/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
@@ -1,0 +1,51 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { TaskStatus } from 'src/project/entity/task.entity';
+import { IsOneDecimalPlace } from './TaskCreateRequest.dto';
+
+class Task {
+  @IsInt()
+  id: number;
+
+  @IsOptional()
+  @IsInt()
+  storyId?: number;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsOneDecimalPlace()
+  expectedTime?: number;
+  
+  @IsOptional()
+  @IsOneDecimalPlace()
+  actualTime?: number;
+
+  @IsOptional()
+  @IsInt()
+  assignedMemberId?: number;
+
+  @IsOptional()
+  @IsEnum(TaskStatus)
+  status?: TaskStatus;
+}
+
+export class TaskUpdateRequestDto {
+  @Matches(/^update$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Task)
+  content: Task;
+}

--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -45,10 +45,14 @@ export class Project {
   @OneToMany(() => Link, (link) => link.id)
   linkList: Link[];
 
+  @Column({type: 'int', nullable: false})
+  displayIdCount: number;
+
   static of(title: string, subject: string) {
     const newProject = new Project();
     newProject.title = title;
     newProject.subject = subject;
+	newProject.displayIdCount = 0;
     return newProject;
   }
 }

--- a/backend/src/project/entity/task.entity.ts
+++ b/backend/src/project/entity/task.entity.ts
@@ -1,0 +1,81 @@
+import { Member } from 'src/member/entity/member.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+import { Story } from './story.entity';
+
+export enum TaskStatus {
+  NotStarted = '시작전',
+  InProgress = '진행중',
+  Completed = '완료',
+}
+
+@Entity()
+export class Task {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  id: number;
+
+  @Column({ type: 'int', name: 'project_id', nullable: false })
+  projectId: number;
+
+  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @Column({ type: 'int', name: 'story_id', nullable: false })
+  storyId: number;
+
+  @ManyToOne(() => Story, (story) => story.id, { nullable: false })
+  @JoinColumn({ name: 'story_id' })
+  story: Story;
+
+  @Column({ type: 'varchar', length: 99, nullable: false })
+  title: string;
+
+  @Column({ type: 'int', nullable: false })
+  displayId: number;
+
+  @Column({ type: 'double', nullable: true })
+  expectedTime: number;
+
+  @Column({ type: 'double', nullable: true })
+  actualTime: number;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  status: TaskStatus;
+
+  @Column({ type: 'int', name: 'member_id', nullable: true })
+  assignedMemberId: number;
+
+  @ManyToOne(() => Member, (member) => member.id, { nullable: true })
+  @JoinColumn({ name: 'member_id' })
+  member: Member;
+
+  static of(
+    project: Project,
+    storyId: number,
+    title: string,
+    displayId: number,
+    expectedTime: number,
+    actualTime: number,
+    memberId: number,
+    status: TaskStatus,
+  ) {
+    const newTask = new Task();
+    newTask.project = project;
+    newTask.storyId = storyId;
+    newTask.title = title;
+    newTask.displayId = displayId;
+
+    newTask.expectedTime = expectedTime;
+    newTask.actualTime = actualTime;
+    newTask.assignedMemberId = memberId;
+    newTask.status = status;
+    return newTask;
+  }
+}

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -20,6 +20,8 @@ import { WsProjectEpicController } from './ws-controller/ws-project-epic.control
 import { Epic } from './entity/epic.entity';
 import { Story } from './entity/story.entity';
 import { WsProjectStoryController } from './ws-controller/ws-project-story.controller';
+import { Task } from './entity/task.entity';
+import { WsProjectTaskController } from './ws-controller/ws-project-task.controller';
 
 @Module({
   imports: [
@@ -31,7 +33,8 @@ import { WsProjectStoryController } from './ws-controller/ws-project-story.contr
       Memo,
       Link,
       Epic,
-	  Story
+	  Story,
+	  Task
     ]),
   ],
   controllers: [ProjectController],
@@ -47,6 +50,7 @@ import { WsProjectStoryController } from './ws-controller/ws-project-story.contr
     WsProjectController,
     WsProjectEpicController,
 	WsProjectStoryController,
+	WsProjectTaskController,
   ],
 })
 export class ProjectModule {}

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -7,6 +7,7 @@ import { Memo, memoColor } from '../entity/memo.entity';
 import { Link } from '../entity/link.entity.';
 import { Epic, EpicColor } from '../entity/epic.entity';
 import { Story, StoryStatus } from '../entity/story.entity';
+import { Task, TaskStatus } from '../entity/task.entity';
 
 @Injectable()
 export class ProjectService {
@@ -113,15 +114,15 @@ export class ProjectService {
     return this.projectRepository.updateEpic(project, id, name, color);
   }
 
-  createStory(
+  async createStory(
     project: Project,
     epicId: number,
     title: string,
     point: number,
     status: StoryStatus,
   ) {
-    const epic = this.projectRepository.getEpicById(project, epicId);
-    if (!epic) throw new Error('epic id is not found');
+    const epic = await this.projectRepository.getEpicById(project, epicId);
+    if (!epic) throw new Error('epic id not found');
     const newStory = Story.of(project, epicId, title, point, status);
     return this.projectRepository.createStory(newStory);
   }
@@ -131,7 +132,7 @@ export class ProjectService {
     return result ? true : false;
   }
 
-  updateStory(
+  async updateStory(
     project: Project,
     id: number,
     epicId: number | undefined,
@@ -140,8 +141,8 @@ export class ProjectService {
     status: StoryStatus | undefined,
   ): Promise<boolean> {
     if (epicId !== undefined) {
-      const epic = this.projectRepository.getEpicById(project, epicId);
-      if (!epic) throw new Error('epic id is not found');
+      const epic = await this.projectRepository.getEpicById(project, epicId);
+      if (!epic) throw new Error('epic id not found');
     }
     return this.projectRepository.updateStory(
       project,
@@ -150,6 +151,64 @@ export class ProjectService {
       title,
       point,
       status,
+    );
+  }
+
+  async createTask(
+    project: Project,
+    title: string,
+    expectedTime: number,
+    actualTime: number,
+    status: TaskStatus,
+    assignedMemberId: number,
+    storyId: number,
+  ) {
+    const story = await this.projectRepository.getStoryById(project, storyId);
+    if (!story) throw new Error('Story id not found');
+    const displayIdCount =
+      await this.projectRepository.getAndIncrementDisplayIdCount(project);
+
+    const newTask = Task.of(
+      project,
+      storyId,
+      title,
+      displayIdCount,
+      expectedTime,
+      actualTime,
+      assignedMemberId,
+      status,
+    );
+    return this.projectRepository.createTask(newTask);
+  }
+
+  async deleteTask(project: Project, taskId: number) {
+    const result = await this.projectRepository.deleteTask(project, taskId);
+    return result ? true : false;
+  }
+
+  async updateTask(
+    project: Project,
+    id: number,
+    storyId: number | undefined,
+    title: string | undefined,
+    expectedTime: number | undefined,
+    actualTime: number | undefined,
+    status: TaskStatus | undefined,
+    assignedMemberId: number | undefined,
+  ): Promise<boolean> {
+    if (storyId !== undefined) {
+      const story = await this.projectRepository.getStoryById(project, storyId);
+      if (!story) throw new Error('story id not found');
+    }
+    return this.projectRepository.updateTask(
+      project,
+      id,
+      storyId,
+      title,
+      expectedTime,
+      actualTime,
+      status,
+      assignedMemberId,
     );
   }
 }

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -20,6 +20,7 @@ import { WsProjectController } from './ws-controller/ws-project.controller';
 import { ClientSocket } from './type/ClientSocket.type';
 import { WsProjectEpicController } from './ws-controller/ws-project-epic.controller';
 import { WsProjectStoryController } from './ws-controller/ws-project-story.controller';
+import { WsProjectTaskController } from './ws-controller/ws-project-task.controller';
 
 @WebSocketGateway({
   namespace: /project-\d+/,
@@ -38,6 +39,7 @@ export class ProjectWebsocketGateway
     private readonly wsProjectController: WsProjectController,
     private readonly wsProjectEpicController: WsProjectEpicController,
     private readonly wsProjectStoryController: WsProjectStoryController,
+    private readonly wsProjectTaskController: WsProjectTaskController,
   ) {
     this.namespaceMap = new Map();
   }
@@ -156,9 +158,22 @@ export class ProjectWebsocketGateway
       this.wsProjectStoryController.createStory(client, data);
     } else if (data.action === 'delete') {
       this.wsProjectStoryController.deleteStory(client, data);
-    }
-    else if (data.action === 'update') {
+    } else if (data.action === 'update') {
       this.wsProjectStoryController.updateStory(client, data);
+    }
+  }
+
+  @SubscribeMessage('task')
+  async handleTaskEvent(
+    @ConnectedSocket() client: ClientSocket,
+    @MessageBody() data: any,
+  ) {
+    if (data.action === 'create') {
+      this.wsProjectTaskController.createTask(client, data);
+    } else if (data.action === 'delete') {
+      this.wsProjectTaskController.deleteTask(client, data);
+    } else if (data.action === 'update') {
+      this.wsProjectTaskController.updateTask(client, data);
     }
   }
 

--- a/backend/src/project/ws-controller/ws-project-task.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-task.controller.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import { plainToClass } from 'class-transformer';
+import { validate } from 'class-validator';
+import { TaskCreateNotifyDto } from '../dto/task/TaskCreateNotify.dto';
+import { TaskCreateRequestDto } from '../dto/task/TaskCreateRequest.dto';
+import { TaskDeleteNotifyDto } from '../dto/task/TaskDeleteNotify.dto';
+import { TaskDeleteRequestDto } from '../dto/task/TaskDeleteRequest.dto';
+import { TaskUpdateNotifyDto } from '../dto/task/TaskUpdateNotify.dto';
+import { TaskUpdateRequestDto } from '../dto/task/TaskUpdateRequest.dto';
+import { ProjectService } from '../service/project.service';
+import { ClientSocket } from '../type/ClientSocket.type';
+import { getRecursiveErrorMsgList } from '../util/validation.util';
+
+@Injectable()
+export class WsProjectTaskController {
+  constructor(private readonly projectService: ProjectService) {}
+  async createTask(client: ClientSocket, data: any) {
+    const errors = await validate(plainToClass(TaskCreateRequestDto, data));
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+
+    const { content } = data as TaskCreateRequestDto;
+    const createdTask = await this.projectService.createTask(
+      client.project,
+      content.title,
+      content.expectedTime,
+      content.actualTime,
+      content.status,
+      content.assignedMemberId,
+      content.storyId,
+    );
+    client.nsp
+      .to('backlog')
+      .emit('backlog', TaskCreateNotifyDto.of(createdTask));
+  }
+
+  async deleteTask(client: ClientSocket, data: any) {
+    const errors = await validate(plainToClass(TaskDeleteRequestDto, data));
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+    const { content } = data as TaskDeleteRequestDto;
+    const isDeleted = await this.projectService.deleteTask(
+      client.project,
+      content.id,
+    );
+    if (isDeleted) {
+      client.nsp
+        .to('backlog')
+        .emit('backlog', TaskDeleteNotifyDto.of(content.id));
+    }
+  }
+
+  async updateTask(client: ClientSocket, data: any) {
+    const errors = await validate(plainToClass(TaskUpdateRequestDto, data));
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+    const { content } = data as TaskUpdateRequestDto;
+    const isUpdated = await this.projectService.updateTask(
+      client.project,
+      content.id,
+      content.storyId,
+      content.title,
+      content.expectedTime,
+      content.actualTime,
+      content.status,
+      content.assignedMemberId,
+    );
+
+    if (isUpdated) {
+      client.nsp
+        .to('backlog')
+        .emit(
+          'backlog',
+          TaskUpdateNotifyDto.of(
+            content.id,
+            content.storyId,
+            content.title,
+            content.expectedTime,
+            content.actualTime,
+            content.status,
+            content.assignedMemberId,
+          ),
+        );
+    }
+  }
+}

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -150,7 +150,6 @@ describe('WS story', () => {
     const expectTitleUpdateStory = (socket, id, title) => {
       return new Promise<void>((resolve) => {
         socket.once('backlog', async (data) => {
-          console.log(data);
           const { content, action, domain } = data;
           expect(domain).toBe('story');
           expect(action).toBe('update');

--- a/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
@@ -1,0 +1,394 @@
+import { Socket } from 'socket.io-client';
+import { app, appInit } from 'test/setup';
+import {
+  getMemberJoinedLandingPage,
+  getTwoMemberJoinedLandingPage,
+} from '../ws-common';
+
+describe('WS task', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  describe('task create', () => {
+    it('should return created task data', async () => {
+      const [socket1, socket2] = await getTwoMemberJoinedLandingPage();
+      socket1.emit('joinBacklog');
+      socket2.emit('joinBacklog');
+      await Promise.all([initBacklog(socket1), initBacklog(socket2)]);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket1.emit('epic', requestData);
+      const [epicId] = await Promise.all([
+        getEpicId(socket1),
+        getEpicId(socket2),
+      ]);
+
+      const storyTitle = '타이틀';
+      const storyPoint = 2;
+      const storyStatus = '시작전';
+      requestData = {
+        action: 'create',
+        content: {
+          title: storyTitle,
+          point: storyPoint,
+          status: storyStatus,
+          epicId,
+        },
+      };
+      socket1.emit('story', requestData);
+      const [storyId] = await Promise.all([
+        getStoryId(socket1),
+        getStoryId(socket2),
+      ]);
+
+      await testCreateTask(
+        socket1,
+        socket2,
+        '타이틀',
+        '시작전',
+        storyId,
+        null,
+        null,
+        null,
+      );
+
+      await testCreateTask(
+        socket1,
+        socket2,
+        '타이틀',
+        '시작전',
+        storyId,
+        2.1,
+        3.3,
+        null,
+      );
+
+      await testCreateTask(
+        socket1,
+        socket2,
+        '타이틀',
+        '진행중',
+        storyId,
+        null,
+        null,
+        null,
+      );
+
+      await testCreateTask(
+        socket1,
+        socket2,
+        '타이틀',
+        '완료',
+        storyId,
+        null,
+        null,
+        null,
+      );
+
+      socket1.close();
+      socket2.close();
+    });
+
+    const testCreateTask = async (
+      socket1,
+      socket2,
+      title,
+      status,
+      storyId,
+      expectedTime,
+      actualTime,
+      assignedMemberId,
+    ) => {
+      const requestData = {
+        action: 'create',
+        content: {
+          title,
+          status,
+          storyId,
+          expectedTime,
+          actualTime,
+          assignedMemberId,
+        },
+      };
+      socket1.emit('task', requestData);
+
+      await Promise.all([
+        expectCreateTask(
+          socket1,
+          title,
+          status,
+          storyId,
+          expectedTime,
+          actualTime,
+          assignedMemberId,
+        ),
+        expectCreateTask(
+          socket2,
+          title,
+          status,
+          storyId,
+          expectedTime,
+          actualTime,
+          assignedMemberId,
+        ),
+      ]);
+    };
+
+    const expectCreateTask = (
+      socket,
+      title,
+      status,
+      storyId,
+      expectedTime,
+      actualTime,
+      assignedMemberId,
+    ) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('task');
+          expect(action).toBe('create');
+          expect(content?.id).toBeDefined();
+          expect(content?.displayId).toBeDefined();
+          expect(content?.title).toBe(title);
+          expect(content?.status).toBe(status);
+          expect(content?.storyId).toBe(storyId);
+          expect(content?.actualTime).toBe(actualTime);
+          expect(content?.expectedTime).toBe(expectedTime);
+          expect(content?.assignedMemberId).toBe(assignedMemberId);
+          resolve();
+        });
+      });
+    };
+  });
+
+  describe('task delete', () => {
+    it('should return deleted task data', async () => {
+      const socket = await getMemberJoinedLandingPage();
+      socket.emit('joinBacklog');
+      await initBacklog(socket);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket.emit('epic', requestData);
+      const [epicId] = await Promise.all([getEpicId(socket)]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket.emit('story', requestData);
+      const storyId = await getStoryId(socket);
+
+      let taskTitle = '타이틀';
+      let taskStatus = '시작전';
+      let expectedTime = null;
+      let actualTime = null;
+      let assignedMemberId = null;
+      requestData = {
+        action: 'create',
+        content: {
+          title: taskTitle,
+          status: taskStatus,
+          storyId,
+          expectedTime,
+          actualTime,
+          assignedMemberId,
+        },
+      };
+      socket.emit('task', requestData);
+      const taskId = await getTaskId(socket);
+
+      requestData = {
+        action: 'delete',
+        content: { id: taskId },
+      };
+      socket.emit('task', requestData);
+      await expectDeleteTask(socket, taskId);
+
+      socket.close();
+    });
+
+    const expectDeleteTask = (socket, id) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('task');
+          expect(action).toBe('delete');
+          expect(content?.id).toBe(id);
+          resolve();
+        });
+      });
+    };
+  });
+
+  describe('task update', () => {
+    it('should return updated task data when update color', async () => {
+      const socket = await getMemberJoinedLandingPage();
+      socket.emit('joinBacklog');
+      await initBacklog(socket);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket.emit('epic', requestData);
+      const [epicId] = await Promise.all([getEpicId(socket)]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket.emit('story', requestData);
+      const storyId = await getStoryId(socket);
+
+      let taskTitle = '타이틀';
+      let taskStatus = '시작전';
+      let expectedTime = null;
+      let actualTime = null;
+      let assignedMemberId = null;
+      requestData = {
+        action: 'create',
+        content: {
+          title: taskTitle,
+          status: taskStatus,
+          storyId,
+          expectedTime,
+          actualTime,
+          assignedMemberId,
+        },
+      };
+      socket.emit('task', requestData);
+      const taskId = await getTaskId(socket);
+
+      const newTitle = 'newTitle';
+      requestData = {
+        action: 'update',
+        content: { id: taskId, title: newTitle },
+      };
+      socket.emit('task', requestData);
+      await expectTitleUpdateTask(socket, taskId, newTitle);
+
+      const newExpectedTime = 5;
+      const newActualTime = 3;
+      const newStatus = '완료';
+      requestData = {
+        action: 'update',
+        content: {
+          id: taskId,
+          expectedTime: newExpectedTime,
+          actualTime: newActualTime,
+          status: newStatus,
+        },
+      };
+      socket.emit('task', requestData);
+      await expectTimeAndStatusWhenUpdateTask(
+        socket,
+        taskId,
+        newExpectedTime,
+        newActualTime,
+        newStatus,
+      );
+
+      socket.close();
+    });
+
+    const expectTitleUpdateTask = (socket, id, title) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('task');
+          expect(action).toBe('update');
+          expect(content?.id).toBe(id);
+          expect(content?.title).toBe(title);
+          resolve();
+        });
+      });
+    };
+
+    const expectTimeAndStatusWhenUpdateTask = (
+      socket,
+      id,
+      expectedTime,
+      actualTime,
+      status,
+    ) => {
+      return new Promise<void>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { content, action, domain } = data;
+          expect(domain).toBe('task');
+          expect(action).toBe('update');
+          expect(content?.id).toBe(id);
+          expect(content?.expectedTime).toBe(expectedTime);
+          expect(content?.actualTime).toBe(actualTime);
+          expect(content?.status).toBe(status);
+          resolve();
+        });
+      });
+    };
+  });
+});
+
+const initBacklog = async (socket: Socket) => {
+  return await new Promise<void>((resolve, reject) => {
+    socket.once('backlog', (data) => {
+      const { action, domain } = data;
+      if (action === 'init' && domain === 'backlog') {
+        resolve();
+      } else reject();
+    });
+  });
+};
+
+const getEpicId = (socket) => {
+  return new Promise((resolve) => {
+    socket.once('backlog', async (data) => {
+      const { content, action, domain } = data;
+      if (domain === 'epic' && action === 'create') {
+        resolve(content.id);
+      }
+    });
+  });
+};
+
+const getStoryId = (socket) => {
+  return new Promise((resolve) => {
+    socket.once('backlog', async (data) => {
+      const { content, action, domain } = data;
+      if (domain === 'story' && action === 'create') {
+        resolve(content.id);
+      }
+    });
+  });
+};
+
+const getTaskId = (socket) => {
+  return new Promise((resolve) => {
+    socket.once('backlog', async (data) => {
+      const { content, action, domain } = data;
+      if (domain === 'task' && action === 'create') {
+        resolve(content.id);
+      }
+    });
+  });
+};


### PR DESCRIPTION
## 🎟️ 태스크

[태스크 생성/삭제/수정 API 구현](https://plastic-toad-cb0.notion.site/API-6f9a6bd7f19c46ad99a3771e14b3c854?pvs=74)

## ✅ 작업 내용

- 태스크 생성, 삭제, 업데이트 엔티티, 레포지토리, 서비스 작성
- 태스크 생성, 삭제, 업데이트 게이트웨이, 컨트롤러, DTO작성
- 태스크 생성, 삭제, 업데이트 E2E 테스트 작성

## 🖊️ 구체적인 작업

### 태스크 생성, 삭제, 업데이트 엔티티, 레포지토리, 서비스 작성
- 태스크 엔티티 작성
- 프로젝트 별 고유 태스크 ID를 위한 displayIdCount를 프로젝트 엔티티에 추가
- 태스크를 모듈에 추가
- 태스크 create, delete, update 레포지토리, 서비스 메서드 작성
### 태스크 생성, 삭제, 업데이트 게이트웨이, 컨트롤러, DTO작성
- 태스크 이벤트를 처리하는 게이트웨이 로직 추가
- 태스크 생성, 삭제, 업데이트를 처리하는 컨트롤러 추가
- 태스크 생성, 삭제, 업데이트에 대해 요청/응답을 확인/생성하는 request, notify DTO 추가
### 태스크 생성, 삭제, 업데이트 E2E 테스트 작성