### PR TITLE
fix: patch형태의 update API에서 falsy값인 경우 notify가 되지 않는 버그 수정

### DIFF
--- a/backend/src/project/dto/epic/EpicUpdateNotify.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateNotify.dto.ts
@@ -7,8 +7,8 @@ class Epic {
   static of(id: number, name: string, color: EpicColor) {
     const dto = new Epic();
     dto.id = id;
-    if (name) dto.name = name;
-    if (color) dto.color = color;
+    if (name !== undefined) dto.name = name;
+    if (color !== undefined) dto.color = color;
     return dto;
   }
 }

--- a/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
@@ -10,10 +10,12 @@ import {
   Length,
 } from 'class-validator';
 import { EpicColor } from 'src/project/entity/epic.entity';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 
 class Epic {
   @IsNotEmpty()
   @IsInt()
+  @AtLeastOneProperty(['name', 'color'])
   id: number;
 
   @IsOptional()

--- a/backend/src/project/dto/member/MemberUpdateRequest.dto.ts
+++ b/backend/src/project/dto/member/MemberUpdateRequest.dto.ts
@@ -8,10 +8,12 @@ import {
   Matches,
   ValidateNested,
 } from 'class-validator';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 import { MemberStatus } from '../../enum/MemberStatus.enum';
 
 class Content {
   @IsInt()
+  @AtLeastOneProperty(['username', 'imageUrl', 'status'])
   id: number;
 
   @IsString()

--- a/backend/src/project/dto/story/StoryUpdateNotify.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateNotify.dto.ts
@@ -16,10 +16,10 @@ class Story {
   ) {
     const dto = new Story();
     dto.id = id;
-    if (title) dto.title = title;
-    if (point) dto.point = point;
-    if (status) dto.status = status;
-    if (epicId) dto.epicId = epicId;
+    if (title !== undefined) dto.title = title;
+    if (point !== undefined) dto.point = point;
+    if (status !== undefined) dto.status = status;
+    if (epicId !== undefined) dto.epicId = epicId;
     return dto;
   }
 }

--- a/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
@@ -12,9 +12,16 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { StoryStatus } from 'src/project/entity/story.entity';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 
 class Story {
   @IsInt()
+  @AtLeastOneProperty([
+	'epicId',
+	'title',
+	'point',
+	'status'
+  ])
   id: number;
 
   @IsOptional()

--- a/backend/src/project/dto/task/TaskUpdateNotify.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateNotify.dto.ts
@@ -20,12 +20,12 @@ class Task {
   ) {
     const dto = new Task();
     dto.id = id;
-    if (storyId) dto.storyId = storyId;
-    if (title) dto.title = title;
-    if (expectedTime) dto.expectedTime = expectedTime;
-    if (actualTime) dto.actualTime = actualTime;
-    if (status) dto.status = status;
-    if (assignedMemberId) dto.assignedMemberId = assignedMemberId;
+    if (storyId !== undefined) dto.storyId = storyId;
+    if (title !== undefined) dto.title = title;
+    if (expectedTime !== undefined) dto.expectedTime = expectedTime;
+    if (actualTime !== undefined) dto.actualTime = actualTime;
+    if (status !== undefined) dto.status = status;
+    if (assignedMemberId !== undefined) dto.assignedMemberId = assignedMemberId;
     return dto;
   }
 }

--- a/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
@@ -10,10 +10,19 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { TaskStatus } from 'src/project/entity/task.entity';
+import { AtLeastOneProperty } from 'src/project/util/validation.util';
 import { IsOneDecimalPlace } from './TaskCreateRequest.dto';
 
 class Task {
   @IsInt()
+  @AtLeastOneProperty([
+    'storyId',
+    'title',
+    'expectedTime',
+    'actualTime',
+    'assignedMemberId',
+    'status',
+  ])
   id: number;
 
   @IsOptional()
@@ -28,7 +37,7 @@ class Task {
   @IsOptional()
   @IsOneDecimalPlace()
   expectedTime?: number;
-  
+
   @IsOptional()
   @IsOneDecimalPlace()
   actualTime?: number;

--- a/backend/src/project/entity/epic.entity.ts
+++ b/backend/src/project/entity/epic.entity.ts
@@ -29,7 +29,10 @@ export class Epic {
   @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
-  @ManyToOne(() => Project, (project) => project.epicList, { nullable: false })
+  @ManyToOne(() => Project, (project) => project.epicList, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 

--- a/backend/src/project/entity/link.entity..ts
+++ b/backend/src/project/entity/link.entity..ts
@@ -17,7 +17,10 @@ export class Link {
   @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
-  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @ManyToOne(() => Project, (project) => project.id, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 

--- a/backend/src/project/entity/memo.entity.ts
+++ b/backend/src/project/entity/memo.entity.ts
@@ -25,7 +25,10 @@ export class Memo {
   @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
-  @ManyToOne(() => Project, (project) => project.id, { nullable: false })
+  @ManyToOne(() => Project, (project) => project.id, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
@@ -41,7 +44,10 @@ export class Memo {
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
 
-  @ManyToOne(() => Member, (member) => member.id, { nullable: false })
+  @ManyToOne(() => Member, (member) => member.id, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'member_id' })
   member: Member;
 

--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -24,14 +24,17 @@ export class Story {
   @Column({ type: 'int', name: 'project_id' })
   projectId: number;
 
-  @ManyToOne(() => Project, { nullable: false })
+  @ManyToOne(() => Project, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
   @Column({ type: 'int', name: 'epic_id' })
   epicId: number;
 
-  @ManyToOne(() => Epic, (epic) => epic.storyList, { nullable: false })
+  @ManyToOne(() => Epic, (epic) => epic.storyList, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'epic_id' })
   epic: Epic;
 
@@ -44,7 +47,7 @@ export class Story {
   @Column({ type: 'varchar', length: 255, nullable: false })
   status: StoryStatus;
 
-  @OneToMany(()=>Task, (task)=>task.story)
+  @OneToMany(() => Task, (task) => task.story)
   taskList: Task[];
 
   static of(

--- a/backend/src/project/entity/task.entity.ts
+++ b/backend/src/project/entity/task.entity.ts
@@ -23,14 +23,17 @@ export class Task {
   @Column({ type: 'int', name: 'project_id', nullable: false })
   projectId: number;
 
-  @ManyToOne(() => Project, { nullable: false })
+  @ManyToOne(() => Project, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
   @Column({ type: 'int', name: 'story_id', nullable: false })
   storyId: number;
 
-  @ManyToOne(() => Story, (story) => story.taskList, { nullable: false })
+  @ManyToOne(() => Story, (story) => story.taskList, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'story_id' })
   story: Story;
 
@@ -52,7 +55,10 @@ export class Task {
   @Column({ type: 'int', name: 'member_id', nullable: true })
   assignedMemberId: number;
 
-  @ManyToOne(() => Member, (member) => member.id, { nullable: true })
+  @ManyToOne(() => Member, (member) => member.id, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'member_id' })
   member: Member;
 

--- a/backend/src/project/util/validation.util.ts
+++ b/backend/src/project/util/validation.util.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from 'class-validator';
+import { registerDecorator, ValidationArguments, ValidationError, ValidationOptions } from 'class-validator';
 
 export function getRecursiveErrorMsgList(errors: ValidationError[]): string[] {
   return errors.reduce((acc, error) => {
@@ -11,3 +11,28 @@ export function getRecursiveErrorMsgList(errors: ValidationError[]): string[] {
     return acc;
   }, []);
 }
+
+export function AtLeastOneProperty(
+	properties: string[],
+	validationOptions?: ValidationOptions
+  ) {
+	return function (object: Object, propertyName: string) {
+	  registerDecorator({
+		name: 'atLeastOneProperty',
+		target: object.constructor,
+		propertyName: propertyName,
+		options: validationOptions,
+		constraints: [properties],
+		validator: {
+		  validate(value: any, args: ValidationArguments) {
+			const object = args.object as any;
+			return properties.some((property) => object[property] !== undefined);
+		  },
+		  defaultMessage(args: ValidationArguments) {
+			const properties = args.constraints[0];
+			return `At least one of these properties must be provided: ${properties.join(', ')}`;
+		  },
+		},
+	  });
+	};
+  }

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -159,6 +159,43 @@ describe('WS story', () => {
         });
       });
     };
+
+    it('should return error when updated property is do not exist', async () => {
+      const socket = await getMemberJoinedLandingPage();
+      socket.emit('joinBacklog');
+      await initBacklog(socket);
+
+      const name = '회원';
+      const color = 'yellow';
+      let requestData: any = {
+        action: 'create',
+        content: { name, color },
+      };
+      socket.emit('epic', requestData);
+      const [epicId] = await Promise.all([getEpicId(socket)]);
+
+      const title = '타이틀';
+      const point = 2;
+      const status = '시작전';
+      requestData = {
+        action: 'create',
+        content: { title, point, status, epicId },
+      };
+      socket.emit('story', requestData);
+      const storyId = await getStoryId(socket);
+
+      requestData = {
+        action: 'update',
+        content: { id: storyId },
+      };
+      socket.emit('story', requestData);
+      await new Promise<void>((resolve) => {
+        socket.on('error', () => {
+          resolve();
+        });
+      });
+      socket.close();
+    });
   });
 });
 


### PR DESCRIPTION
✅ 작업 내용
- update후 notify할 프로퍼티의 여부를 falsy로 체크하는게 아니라 undefined인지 체크하게 변경
- task를 업데이트 할 때 프로퍼티의 값이 falsy값인 경우 테스트 추가