### PR TITLE
feat: 태스크 생성 API 연동, 스토리 피드백 반영

### DIFF
--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -206,7 +206,12 @@ const StoryBlock = ({
               defaultValue={title}
             />
           ) : (
-            <span className="w-full hover:cursor-pointer">{title}</span>
+            <span
+              title={title}
+              className="w-full overflow-hidden hover:cursor-pointer text-ellipsis whitespace-nowrap"
+            >
+              {title}
+            </span>
           )}
         </div>
         <div

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -4,7 +4,6 @@ import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import { BacklogStatusType, EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import BacklogStatusChip from "./BacklogStatusChip";
 import CategoryChip from "./CategoryChip";
-import TaskCreateButton from "./TaskCreateButton";
 import ChevronDown from "../../assets/icons/chevron-down.svg?react";
 import ChevronRight from "../../assets/icons/chevron-right.svg?react";
 import TaskContainer from "./TaskContainer";
@@ -19,6 +18,7 @@ import TrashCan from "../../assets/icons/trash-can.svg?react";
 import { useModal } from "../../hooks/common/modal/useModal";
 import ConfirmModal from "../common/ConfirmModal";
 import EpicDropdown from "./EpicDropdown";
+import TaskCreateBlock from "./TaskCreateBlock";
 
 interface StoryBlockProps {
   id: number;
@@ -263,7 +263,7 @@ const StoryBlock = ({
         <TaskContainer>
           <TaskHeader />
           {children}
-          <TaskCreateButton />
+          <TaskCreateBlock storyId={id} />
         </TaskContainer>
       )}
     </>

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -182,7 +182,10 @@ const StoryBlock = ({
           <button
             className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
             type="button"
-            onClick={() => handleShowDetail(!showDetail)}
+            onClick={(event) => {
+              event.stopPropagation();
+              handleShowDetail(!showDetail);
+            }}
           >
             {showDetail ? (
               <ChevronDown

--- a/frontend/src/components/backlog/StoryCreateForm.tsx
+++ b/frontend/src/components/backlog/StoryCreateForm.tsx
@@ -39,6 +39,7 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
+
     if (epicId === undefined) {
       alert("에픽을 지정해주세요.");
       return;
@@ -51,6 +52,21 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
 
     if (point === undefined) {
       alert("포인트를 입력해주세요.");
+      return;
+    }
+
+    if (title.length > 100) {
+      alert("스토리 타이틀은 100자 이하여야 합니다.");
+      return;
+    }
+
+    if (point < 0 || point > 100) {
+      alert("포인트는 0이상 100이하여야 합니다.");
+      return;
+    }
+
+    if (!Number.isInteger(point)) {
+      alert("포인트는 정수여야 합니다.");
       return;
     }
 

--- a/frontend/src/components/backlog/TaskCreateBlock.tsx
+++ b/frontend/src/components/backlog/TaskCreateBlock.tsx
@@ -1,0 +1,25 @@
+import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
+import TaskCreateButton from "./TaskCreateButton";
+import TaskCreateForm from "./TaskCreateForm";
+
+interface TaskCreateBlockProps {
+  storyId: number;
+}
+
+const TaskCreateBlock = ({ storyId }: TaskCreateBlockProps) => {
+  const { showDetail, handleShowDetail } = useShowDetail();
+  return (
+    <>
+      {showDetail ? (
+        <TaskCreateForm
+          {...{ storyId }}
+          onCloseClick={() => handleShowDetail(false)}
+        />
+      ) : (
+        <TaskCreateButton onClick={() => handleShowDetail(true)} />
+      )}
+    </>
+  );
+};
+
+export default TaskCreateBlock;

--- a/frontend/src/components/backlog/TaskCreateButton.tsx
+++ b/frontend/src/components/backlog/TaskCreateButton.tsx
@@ -1,10 +1,15 @@
 import Plus from "../../assets/icons/plus.svg?react";
 
-const TaskCreateButton = () => (
+interface TaskCreateButtonProps {
+  onClick: () => void;
+}
+
+const TaskCreateButton = ({ onClick }: TaskCreateButtonProps) => (
   <div className="py-1 text-dark-gray">
     <button
       className="flex items-center justify-center w-full gap-1"
       type="button"
+      onClick={onClick}
     >
       <Plus width={24} height={24} stroke="#696969" />
       <p>Task 생성하기</p>

--- a/frontend/src/components/backlog/TaskCreateForm.tsx
+++ b/frontend/src/components/backlog/TaskCreateForm.tsx
@@ -1,0 +1,130 @@
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useOutletContext } from "react-router-dom";
+import { Socket } from "socket.io-client";
+import Check from "../../assets/icons/check.svg?react";
+import Closed from "../../assets/icons/closed.svg?react";
+import useTaskEmitEvent from "../../hooks/pages/backlog/useTaskEmitEvent";
+import { TaskForm } from "../../types/common/backlog";
+
+interface TaskCreateFormProps {
+  onCloseClick: () => void;
+  storyId: number;
+}
+
+const TaskCreateForm = ({ onCloseClick, storyId }: TaskCreateFormProps) => {
+  const [taskFormData, setTaskFormData] = useState<TaskForm>({
+    title: "",
+    expectedTime: null,
+    actualTime: null,
+    status: "시작전",
+    assignedMemberId: null,
+    storyId,
+  });
+  const { socket }: { socket: Socket } = useOutletContext();
+  const { emitTaskCreateEvent } = useTaskEmitEvent(socket);
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setTaskFormData({ ...taskFormData, title: value });
+  };
+
+  const handleExpectedTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setTaskFormData({ ...taskFormData, expectedTime: Number(value) });
+  };
+
+  const handleActualTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setTaskFormData({ ...taskFormData, actualTime: Number(value) });
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    let { title, actualTime, expectedTime } = taskFormData;
+    console.log(taskFormData);
+
+    if (title.length > 100) {
+      alert("제목은 100자 이내여야 합니다.");
+      return;
+    }
+
+    if (
+      typeof expectedTime === "number" &&
+      (expectedTime < 0 || expectedTime >= 100)
+    ) {
+      alert("예상 시간은 0이상, 100 미만이어야 합니다.");
+      return;
+    }
+
+    if (
+      typeof actualTime === "number" &&
+      (actualTime < 0 || actualTime >= 100)
+    ) {
+      alert("실제 시간은 0이상, 100 미만이어야 합니다.");
+      return;
+    }
+
+    if (actualTime === "") {
+      actualTime = null;
+    }
+
+    if (expectedTime === "") {
+      expectedTime = null;
+    }
+
+    emitTaskCreateEvent({ ...taskFormData, actualTime, expectedTime });
+    onCloseClick();
+  };
+
+  return (
+    <form className="flex items-center justify-between px-1 py-1 border-b">
+      <div className="w-[4rem]" />
+      <input
+        type="text"
+        className="w-[25rem] bg-gray-200 rounded-sm focus:outline-none px-1"
+        onChange={handleTitleChange}
+      />
+      <div className="w-12"></div>
+      <div className="w-16 ">
+        <input
+          type="number"
+          className="max-w-full px-1 text-right bg-gray-200 rounded-sm no-arrows focus:outline-none"
+          onChange={handleExpectedTimeChange}
+          value={
+            taskFormData.expectedTime === null ? "" : taskFormData.expectedTime
+          }
+        />
+      </div>
+      <div className="w-16 ">
+        <input
+          type="number"
+          className="max-w-full px-1 text-right bg-gray-200 rounded-sm no-arrows focus:outline-none"
+          onChange={handleActualTimeChange}
+          value={
+            taskFormData.actualTime === null ? "" : taskFormData.actualTime
+          }
+        />
+      </div>
+      <div className="w-[6.25rem]">
+        <div className="flex items-center gap-2">
+          <button
+            className="flex items-center justify-center w-6 h-6 rounded-md bg-confirm-green"
+            type="button"
+            onClick={handleSubmit}
+          >
+            <Check width={20} height={20} stroke="white" />
+          </button>
+          <button
+            className="flex items-center justify-center w-6 h-6 rounded-md bg-error-red"
+            type="button"
+            onClick={onCloseClick}
+          >
+            <Closed stroke="white" />
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default TaskCreateForm;

--- a/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
@@ -1,0 +1,12 @@
+import { Socket } from "socket.io-client";
+import { TaskForm } from "../../../types/common/backlog";
+
+const useTaskEmitEvent = (socket: Socket) => {
+  const emitTaskCreateEvent = (content: TaskForm) => {
+    socket.emit("task", { action: "create", content });
+  };
+
+  return { emitTaskCreateEvent };
+};
+
+export default useTaskEmitEvent;

--- a/frontend/src/types/DTO/backlogDTO.ts
+++ b/frontend/src/types/DTO/backlogDTO.ts
@@ -17,6 +17,7 @@ export interface TaskDTO {
   actualTime: number | null;
   status: BacklogStatusType;
   assignedMemberId: number | null;
+  storyId: number;
 }
 
 export interface StoryDTO {

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -3,6 +3,7 @@ import {
   EpicCategoryDTO,
   EpicDTO,
   StoryDTO,
+  TaskDTO,
 } from "../DTO/backlogDTO";
 
 export type BacklogPath = "backlog" | "epic" | "completed";
@@ -29,6 +30,15 @@ export interface StoryForm {
   status: "시작전";
 }
 
+export interface TaskForm {
+  storyId: number;
+  title: string;
+  expectedTime: number | null | "";
+  actualTime: number | null | "";
+  status: "시작전";
+  assignedMemberId: null;
+}
+
 export enum BacklogSocketDomain {
   BACKLOG = "backlog",
   EPIC = "epic",
@@ -43,6 +53,12 @@ export enum BacklogSocketEpicAction {
 }
 
 export enum BacklogSocketStoryAction {
+  CREATE = "create",
+  DELETE = "delete",
+  UPDATE = "update",
+}
+
+export enum BacklogSocketTaskAction {
   CREATE = "create",
   DELETE = "delete",
   UPDATE = "update",
@@ -66,7 +82,14 @@ export interface BacklogSocketStoryData {
   content: StoryDTO;
 }
 
+export interface BacklogSocketTaskData {
+  domain: BacklogSocketDomain.TASK;
+  action: BacklogSocketTaskAction;
+  content: TaskDTO;
+}
+
 export type BacklogSocketData =
   | BacklogSocketInitData
   | BacklogSocketEpicData
-  | BacklogSocketStoryData;
+  | BacklogSocketStoryData
+  | BacklogSocketTaskData;


### PR DESCRIPTION
## 🎟️ 태스크

[태스크 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-9967c3b1ef5d4610bbcbeb4c2b2f887b)
[스토리 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-5b983a7e2ac84de2b4062377717f617c)

## ✅ 작업 내용

- 태스크 생성 API 연동
- 스토리 피드백 반영(스토리 타이틀 글자 수 제한, 스토리 포인트 범위 제한, 스토리 타이틀의 길이가 길 시 말줄임표 표시)

## 🖊️ 구체적인 작업

### 태스크 생성 API 연동
- 태스크를 생성할 때 예상 시간, 실제 시간을 입력하지 않더라도 생성할 수 있도록 했습니다.
- 담당자는 스프린트 중에 분배되도록 하기 위해 미리 입력받지 않도록 했습니다.

## 📸 결과 화면
![녹화_2024_07_15_15_09_03_68](https://github.com/user-attachments/assets/a7380a1f-e04b-414e-acb8-71dc75f2b417)
