### PR TITLE
feat: epic, story, task 엔티티, DTO에 대해 제약조건 설정

### DIFF
--- a/backend/src/project/dto/epic/EpicCreateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicCreateRequest.dto.ts
@@ -1,9 +1,17 @@
 import { Type } from 'class-transformer';
-import { IsEnum, IsNotEmpty, IsString, Matches, ValidateNested } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsString,
+  Length,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
 import { EpicColor } from 'src/project/entity/epic.entity';
 
 class Epic {
   @IsString()
+  @Length(1, 10)
   name: string;
 
   @IsEnum(EpicColor)

--- a/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
@@ -7,6 +7,7 @@ import {
   IsString,
   Matches,
   ValidateNested,
+  Length,
 } from 'class-validator';
 import { EpicColor } from 'src/project/entity/epic.entity';
 
@@ -17,6 +18,7 @@ class Epic {
 
   @IsOptional()
   @IsString()
+  @Length(1, 10)
   name?: string;
 
   @IsOptional()

--- a/backend/src/project/dto/story/StoryCreateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryCreateRequest.dto.ts
@@ -4,16 +4,22 @@ import {
   IsInt,
   IsNotEmpty,
   IsString,
+  Length,
   Matches,
+  Max,
+  Min,
   ValidateNested,
 } from 'class-validator';
 import { StoryStatus } from 'src/project/entity/story.entity';
 
 class Story {
   @IsString()
+  @Length(1, 100)
   title: string;
 
   @IsInt()
+  @Min(0)
+  @Max(100)
   point: number;
 
   @IsEnum(StoryStatus)

--- a/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
@@ -5,7 +5,10 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Length,
   Matches,
+  Max,
+  Min,
   ValidateNested,
 } from 'class-validator';
 import { StoryStatus } from 'src/project/entity/story.entity';
@@ -20,10 +23,13 @@ class Story {
 
   @IsOptional()
   @IsString()
+  @Length(1, 100)
   title?: string;
-
+  
   @IsOptional()
   @IsInt()
+  @Min(0)
+  @Max(100)
   point?: number;
 
   @IsOptional()

--- a/backend/src/project/dto/task/TaskCreateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskCreateRequest.dto.ts
@@ -41,7 +41,7 @@ export function IsOneDecimalPlace(validationOptions?: ValidationOptions) {
 
 class Task {
   @IsString()
-  @Length(0, 100, { message: 'Title must be 100 characters or less' })
+  @Length(1, 100, { message: 'Title must be 100 characters or less' })
   title: string;
 
   @IsOptional()

--- a/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Length,
   Matches,
   ValidateNested,
 } from 'class-validator';
@@ -21,6 +22,7 @@ class Task {
 
   @IsOptional()
   @IsString()
+  @Length(1, 100)
   title?: string;
 
   @IsOptional()

--- a/backend/src/project/entity/epic.entity.ts
+++ b/backend/src/project/entity/epic.entity.ts
@@ -33,7 +33,7 @@ export class Epic {
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
-  @Column({ type: 'varchar', length: 255, nullable: false })
+  @Column({ type: 'varchar', length: 10, nullable: false })
   name: string;
 
   @Column({ type: 'varchar', length: 255, nullable: false })

--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -35,7 +35,7 @@ export class Story {
   @JoinColumn({ name: 'epic_id' })
   epic: Epic;
 
-  @Column({ type: 'varchar', length: 255, nullable: false })
+  @Column({ type: 'varchar', length: 100, nullable: false })
   title: string;
 
   @Column({ type: 'int', nullable: false })

--- a/backend/src/project/entity/task.entity.ts
+++ b/backend/src/project/entity/task.entity.ts
@@ -34,7 +34,7 @@ export class Task {
   @JoinColumn({ name: 'story_id' })
   story: Story;
 
-  @Column({ type: 'varchar', length: 99, nullable: false })
+  @Column({ type: 'varchar', length: 100, nullable: false })
   title: string;
 
   @Column({ type: 'int', nullable: false })


### PR DESCRIPTION
## 🎟️ 태스크

[스토리 타이틀, 포인트 제약조건 수정하기(백엔드)](https://plastic-toad-cb0.notion.site/e554eeaae433457085b0fa3a23589889?pvs=74)
[에픽 이름 제약조건 수정하기(백엔드)](https://plastic-toad-cb0.notion.site/e3bcc8172e694936b809232e70e64941?pvs=74)

## ✅ 작업 내용

## feat: epic, story, task 엔티티, DTO에 대해 제약조건 설정

- epic
  - name을 1자 이상 10자 이하로 설정
- story
  - title을 1자 이상 100자 이하로 설정
  - point을 1 포인트 이상 100 포인트 이하로 설정
- task
  - title을 1자 이상 100자 이하로 설정