### PR TITLE
feat: backlog 페이지 접속시 백로그 데이터 반환하도록 구현

### DIFF
--- a/backend/src/project/dto/InitBacklogResponse.dto.ts
+++ b/backend/src/project/dto/InitBacklogResponse.dto.ts
@@ -1,0 +1,83 @@
+import { Epic, EpicColor } from '../entity/epic.entity';
+import { Story, StoryStatus } from '../entity/story.entity';
+import { Task, TaskStatus } from '../entity/task.entity';
+
+class TaskDto {
+  id: number;
+  displayId: number;
+  title: string;
+  expectedTime: number | null;
+  actualTime: number | null;
+  status: TaskStatus;
+  assignedMemberId: number | null;
+
+  static of(task: Task): TaskDto {
+    const dto = new TaskDto();
+    dto.id = task.id;
+    dto.displayId = task.displayId;
+    dto.title = task.title;
+    dto.expectedTime = task.expectedTime;
+    dto.actualTime = task.actualTime;
+    dto.status = task.status;
+    dto.assignedMemberId = task.assignedMemberId;
+    return dto;
+  }
+}
+
+class StoryDto {
+  id: number;
+  title: string;
+  point: number | null;
+  status: StoryStatus;
+  taskList: TaskDto[];
+
+  static of(story: Story): StoryDto {
+    const dto = new StoryDto();
+    dto.id = story.id;
+    dto.title = story.title;
+    dto.point = story.point;
+    dto.status = story.status;
+    dto.taskList = story.taskList.map(TaskDto.of);
+    return dto;
+  }
+}
+
+class EpicDto {
+  id: number;
+  name: string;
+  color: EpicColor;
+  storyList: StoryDto[];
+
+  static of(epic: Epic): EpicDto {
+    const dto = new EpicDto();
+    dto.id = epic.id;
+    dto.name = epic.name;
+    dto.color = epic.color;
+    dto.storyList = epic.storyList.map(StoryDto.of);
+    return dto;
+  }
+}
+
+class BacklogDto {
+  backlog: { epicList: EpicDto[] };
+
+  static of(epicList: Epic[]): BacklogDto {
+    const dto = new BacklogDto();
+    dto.backlog = { epicList: epicList.map(EpicDto.of) };
+    return dto;
+  }
+}
+
+export class InitBacklogResponseDto {
+  domain: string;
+  action: string;
+  content: BacklogDto;
+
+  static of(epicList: Epic[]): InitBacklogResponseDto {
+    const dto = new InitBacklogResponseDto();
+    dto.domain = 'backlog';
+    dto.action = 'init';
+    dto.content = BacklogDto.of(epicList);
+    return dto;
+  }
+}

--- a/backend/src/project/entity/epic.entity.ts
+++ b/backend/src/project/entity/epic.entity.ts
@@ -4,10 +4,12 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Project } from './project.entity';
+import { Story } from './story.entity';
 
 export enum EpicColor {
   YELLOW = 'yellow',
@@ -27,7 +29,7 @@ export class Epic {
   @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
-  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @ManyToOne(() => Project, (project) => project.epicList, { nullable: false })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
@@ -42,6 +44,9 @@ export class Epic {
 
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
+
+  @OneToMany(() => Story, (story) => story.epic)
+  storyList: Story[];
 
   static of(project: Project, name: string, color: EpicColor) {
     const newEpic = new Epic();

--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -8,6 +8,7 @@ import {
   Generated,
   JoinColumn,
 } from 'typeorm';
+import { Epic } from './epic.entity';
 import { Link } from './link.entity.';
 import { Memo } from './memo.entity';
 import { ProjectToMember } from './project-member.entity';
@@ -45,14 +46,17 @@ export class Project {
   @OneToMany(() => Link, (link) => link.id)
   linkList: Link[];
 
-  @Column({type: 'int', nullable: false})
+  @Column({ type: 'int', nullable: false })
   displayIdCount: number;
+
+  @OneToMany(() => Epic, (epic) => epic.project)
+  epicList: Epic[];
 
   static of(title: string, subject: string) {
     const newProject = new Project();
     newProject.title = title;
     newProject.subject = subject;
-	newProject.displayIdCount = 0;
+    newProject.displayIdCount = 0;
     return newProject;
   }
 }

--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -3,10 +3,12 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Epic } from './epic.entity';
 import { Project } from './project.entity';
+import { Task } from './task.entity';
 
 export enum StoryStatus {
   NotStarted = '시작전',
@@ -22,14 +24,14 @@ export class Story {
   @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
-  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @ManyToOne(() => Project, { nullable: false })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
   @Column({ type: 'int', name: 'epic_id' })
   epicId: number;
 
-  @ManyToOne(() => Epic, (epic) => epic.id, { nullable: false })
+  @ManyToOne(() => Epic, (epic) => epic.storyList, { nullable: false })
   @JoinColumn({ name: 'epic_id' })
   epic: Epic;
 
@@ -41,6 +43,9 @@ export class Story {
 
   @Column({ type: 'varchar', length: 255, nullable: false })
   status: StoryStatus;
+
+  @OneToMany(()=>Task, (task)=>task.story)
+  taskList: Task[];
 
   static of(
     project: Project,

--- a/backend/src/project/entity/task.entity.ts
+++ b/backend/src/project/entity/task.entity.ts
@@ -23,14 +23,14 @@ export class Task {
   @Column({ type: 'int', name: 'project_id', nullable: false })
   projectId: number;
 
-  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @ManyToOne(() => Project, { nullable: false })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
   @Column({ type: 'int', name: 'story_id', nullable: false })
   storyId: number;
 
-  @ManyToOne(() => Story, (story) => story.id, { nullable: false })
+  @ManyToOne(() => Story, (story) => story.taskList, { nullable: false })
   @JoinColumn({ name: 'story_id' })
   story: Story;
 

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -264,4 +264,11 @@ export class ProjectRepository {
     );
     return !!result.affected;
   }
+
+  getProjectBacklog(project: Project) {
+    return this.epicRepository.find({
+      where: { project: { id: project.id } },
+      relations: ['storyList', 'storyList.taskList'],
+    });
+  }
 }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -211,4 +211,8 @@ export class ProjectService {
       assignedMemberId,
     );
   }
+  
+  getProjectBacklog(project: Project){
+	return this.projectRepository.getProjectBacklog(project);
+  }
 }

--- a/backend/src/project/ws-controller/ws-project.controller.ts
+++ b/backend/src/project/ws-controller/ws-project.controller.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InitBacklogResponseDto } from '../dto/InitBacklogResponse.dto';
 import { InitLandingResponseDto } from '../dto/InitLandingResponse.dto';
 import { MemberUpdateNotifyDto } from '../dto/member/MemberUpdateNotify.dto';
 import { MemberStatus } from '../enum/MemberStatus.enum';
@@ -53,10 +54,8 @@ export class WsProjectController {
   async joinBacklogPage(client: ClientSocket) {
     client.leave('landing');
     client.join('backlog');
-    client.emit('backlog', {
-      domain: 'backlog',
-      action: 'init',
-      content: {},
-    });
+    const backlog = await this.projectService.getProjectBacklog(client.project);
+
+    client.emit('backlog', InitBacklogResponseDto.of(backlog));
   }
 }

--- a/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
@@ -1,0 +1,146 @@
+import { Socket } from 'socket.io-client';
+import { app, appInit } from 'test/setup';
+import {
+  getTwoMemberJoinedLandingPage,
+} from '../ws-common';
+
+describe('WS epic', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await app.listen(3000);
+  });
+
+  describe('backlog init', () => {
+    it('should return backlog data', async () => {
+      const [socket1, socket2] = await getTwoMemberJoinedLandingPage();
+      socket1.emit('joinBacklog');
+      await initBacklog(socket1);
+      const epicName = '회원';
+      const epicColor = 'yellow';
+      socket1.emit('epic', {
+        action: 'create',
+        content: { name: epicName, color: epicColor },
+      });
+      const epicId = await getEpicId(socket1);
+      const storyTitle = '타이틀';
+      const storyPoint = 2;
+      const storyStatus = '시작전';
+      socket1.emit('story', {
+        action: 'create',
+        content: {
+          title: storyTitle,
+          point: storyPoint,
+          status: storyStatus,
+          epicId,
+        },
+      });
+      const storyId = await getStoryId(socket1);
+      const taskTitle = '타이틀';
+      const taskStatus = '시작전';
+      const taskExpectedTime = 3.5;
+      const taskActualTime = 3.5;
+      const taskAssignedMemberId = null;
+
+      socket1.emit('task', {
+        action: 'create',
+        content: {
+          title: taskTitle,
+          expectedTime: taskExpectedTime,
+          actualTime: taskActualTime,
+          status: taskStatus,
+          assignedMemberId: taskAssignedMemberId,
+          storyId,
+        },
+      });
+
+      const { id: taskId, displayId: taskDisplayId } =
+        await getTaskIdAndDisplayId(socket1);
+
+      socket2.emit('joinBacklog');
+
+      await new Promise<void>((resolve, reject) => {
+        socket2.once('backlog', async (data) => {
+          const { domain, action, content } = data;
+          if (domain === 'backlog' && action === 'init') {
+            try {
+              expect(content.backlog.epicList).toHaveLength(1);
+              const epic = content.backlog.epicList[0];
+              expect(epic.id).toBe(epicId);
+              expect(epic.name).toBe(epicName);
+              expect(epic.color).toBe(epicColor);
+              expect(epic.storyList).toHaveLength(1);
+              const story = epic.storyList[0];
+              expect(story.id).toBe(storyId);
+              expect(story.title).toBe(storyTitle);
+              expect(story.point).toBe(storyPoint);
+              expect(story.status).toBe(storyStatus);
+              expect(story.taskList).toHaveLength(1);
+              const task = story.taskList[0];
+              expect(task.id).toBe(taskId);
+              expect(task.displayId).toBe(taskDisplayId);
+              expect(task.title).toBe(taskTitle);
+              expect(task.expectedTime).toBe(taskExpectedTime);
+              expect(task.actualTime).toBe(taskActualTime);
+              expect(task.status).toBe(taskStatus);
+              expect(task.assignedMemberId).toBe(taskAssignedMemberId);
+            } catch (e) {
+              reject(e);
+            }
+            resolve();
+          }
+        });
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
+      });
+    });
+
+    const getEpicId = (socket) => {
+      return new Promise((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { domain, action, content } = data;
+          if (domain === 'epic' && action === 'create') {
+            resolve(content.id);
+            return;
+          }
+        });
+      });
+    };
+
+    const getStoryId = (socket) => {
+      return new Promise((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { domain, action, content } = data;
+          if (domain === 'story' && action === 'create') {
+            resolve(content.id);
+            return;
+          }
+        });
+      });
+    };
+
+    const getTaskIdAndDisplayId = (socket) => {
+      return new Promise<any>((resolve) => {
+        socket.once('backlog', async (data) => {
+          const { domain, action, content } = data;
+          if (domain === 'task' && action === 'create') {
+            resolve({ id: content.id, displayId: content.displayId });
+            return;
+          }
+        });
+      });
+    };
+  });
+});
+
+const initBacklog = async (socket: Socket) => {
+  return await new Promise<void>((resolve, reject) => {
+    socket.once('backlog', (data) => {
+      const { action, domain } = data;
+      if (action === 'init' && domain === 'backlog') {
+        resolve();
+      } else reject();
+    });
+  });
+};


### PR DESCRIPTION
## 🎟️ 태스크

[스토리 조회 API 구현(백엔드)](https://plastic-toad-cb0.notion.site/API-a974a1e261c74ee29705faff8ec339e3?pvs=74)

## ✅ 작업 내용

- 프로젝트, 에픽, 스토리, 태스크 ManyToOne 데코레이터 추가
- 백로그 조회 레포지토리, 서비스 메서드 작성
- initBacklog시 백로그 데이터 응답하도록 컨트롤러 구현, DTO 작성
- 백로그 조회 E2E 테스트 작성

## 🖊️ 구체적인 작업

### 프로젝트, 에픽, 스토리, 태스크 ManyToOne 데코레이터 추가
- ManyToOne 관계에서 relation을 걸어 조회가 가능하도록 엔티티에 [epic|story|task]List 프로퍼티추가
- OneToMany, ManyToOne 데코레이터의 인자로 (epic)=>epic.id가 아니라 epic=>epic.storyList 와 같이 서로의 관계를 정확하게 드러내도록 수정
### 백로그 조회 레포지토리, 서비스 메서드 작성
### initBacklog시 백로그 데이터 응답하도록 컨트롤러 구현, DTO 작성
### 백로그 조회 E2E 테스트 작성
