### PR TITLE
feat: 태스크 삭제, 수정 API 연동

### DIFF
--- a/frontend/src/components/backlog/AssignedMemberDropdown.tsx
+++ b/frontend/src/components/backlog/AssignedMemberDropdown.tsx
@@ -13,11 +13,11 @@ const AssignedMemberDropdown = ({
   const memberList = [myInfo, ...partialMemberList];
 
   return (
-    <div className="rounded-md w-fit shadow-box">
+    <div className="absolute top-0 bg-white rounded-md w-fit shadow-box">
       <ul>
         {...memberList.map((member: LandingMemberDTO) => (
           <li
-            className="p-2 hover:cursor-pointer hover:bg-gray-100"
+            className="p-3 overflow-hidden rounded-md hover:cursor-pointer hover:bg-gray-100 text-ellipsis whitespace-nowrap"
             key={member.id}
             onClick={() => onOptionClick(member.id)}
           >

--- a/frontend/src/components/backlog/TaskBlock.tsx
+++ b/frontend/src/components/backlog/TaskBlock.tsx
@@ -1,33 +1,210 @@
-import { TaskDTO } from "../../types/DTO/backlogDTO";
+import { useOutletContext } from "react-router-dom";
+import { Socket } from "socket.io-client";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
+import useBacklogInputChange from "../../hooks/pages/backlog/useBacklogInputChange";
+import useTaskEmitEvent from "../../hooks/pages/backlog/useTaskEmitEvent";
+import { BacklogStatusType, TaskDTO } from "../../types/DTO/backlogDTO";
+import AssignedMemberDropdown from "./AssignedMemberDropdown";
 import BacklogStatusChip from "./BacklogStatusChip";
-import CategoryChip from "./CategoryChip";
+import BacklogStatusDropdown from "./BacklogStatusDropdown";
+import useMemberStore from "../../stores/useMemberStore";
+import { useMemo } from "react";
 
 const TaskBlock = ({
+  id,
   displayId,
   title,
   assignedMemberId,
   expectedTime,
   actualTime,
   status,
-}: TaskDTO) => (
-  <div className="flex items-center justify-between py-1 border-b">
-    <p className="w-[4rem]">Task-{displayId}</p>
-    <p className="w-[25rem]">{title}</p>
-    <div className="w-12">
-      {assignedMemberId && (
-        <CategoryChip content={`${assignedMemberId}`} bgColor="green" />
-      )}
+}: TaskDTO) => {
+  const { socket }: { socket: Socket } = useOutletContext();
+  const {
+    inputContainerRef: titleRef,
+    inputElementRef: titleInputRef,
+    updating: titleUpdating,
+    handleUpdating: handleTitleUpdating,
+  } = useBacklogInputChange(updateTitle);
+  const {
+    inputContainerRef: expectedTimeRef,
+    inputElementRef: expectedTimeInputRef,
+    updating: expectedTimeUpdating,
+    handleUpdating: handleExpectedTimeUpdating,
+  } = useBacklogInputChange(updateExpectedTime);
+  const {
+    inputContainerRef: actualTimeRef,
+    inputElementRef: actualTimeInputRef,
+    updating: actualTimeUpdating,
+    handleUpdating: handleActualTimeUpdating,
+  } = useBacklogInputChange(updateActualTime);
+  const {
+    open: assignedMemberUpdating,
+    handleOpen: handleAssignedMemberUpdateOpen,
+    dropdownRef: assignedMemberRef,
+  } = useDropdownState();
+  const {
+    open: statusUpdating,
+    handleOpen: handleStatusUpdateOpen,
+    dropdownRef: statusRef,
+  } = useDropdownState();
+  const myInfo = useMemberStore((state) => state.myInfo);
+  const partialMemberList = useMemberStore((state) => state.memberList);
+  const { emitTaskUpdateEvent } = useTaskEmitEvent(socket);
+
+  const assignedMemberName = useMemo(() => {
+    if (assignedMemberId === null) {
+      return "";
+    }
+
+    if (myInfo.id === assignedMemberId) {
+      return myInfo.username;
+    }
+
+    return partialMemberList.filter(({ id }) => id === assignedMemberId)[0]
+      .username;
+  }, [assignedMemberId, partialMemberList]);
+
+  function updateTitle<T>(data: T) {
+    if (!data || data === title) {
+      return;
+    }
+
+    if ((data as string).length > 100) {
+      alert("태스크 타이틀은 100자 이하여야 합니다.");
+      return;
+    }
+
+    emitTaskUpdateEvent({ id, title: data as string });
+  }
+  function updateExpectedTime<T>(data: T) {
+    if (!data || data === String(expectedTime)) {
+      return;
+    }
+
+    if (data === "") {
+      emitTaskUpdateEvent({ id, expectedTime: null });
+      return;
+    }
+
+    if (!isNaN(Number(data)) && (Number(data) >= 100 || Number(data) < 0)) {
+      alert(
+        "예상 시간은 0이상, 100미만의 정수 또는 소수점 한 자릿수여야 합니다."
+      );
+      return;
+    }
+
+    emitTaskUpdateEvent({ id, expectedTime: Number(data) });
+  }
+  function updateActualTime<T>(data: T) {
+    if (!data || data === String(actualTime)) {
+      return;
+    }
+
+    if (data === "") {
+      emitTaskUpdateEvent({ id, actualTime: null });
+      return;
+    }
+
+    if (!isNaN(Number(data)) && (Number(data) >= 100 || Number(data) < 0)) {
+      alert(
+        "실제 시간은 0이상, 100미만의 정수 또는 소수점 한 자릿수여야 합니다."
+      );
+      return;
+    }
+    emitTaskUpdateEvent({ id, actualTime: Number(data) });
+  }
+  function updateAssignedMember(data: number) {
+    if (data === assignedMemberId) {
+      return;
+    }
+
+    emitTaskUpdateEvent({ id, assignedMemberId: data });
+  }
+
+  function updateStatus(data: BacklogStatusType) {
+    if (data === status) {
+      return;
+    }
+
+    emitTaskUpdateEvent({ id, status: data });
+  }
+
+  return (
+    <div className="flex items-center justify-between py-1 border-b">
+      <p className="w-[4rem]">Task-{displayId}</p>
+      <div
+        className="w-[25rem] min-h-[1.5rem] hover:cursor-pointer"
+        ref={titleRef}
+        onClick={() => handleTitleUpdating(true)}
+      >
+        {titleUpdating ? (
+          <input
+            className="w-full min-w-[1rem] focus:outline-none rounded-sm bg-gray-200 hover:cursor-pointer"
+            ref={titleInputRef}
+            defaultValue={title}
+            type="text"
+          />
+        ) : (
+          <span>{title}</span>
+        )}
+      </div>
+      <div
+        className="w-12 min-h-[1.5rem] hover:cursor-pointer relative"
+        onClick={handleAssignedMemberUpdateOpen}
+      >
+        <div className="w-full min-h-[1.5rem]" ref={assignedMemberRef}>
+          {assignedMemberId && <p>{assignedMemberName}</p>}
+        </div>
+        {assignedMemberUpdating && (
+          <AssignedMemberDropdown onOptionClick={updateAssignedMember} />
+        )}
+      </div>
+      <div
+        className="w-16 min-h-[1.5rem] hover:cursor-pointer"
+        ref={expectedTimeRef}
+        onClick={() => handleExpectedTimeUpdating(true)}
+      >
+        {expectedTimeUpdating ? (
+          <input
+            className="w-full min-w-[1rem] no-arrows text-right focus:outline-none rounded-sm bg-gray-200 hover:cursor-pointer"
+            ref={expectedTimeInputRef}
+            defaultValue={expectedTime === null ? "" : expectedTime}
+            type="number"
+          />
+        ) : (
+          <p className="max-w-full text-right">{expectedTime}</p>
+        )}
+      </div>
+      <div
+        className="w-16 min-h-[1.5rem] hover:cursor-pointer"
+        ref={actualTimeRef}
+        onClick={() => handleActualTimeUpdating(true)}
+      >
+        {actualTimeUpdating ? (
+          <input
+            className="w-full min-w-[1rem] no-arrows text-right focus:outline-none rounded-sm bg-gray-200 hover:cursor-pointer"
+            ref={actualTimeInputRef}
+            defaultValue={actualTime === null ? "" : actualTime}
+            type="number"
+          />
+        ) : (
+          <p className="min-w-full text-right">{actualTime}</p>
+        )}
+      </div>
+      <div
+        className="w-[6.25rem] hover:cursor-pointer relative"
+        onClick={handleStatusUpdateOpen}
+      >
+        <div ref={statusRef}>
+          <BacklogStatusChip status={status} />
+        </div>
+        {statusUpdating && (
+          <BacklogStatusDropdown onOptionClick={updateStatus} />
+        )}
+      </div>
     </div>
-    <div className="w-16 ">
-      <p className="max-w-full text-right">{expectedTime}</p>
-    </div>
-    <div className="w-16 ">
-      <p className="max-w-full text-right">{actualTime}</p>
-    </div>
-    <div className="w-[6.25rem]">
-      <BacklogStatusChip status={status} />
-    </div>
-  </div>
-);
+  );
+};
 
 export default TaskBlock;

--- a/frontend/src/components/backlog/TaskCreateForm.tsx
+++ b/frontend/src/components/backlog/TaskCreateForm.tsx
@@ -41,7 +41,6 @@ const TaskCreateForm = ({ onCloseClick, storyId }: TaskCreateFormProps) => {
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     let { title, actualTime, expectedTime } = taskFormData;
-    console.log(taskFormData);
 
     if (title.length > 100) {
       alert("제목은 100자 이내여야 합니다.");

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -151,6 +151,22 @@ const useBacklogSocket = (socket: Socket) => {
         });
 
         break;
+      case BacklogSocketTaskAction.DELETE:
+        setBacklog((prevBacklog) => {
+          const newEpicList = prevBacklog.epicList.map((epic) => {
+            const newStoryList = epic.storyList.map((story) => {
+              const newTaskList = story.taskList.filter(
+                ({ id }) => id !== content.id
+              );
+
+              return { ...story, taskList: newTaskList };
+            });
+            return { ...epic, storyList: newStoryList };
+          });
+
+          return { epicList: newEpicList };
+        });
+        break;
     }
   };
 

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -130,6 +130,27 @@ const useBacklogSocket = (socket: Socket) => {
           return { epicList: newEpicList };
         });
         break;
+      case BacklogSocketTaskAction.UPDATE:
+        setBacklog((prevBacklog) => {
+          const newEpicList = prevBacklog.epicList.map((epic) => {
+            const newStoryList = epic.storyList.map((story) => {
+              const newTaskList = story.taskList.map((task) => {
+                if (task.id === content.id) {
+                  return { ...task, ...content };
+                }
+
+                return task;
+              });
+
+              return { ...story, taskList: newTaskList };
+            });
+            return { ...epic, storyList: newStoryList };
+          });
+
+          return { epicList: newEpicList };
+        });
+
+        break;
     }
   };
 

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -62,7 +62,10 @@ const useBacklogSocket = (socket: Socket) => {
         setBacklog((prevBacklog) => {
           const newEpicList = prevBacklog.epicList.map((epic) => {
             if (epic.id === content.epicId) {
-              const newStoryList = [...epic.storyList, content];
+              const newStoryList = [
+                ...epic.storyList,
+                { ...content, taskList: [] },
+              ];
               return { ...epic, storyList: newStoryList };
             }
 

--- a/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
@@ -1,12 +1,25 @@
 import { Socket } from "socket.io-client";
 import { TaskForm } from "../../../types/common/backlog";
+import { BacklogStatusType } from "../../../types/DTO/backlogDTO";
 
 const useTaskEmitEvent = (socket: Socket) => {
   const emitTaskCreateEvent = (content: TaskForm) => {
     socket.emit("task", { action: "create", content });
   };
 
-  return { emitTaskCreateEvent };
+  const emitTaskUpdateEvent = (content: {
+    id: number;
+    title?: string;
+    expectedTime?: number | null;
+    actualTime?: number | null;
+    assignedMemberId?: number;
+    storyId?: number;
+    status?: BacklogStatusType;
+  }) => {
+    socket.emit("task", { action: "update", content });
+  };
+
+  return { emitTaskCreateEvent, emitTaskUpdateEvent };
 };
 
 export default useTaskEmitEvent;

--- a/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
@@ -19,7 +19,11 @@ const useTaskEmitEvent = (socket: Socket) => {
     socket.emit("task", { action: "update", content });
   };
 
-  return { emitTaskCreateEvent, emitTaskUpdateEvent };
+  const emitTaskDeleteEvent = (content: {id: number}) => {
+    socket.emit("task", {action: "delete", content})
+  }
+
+  return { emitTaskCreateEvent, emitTaskUpdateEvent, emitTaskDeleteEvent };
 };
 
 export default useTaskEmitEvent;


### PR DESCRIPTION
## 🎟️ 태스크

[태스크 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-9967c3b1ef5d4610bbcbeb4c2b2f887b?pvs=74)

## ✅ 작업 내용

- 태스크 수정, 삭제 API 연동

## 🖊️ 구체적인 작업

### 태스크 수정, 삭제 API 연동

- 스토리 수정, 삭제 API와 동일한 방식으로 태스크 수정, 삭제 API를 연동했습니다. 태스크 또한 태스크 블록 컴포넌트의 크기가 커져 코드 파악이 힘들고, 버그가 발생하기 쉽기 때문에 리팩토링이 필요합니다.