### PR TITLE
feat: Patch형태의 업데이트 API에서 변경하는 프로퍼티가 없을경우 업데이트가 실패하도록 구현

### DIFF
--- a/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
@@ -10,10 +10,12 @@ import {
   Length,
 } from 'class-validator';
 import { EpicColor } from 'src/project/entity/epic.entity';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 
 class Epic {
   @IsNotEmpty()
   @IsInt()
+  @AtLeastOneProperty(['name', 'color'])
   id: number;
 
   @IsOptional()

--- a/backend/src/project/dto/member/MemberUpdateRequest.dto.ts
+++ b/backend/src/project/dto/member/MemberUpdateRequest.dto.ts
@@ -8,10 +8,12 @@ import {
   Matches,
   ValidateNested,
 } from 'class-validator';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 import { MemberStatus } from '../../enum/MemberStatus.enum';
 
 class Content {
   @IsInt()
+  @AtLeastOneProperty(['username', 'imageUrl', 'status'])
   id: number;
 
   @IsString()

--- a/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
@@ -12,9 +12,16 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { StoryStatus } from 'src/project/entity/story.entity';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 
 class Story {
   @IsInt()
+  @AtLeastOneProperty([
+	'epicId',
+	'title',
+	'point',
+	'status'
+  ])
   id: number;
 
   @IsOptional()

--- a/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
@@ -10,10 +10,19 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { TaskStatus } from 'src/project/entity/task.entity';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 import { IsOneDecimalPlace } from './TaskCreateRequest.dto';
 
 class Task {
   @IsInt()
+  @AtLeastOneProperty([
+    'storyId',
+    'title',
+    'expectedTime',
+    'actualTime',
+    'assignedMemberId',
+    'status',
+  ])
   id: number;
 
   @IsOptional()
@@ -28,7 +37,7 @@ class Task {
   @IsOptional()
   @IsOneDecimalPlace()
   expectedTime?: number;
-  
+
   @IsOptional()
   @IsOneDecimalPlace()
   actualTime?: number;

--- a/backend/src/project/util/validation.util.ts
+++ b/backend/src/project/util/validation.util.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from 'class-validator';
+import { registerDecorator, ValidationArguments, ValidationError, ValidationOptions } from 'class-validator';
 
 export function getRecursiveErrorMsgList(errors: ValidationError[]): string[] {
   return errors.reduce((acc, error) => {
@@ -11,3 +11,28 @@ export function getRecursiveErrorMsgList(errors: ValidationError[]): string[] {
     return acc;
   }, []);
 }
+
+export function AtLeastOneProperty(
+	properties: string[],
+	validationOptions?: ValidationOptions
+  ) {
+	return function (object: Object, propertyName: string) {
+	  registerDecorator({
+		name: 'atLeastOneProperty',
+		target: object.constructor,
+		propertyName: propertyName,
+		options: validationOptions,
+		constraints: [properties],
+		validator: {
+		  validate(value: any, args: ValidationArguments) {
+			const object = args.object as any;
+			return properties.some((property) => object[property] !== undefined);
+		  },
+		  defaultMessage(args: ValidationArguments) {
+			const properties = args.constraints[0];
+			return `At least one of these properties must be provided: ${properties.join(', ')}`;
+		  },
+		},
+	  });
+	};
+  }

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -159,6 +159,43 @@ describe('WS story', () => {
         });
       });
     };
+
+    it('should return error when updated property is do not exist', async () => {
+      const socket = await getMemberJoinedLandingPage();
+      socket.emit('joinBacklog');
+      await initBacklog(socket);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket.emit('epic', requestData);
+      const [epicId] = await Promise.all([getEpicId(socket)]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket.emit('story', requestData);
+      const storyId = await getStoryId(socket);
+
+      requestData = {
+        action: 'update',
+        content: { id: storyId },
+      };
+      socket.emit('story', requestData);
+      await new Promise<void>((resolve) => {
+        socket.on('error', () => {
+          resolve();
+        });
+      });
+      socket.close();
+    });
   });
 });
 


### PR DESCRIPTION
## 🎟️ 태스크

[Patch형태의 업데이트 API에서 변경하는 프로퍼티가 없을경우 업데이트가 실패하도록 변경하기](https://plastic-toad-cb0.notion.site/Patch-API-411a6381874d4ac89b82612b371cfc72?pvs=74)

## ✅ 작업 내용

- Patch형태의 수정 API에서 수정할 프로퍼티가 없으면 유효하지 않은 요청으로 판단하는 유효성검사 추가
- story update API에서 업데이트할 프로퍼티가 존재하지 않을 경우 에러임을 확인하는 테스트 추가

## 🖊️ 구체적인 작업

### Patch형태의 수정 API에서 수정할 프로퍼티가 없으면 유효하지 않은 요청으로 판단하는 유효성검사 추가
- epic 수정 API에 적용
- story 수정 API에 적용
- task 수정 API에 적용
- member 수정 API에 적용
### story update API에서 업데이트할 프로퍼티가 존재하지 않을 경우 에러임을 확인하는 테스트 추가
- 장애가 발생한 케이스에 대한 회귀테스트임