### PR TITLE
feat: 스토리 수정, 삭제 기능 구현, 에픽 기능 피드백 반영

### DIFF
--- a/frontend/src/components/backlog/BacklogStatusDropdown.tsx
+++ b/frontend/src/components/backlog/BacklogStatusDropdown.tsx
@@ -11,7 +11,7 @@ const BacklogStatusDropdown = ({
   const statusList: BacklogStatusType[] = ["시작전", "진행중", "완료"];
 
   return (
-    <div className="rounded-md w-fit shadow-box">
+    <div className="absolute top-0 bg-white rounded-md w-fit shadow-box">
       <ul>
         {...statusList.map((status) => (
           <li

--- a/frontend/src/components/backlog/CategoryChip.tsx
+++ b/frontend/src/components/backlog/CategoryChip.tsx
@@ -8,7 +8,8 @@ interface CategoryChipProps {
 
 const CategoryChip = ({ content, bgColor }: CategoryChipProps) => (
   <div
-    className={`w-fit max-w-[4.5rem] rounded-md ${CATEGORY_COLOR[bgColor]} px-2 py-[2px]`}
+    title={content}
+    className={`w-fit max-w-[4.5rem] rounded-md ${CATEGORY_COLOR[bgColor]} px-2 py-[2px] overflow-hidden text-ellipsis whitespace-nowrap`}
   >
     {content}
   </div>

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -8,21 +8,24 @@ import { CATEGORY_COLOR } from "../../constants/backlog";
 import getRandomNumber from "../../utils/getRandomNumber";
 import { BacklogCategoryColor } from "../../types/common/backlog";
 import EpicDropdownOption from "./EpicDropdownOption";
+import EpicUpdateBox from "./EpicUpdateBox";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
 
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
   epicList: EpicCategoryDTO[];
-  onEpicSelect: (epicId: number) => void;
+  onEpicChange: (epicId: number | undefined) => void;
 }
 
 const EpicDropdown = ({
   selectedEpic,
   epicList,
-  onEpicSelect,
+  onEpicChange,
 }: EpicDropdownProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitEpicCreateEvent } = useEpicEmitEvent(socket);
   const [value, setValue] = useState("");
+  const { open, handleOpen, handleClose } = useDropdownState();
 
   const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const { value } = target;
@@ -50,8 +53,8 @@ const EpicDropdown = ({
     }
   };
 
-  const handleEpicSelect = (epicId: number) => {
-    onEpicSelect(epicId);
+  const handleEpicChange = (epicId: number | undefined) => {
+    onEpicChange(epicId);
   };
 
   return (
@@ -76,8 +79,20 @@ const EpicDropdown = ({
       </div>
       <ul className="pt-1">
         {...epicList.map((epic) => (
-          <li key={epic.id} onClick={() => handleEpicSelect(epic.id)}>
-            <EpicDropdownOption key={epic.id} epic={epic} />
+          <li
+            key={epic.id}
+            onClick={() => {
+              handleEpicChange(epic.id);
+            }}
+          >
+            <EpicDropdownOption key={epic.id} epic={epic} onOpen={handleOpen} />
+            {open && (
+              <EpicUpdateBox
+                epic={epic}
+                onBoxClose={handleClose}
+                onEpicChange={handleEpicChange}
+              />
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -36,6 +36,11 @@ const EpicDropdown = ({
     }
 
     if (event.key === "Enter" && value) {
+      if (value.length > 10) {
+        alert("에픽 이름은 10자 이하여야 합니다.");
+        return;
+      }
+
       setValue("");
       const colors = Object.keys(CATEGORY_COLOR);
       const color = colors[

--- a/frontend/src/components/backlog/EpicDropdownOption.tsx
+++ b/frontend/src/components/backlog/EpicDropdownOption.tsx
@@ -1,44 +1,31 @@
 import CategoryChip from "./CategoryChip";
 import MenuKebab from "../../assets/icons/menu-kebab.svg?react";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
-import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
-import EpicUpdateBox from "./EpicUpdateBox";
-import { MouseEvent, useRef } from "react";
+
+import { MouseEvent } from "react";
 
 interface EpicDropdownOptionProps {
   epic: EpicCategoryDTO;
+  onOpen: () => void;
 }
 
-const EpicDropdownOption = ({ epic }: EpicDropdownOptionProps) => {
-  const { open, handleOpen, handleClose } = useDropdownState();
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-
+const EpicDropdownOption = ({ epic, onOpen }: EpicDropdownOptionProps) => {
   const handleMenuButtonClick = (event: MouseEvent) => {
     event.stopPropagation();
-    handleOpen();
+    onOpen();
   };
 
   return (
-    <>
-      <div className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100">
-        <CategoryChip content={epic.name} bgColor={epic.color} />
-        <button
-          className="invisible px-1 rounded-md group-hover:visible hover:bg-gray-300"
-          type="button"
-          onClick={handleMenuButtonClick}
-          ref={buttonRef}
-        >
-          <MenuKebab width={20} height={20} stroke="#696969" />
-        </button>
-      </div>
-      {open && (
-        <EpicUpdateBox
-          epic={epic}
-          onBoxClose={handleClose}
-          buttonRef={buttonRef}
-        />
-      )}
-    </>
+    <div className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100">
+      <CategoryChip content={epic.name} bgColor={epic.color} />
+      <button
+        className="invisible px-1 rounded-md group-hover:visible hover:bg-gray-300"
+        type="button"
+        onClick={handleMenuButtonClick}
+      >
+        <MenuKebab width={20} height={20} stroke="#696969" />
+      </button>
+    </div>
   );
 };
 

--- a/frontend/src/components/backlog/EpicUpdateBox.tsx
+++ b/frontend/src/components/backlog/EpicUpdateBox.tsx
@@ -13,10 +13,14 @@ import { BacklogCategoryColor } from "../../types/common/backlog";
 interface EpicUpdateBoxProps {
   epic: EpicCategoryDTO;
   onBoxClose: () => void;
-  buttonRef: React.MutableRefObject<HTMLButtonElement | null>;
+  onEpicChange: (epicId: number | undefined) => void;
 }
 
-const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
+const EpicUpdateBox = ({
+  epic,
+  onBoxClose,
+  onEpicChange,
+}: EpicUpdateBoxProps) => {
   const { open, close } = useModal();
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitEpicDeleteEvent, emitEpicUpdateEvent } = useEpicEmitEvent(socket);
@@ -26,6 +30,7 @@ const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
 
   const handleConfirmButtonClick = (event?: React.MouseEvent) => {
     event?.stopPropagation();
+    onEpicChange(undefined);
     emitEpicDeleteEvent({ id: epic.id });
     onBoxClose();
     close();
@@ -70,10 +75,6 @@ const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
   };
 
   const handleOutsideClick = ({ target }: MouseEvent) => {
-    if (buttonRef.current && buttonRef.current.contains(target as Node)) {
-      return;
-    }
-
     if (boxRef.current && !boxRef.current.contains(target as Node)) {
       onBoxClose();
     }

--- a/frontend/src/components/backlog/EpicUpdateBox.tsx
+++ b/frontend/src/components/backlog/EpicUpdateBox.tsx
@@ -24,12 +24,15 @@ const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const colorList = Object.entries(CATEGORY_COLOR);
 
-  const handleConfirmButtonClick = () => {
+  const handleConfirmButtonClick = (event?: React.MouseEvent) => {
+    event?.stopPropagation();
     emitEpicDeleteEvent({ id: epic.id });
+    onBoxClose();
     close();
   };
 
-  const handleDeleteButtonClick = () => {
+  const handleDeleteButtonClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
     open(
       <ConfirmModal
         title="에픽을 삭제하시겠습니까?"
@@ -54,7 +57,11 @@ const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
     }
   };
 
-  const handleColorUpdate = (color: BacklogCategoryColor) => {
+  const handleColorUpdate = (
+    event: React.MouseEvent,
+    color: BacklogCategoryColor
+  ) => {
+    event.stopPropagation();
     if (epic.color === color) {
       return;
     }
@@ -66,6 +73,7 @@ const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
     if (buttonRef.current && buttonRef.current.contains(target as Node)) {
       return;
     }
+
     if (boxRef.current && !boxRef.current.contains(target as Node)) {
       onBoxClose();
     }
@@ -100,7 +108,9 @@ const EpicUpdateBox = ({ epic, onBoxClose, buttonRef }: EpicUpdateBoxProps) => {
           <li
             key={color}
             className="flex items-center gap-2 pl-1 pr-2 mb-1 rounded-md hover:cursor-pointer hover:bg-gray-100"
-            onClick={() => handleColorUpdate(name as BacklogCategoryColor)}
+            onClick={(event) =>
+              handleColorUpdate(event, name as BacklogCategoryColor)
+            }
           >
             <div className={`w-5 h-5 rounded-md ${color}`}></div>
             <span>{name}</span>

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -1,5 +1,7 @@
+import { Socket } from "socket.io-client";
+import { useOutletContext } from "react-router-dom";
 import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
-import { BacklogStatusType } from "../../types/DTO/backlogDTO";
+import { BacklogStatusType, EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import BacklogStatusChip from "./BacklogStatusChip";
 import CategoryChip from "./CategoryChip";
 import TaskCreateButton from "./TaskCreateButton";
@@ -7,35 +9,176 @@ import ChevronDown from "../../assets/icons/chevron-down.svg?react";
 import ChevronRight from "../../assets/icons/chevron-right.svg?react";
 import TaskContainer from "./TaskContainer";
 import TaskHeader from "./TaskHeader";
+import BacklogStatusDropdown from "./BacklogStatusDropdown";
+import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
+import useBacklogInputChange from "../../hooks/pages/backlog/useBacklogInputChange";
+import { MouseEvent } from "react";
+import { MOUSE_KEY } from "../../constants/event";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
+import TrashCan from "../../assets/icons/trash-can.svg?react";
+import { useModal } from "../../hooks/common/modal/useModal";
+import ConfirmModal from "../common/ConfirmModal";
+import EpicDropdown from "./EpicDropdown";
 
 interface StoryBlockProps {
-  epic: string;
+  id: number;
+  epic: EpicCategoryDTO;
   title: string;
   point: number | null;
   progress: number;
   status: BacklogStatusType;
   children: React.ReactNode;
   taskExist: boolean;
+  epicList: EpicCategoryDTO[];
 }
 
 const StoryBlock = ({
+  id,
   epic,
   title,
   point,
   progress,
   status,
   taskExist,
+  epicList,
   children,
 }: StoryBlockProps) => {
+  const { socket }: { socket: Socket } = useOutletContext();
   const { showDetail, handleShowDetail } = useShowDetail();
+  const {
+    updating: titleUpdating,
+    handleUpdating: handleTitleUpdatingOpen,
+    inputContainerRef: titleRef,
+    inputElementRef: titleInputRef,
+  } = useBacklogInputChange(updateTitle);
+  const {
+    updating: pointUpdating,
+    handleUpdating: handlePointUpdatingOpen,
+    inputContainerRef: pointRef,
+    inputElementRef: pointInputRef,
+  } = useBacklogInputChange(updatePoint);
+  const {
+    open: statusUpdating,
+    handleOpen: handleStatusUpdateOpen,
+    dropdownRef: statusRef,
+  } = useDropdownState();
+  const {
+    open: epicUpdating,
+    handleOpen: handleEpicUpdateOpen,
+    handleClose: handleEpicUpdateClose,
+    dropdownRef: epicRef,
+  } = useDropdownState();
+  const {
+    open: deleteMenuOpen,
+    handleOpen: handleDeleteMenuOpen,
+
+    dropdownRef: blockRef,
+  } = useDropdownState();
+  const { emitStoryUpdateEvent, emitStoryDeleteEvent } =
+    useStoryEmitEvent(socket);
+  const { open, close } = useModal();
+
+  function updateTitle<T>(data: T) {
+    if (!data || data === title) {
+      return;
+    }
+
+    if ((data as string).length > 100) {
+      alert("스토리 제목은 100자 이하여야 합니다.");
+      return;
+    }
+
+    emitStoryUpdateEvent({ id, title: data as string });
+  }
+  function updatePoint<T>(data: T) {
+    if ((!data && data !== 0) || data === point) {
+      return;
+    }
+
+    if ((data as number) < 0 || (data as number) > 100) {
+      alert("스토리 포인트는 0이상 100이하여야 합니다.");
+      return;
+    }
+
+    emitStoryUpdateEvent({ id, point: Number(data) });
+  }
+
+  function updateStatus(data: BacklogStatusType) {
+    if (data === status) {
+      return;
+    }
+    emitStoryUpdateEvent({ id, status: data as BacklogStatusType });
+  }
+
+  function updateEpic(data: number | undefined) {
+    if (data === epic.id) {
+      return;
+    }
+
+    emitStoryUpdateEvent({ id, epicId: data });
+    handleEpicUpdateClose();
+  }
+
+  const handleRightButtonClick = (event: MouseEvent) => {
+    if (event.button === MOUSE_KEY.RIGHT) {
+      handleDeleteMenuOpen();
+    }
+  };
+
+  const handleEpicColumnClick = () => {
+    if (!epicUpdating) {
+      handleEpicUpdateOpen();
+    }
+  };
+
+  const handleStoryDelete = () => {
+    emitStoryDeleteEvent({ id });
+    close();
+  };
+
+  const handleDeleteButtonClick = () => {
+    open(
+      <ConfirmModal
+        title="스토리 삭제"
+        body="해당 스토리와 연결된 모든 태스크가 삭제됩니다."
+        confirmText="삭제"
+        cancelText="취소"
+        confirmColor="#E33535"
+        cancelColor="#C6C6C6"
+        onCancelButtonClick={close}
+        onConfirmButtonClick={handleStoryDelete}
+      />
+    );
+  };
 
   return (
     <>
-      <div className="flex items-center py-1 border-t border-b">
-        <div className="w-[5rem] mr-5">
-          <CategoryChip content={epic} bgColor="green" />
+      <div
+        className="flex items-center py-1 border-t border-b"
+        onMouseUp={handleRightButtonClick}
+        onContextMenu={(event) => event.preventDefault()}
+        ref={blockRef}
+      >
+        <div
+          className="w-[5rem] mr-5 hover:cursor-pointer"
+          onClick={handleEpicColumnClick}
+          ref={epicRef}
+        >
+          <CategoryChip content={epic.name} bgColor={epic.color} />
+
+          {epicUpdating && (
+            <EpicDropdown
+              selectedEpic={epic}
+              epicList={epicList}
+              onEpicChange={updateEpic}
+            />
+          )}
         </div>
-        <div className="flex items-center gap-1 w-[40.9rem] mr-4">
+        <div
+          className="flex items-center gap-1 w-[40.9rem] mr-4 hover:cursor-pointer"
+          onClick={() => handleTitleUpdatingOpen(true)}
+          ref={titleRef}
+        >
           <button
             className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
             type="button"
@@ -55,18 +198,62 @@ const StoryBlock = ({
               />
             )}
           </button>
-          <p>{title}</p>
+          {titleUpdating ? (
+            <input
+              className={`w-full rounded-sm focus:outline-none bg-gray-200 hover:cursor-pointer`}
+              type="text"
+              ref={titleInputRef}
+              defaultValue={title}
+            />
+          ) : (
+            <span className="w-full hover:cursor-pointer">{title}</span>
+          )}
         </div>
-        <div className="w-[4rem] mr-[2.76rem] text-right">
-          <p className="">{point} POINT</p>
+        <div
+          className="flex items-center gap-1 w-[4rem] mr-[2.76rem] text-right hover:cursor-pointer"
+          onClick={() => handlePointUpdatingOpen(true)}
+          ref={pointRef}
+        >
+          {pointUpdating ? (
+            <input
+              className={`w-fit min-w-[1rem] max-w-[3.5rem] no-arrows text-right focus:outline-none rounded-sm bg-gray-200 hover:cursor-pointer`}
+              type="number"
+              ref={pointInputRef}
+              defaultValue={point !== 0 && !point ? 0 : point}
+            />
+          ) : (
+            <span>{point}</span>
+          )}
+
+          <span> POINT</span>
         </div>
         <div className="w-[4rem] mr-[2.76rem] text-right">
           <span>{progress}%</span>
         </div>
-        <div className="w-[6.25rem]">
-          <BacklogStatusChip status={status} />
+        <div
+          className="w-[6.25rem] hover:cursor-pointer relative"
+          onClick={handleStatusUpdateOpen}
+        >
+          <div ref={statusRef}>
+            <BacklogStatusChip status={status} />
+          </div>
+          {statusUpdating && (
+            <BacklogStatusDropdown onOptionClick={updateStatus} />
+          )}
         </div>
       </div>
+      {deleteMenuOpen && (
+        <div className="absolute px-2 py-1 bg-white rounded-md shadow-box">
+          <button
+            className="flex items-center w-full gap-3"
+            type="button"
+            onClick={handleDeleteButtonClick}
+          >
+            <TrashCan width={20} height={20} fill="red" />
+            <span>삭제</span>
+          </button>
+        </div>
+      )}
       {showDetail && (
         <TaskContainer>
           <TaskHeader />

--- a/frontend/src/components/backlog/StoryCreateForm.tsx
+++ b/frontend/src/components/backlog/StoryCreateForm.tsx
@@ -6,7 +6,6 @@ import { StoryForm } from "../../types/common/backlog";
 import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
 import { Socket } from "socket.io-client";
 import { useOutletContext } from "react-router-dom";
-// import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import EpicDropdown from "./EpicDropdown";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
@@ -59,7 +58,7 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
     onCloseClick();
   };
 
-  const handleEpicChange = (selectedEpicId: number) => {
+  const handleEpicChange = (selectedEpicId: number | undefined) => {
     setStoryFormData({ title, status, point, epicId: selectedEpicId });
     handleClose();
   };
@@ -72,8 +71,9 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
 
   const selectedEpic = useMemo(
     () => epicList.filter(({ id }) => id === epicId)[0],
-    [epicId]
+    [epicId, epicList]
   );
+
   return (
     <form
       className="flex items-center w-full py-1 border-t border-b"
@@ -94,7 +94,7 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
           <EpicDropdown
             selectedEpic={selectedEpic}
             epicList={epicList}
-            onEpicSelect={handleEpicChange}
+            onEpicChange={handleEpicChange}
           />
         )}
       </div>

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -1,3 +1,5 @@
+import { MouseEvent } from "react";
+
 interface ConfirmModalProps {
   title: string;
   body: string;
@@ -5,7 +7,7 @@ interface ConfirmModalProps {
   cancelText: string;
   confirmColor: string;
   cancelColor: string;
-  onConfirmButtonClick: () => void;
+  onConfirmButtonClick: (event?: MouseEvent) => void;
   onCancelButtonClick: () => void;
 }
 

--- a/frontend/src/constants/event.ts
+++ b/frontend/src/constants/event.ts
@@ -1,0 +1,4 @@
+export const MOUSE_KEY = {
+  LEFT: 0,
+  RIGHT: 2,
+};

--- a/frontend/src/hooks/pages/backlog/useBacklogInputChange.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogInputChange.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from "react";
+
+const useBacklogInputChange = (update: <T>(data: T) => void) => {
+  const [updating, setUpdating] = useState<boolean>(false);
+  const inputContainerRef = useRef<HTMLDivElement | null>(null);
+  const inputElementRef = useRef<HTMLInputElement | null>(null);
+
+  const handleUpdating = (updating: boolean) => {
+    setUpdating(updating);
+  };
+
+  const handleOutsideClick = ({ target }: MouseEvent) => {
+    if (
+      inputContainerRef.current &&
+      !inputContainerRef.current.contains(target as Node)
+    ) {
+      if (!updating) {
+        return;
+      }
+
+      if (inputElementRef.current) {
+        update(inputElementRef.current.value);
+      }
+
+      setUpdating(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("mouseup", handleOutsideClick);
+
+    return () => {
+      window.removeEventListener("mouseup", handleOutsideClick);
+    };
+  }, [updating]);
+
+  return { updating, inputContainerRef, inputElementRef, handleUpdating };
+};
+
+export default useBacklogInputChange;

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -65,6 +65,34 @@ const useBacklogSocket = (socket: Socket) => {
           return { epicList: newEpicList };
         });
         break;
+      case BacklogSocketStoryAction.UPDATE:
+        setBacklog((prevBacklog) => {
+          const newEpicList = prevBacklog.epicList.map((epic) => {
+            const newStoryList = epic.storyList.map((story) => {
+              if (story.id === content.id) {
+                return { ...story, ...content };
+              }
+              return story;
+            });
+            return { ...epic, storyList: newStoryList };
+          });
+
+          return { epicList: newEpicList };
+        });
+
+        break;
+      case BacklogSocketStoryAction.DELETE:
+        setBacklog((prevBacklog) => {
+          const newEpicList = prevBacklog.epicList.map((epic) => {
+            const newStoryList = epic.storyList.filter(
+              ({ id }) => id !== content.id
+            );
+            return { ...epic, storyList: newStoryList };
+          });
+
+          return { epicList: newEpicList };
+        });
+        break;
     }
   };
 

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -23,12 +23,13 @@ const UnfinishedStoryPage = () => {
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="w-full border-b">
-        {...storyList.map(({ epic, title, point, status, taskList }) => (
+        {...storyList.map(({ id, epic, title, point, status, taskList }) => (
           <StoryBlock
-            {...{ title, point, status }}
-            epic={epic.name}
+            {...{ id, title, point, status }}
+            epic={epic}
             progress={2}
             taskExist={taskList.length > 0}
+            epicList={epicCategoryList}
           >
             {...taskList.map((task) => <TaskBlock {...task} />)}
           </StoryBlock>

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -16,6 +16,8 @@ export type BacklogCategoryColor =
   | "purple"
   | "gray";
 
+export type BacklogInputField = "title" | "point";
+
 export interface UnfinishedStory extends StoryDTO {
   epic: EpicCategoryDTO;
 }


### PR DESCRIPTION
## 🎟️ 태스크

[에픽 기능 피드백 반영](https://plastic-toad-cb0.notion.site/1b109721e4dd4dd28bdac9b42db4e46c)
[스토리 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-5b983a7e2ac84de2b4062377717f617c?pvs=74)

## ✅ 작업 내용

- 에픽 기능 피드백 반영(에픽 글자 수 제한, 에픽 수정 반영 등)
- 스토리 수정, 삭제 기능 구현

## 🖊️ 구체적인 작업

### 스토리 수정, 삭제 기능 구현

- 노션의 디자인을 차용해 스토리의 에픽, 타이틀, 포인트, 상태를 수정할 수 있도록 했습니다.
- 스토리를 우클릭할 시 삭제 버튼이 나와 삭제할 수 있도록 했습니다. 스토리를 삭제할 때도 해당 스토리에 있는 모든 태스크가 삭제되므로 모달을 통해 한 번 더 삭제 여부를 확인하도록 했습니다.

## 🤔 고민 및 의논할 거리
    
- 현재 스토리 블록 컴포넌트의 크기가 너무 커서 코드를 이해하기가 쉽지 않고, 버그가 발생할 확률이 높습니다. 컴포넌트 분리가 필요할 것 같은데 컴포넌트를 나누는 기준을 잘 고려해서 나눠야할 것 같습니다.
