### PR TITLE
fix: 스토리 에픽 수정 문제 해결, 태스크 수정 시 디테일 요구사항 반영

### DIFF
--- a/frontend/src/components/backlog/AssignedMemberDropdown.tsx
+++ b/frontend/src/components/backlog/AssignedMemberDropdown.tsx
@@ -13,7 +13,7 @@ const AssignedMemberDropdown = ({
   const memberList = [myInfo, ...partialMemberList];
 
   return (
-    <div className="absolute top-0 bg-white rounded-md w-fit shadow-box">
+    <div className="absolute top-0 z-10 bg-white rounded-md w-fit shadow-box">
       <ul>
         {...memberList.map((member: LandingMemberDTO) => (
           <li

--- a/frontend/src/components/backlog/BacklogStatusDropdown.tsx
+++ b/frontend/src/components/backlog/BacklogStatusDropdown.tsx
@@ -11,7 +11,7 @@ const BacklogStatusDropdown = ({
   const statusList: BacklogStatusType[] = ["시작전", "진행중", "완료"];
 
   return (
-    <div className="absolute top-0 bg-white rounded-md w-fit shadow-box">
+    <div className="absolute top-0 z-10 bg-white rounded-md w-fit shadow-box">
       <ul>
         {...statusList.map((status) => (
           <li

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -8,8 +8,6 @@ import { CATEGORY_COLOR } from "../../constants/backlog";
 import getRandomNumber from "../../utils/getRandomNumber";
 import { BacklogCategoryColor } from "../../types/common/backlog";
 import EpicDropdownOption from "./EpicDropdownOption";
-import EpicUpdateBox from "./EpicUpdateBox";
-import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
 
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
@@ -25,7 +23,6 @@ const EpicDropdown = ({
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitEpicCreateEvent } = useEpicEmitEvent(socket);
   const [value, setValue] = useState("");
-  const { open, handleOpen, handleClose } = useDropdownState();
 
   const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const { value } = target;
@@ -85,14 +82,11 @@ const EpicDropdown = ({
               handleEpicChange(epic.id);
             }}
           >
-            <EpicDropdownOption key={epic.id} epic={epic} onOpen={handleOpen} />
-            {open && (
-              <EpicUpdateBox
-                epic={epic}
-                onBoxClose={handleClose}
-                onEpicChange={handleEpicChange}
-              />
-            )}
+            <EpicDropdownOption
+              key={epic.id}
+              epic={epic}
+              onEpicChange={handleEpicChange}
+            />
           </li>
         ))}
       </ul>

--- a/frontend/src/components/backlog/EpicDropdownOption.tsx
+++ b/frontend/src/components/backlog/EpicDropdownOption.tsx
@@ -1,31 +1,45 @@
+import { MouseEvent } from "react";
 import CategoryChip from "./CategoryChip";
 import MenuKebab from "../../assets/icons/menu-kebab.svg?react";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
-
-import { MouseEvent } from "react";
+import EpicUpdateBox from "./EpicUpdateBox";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
 
 interface EpicDropdownOptionProps {
   epic: EpicCategoryDTO;
-  onOpen: () => void;
+  onEpicChange: (epicId: number | undefined) => void;
 }
 
-const EpicDropdownOption = ({ epic, onOpen }: EpicDropdownOptionProps) => {
+const EpicDropdownOption = ({
+  epic,
+  onEpicChange,
+}: EpicDropdownOptionProps) => {
+  const { open, handleOpen, handleClose } = useDropdownState();
   const handleMenuButtonClick = (event: MouseEvent) => {
     event.stopPropagation();
-    onOpen();
+    handleOpen();
   };
 
   return (
-    <div className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100">
-      <CategoryChip content={epic.name} bgColor={epic.color} />
-      <button
-        className="invisible px-1 rounded-md group-hover:visible hover:bg-gray-300"
-        type="button"
-        onClick={handleMenuButtonClick}
-      >
-        <MenuKebab width={20} height={20} stroke="#696969" />
-      </button>
-    </div>
+    <>
+      <div className="flex justify-between px-1 py-1 rounded-md group hover:cursor-pointer hover:bg-gray-100">
+        <CategoryChip content={epic.name} bgColor={epic.color} />
+        <button
+          className="invisible px-1 rounded-md group-hover:visible hover:bg-gray-300"
+          type="button"
+          onClick={handleMenuButtonClick}
+        >
+          <MenuKebab width={20} height={20} stroke="#696969" />
+        </button>
+      </div>
+      {open && (
+        <EpicUpdateBox
+          epic={epic}
+          onBoxClose={handleClose}
+          onEpicChange={onEpicChange}
+        />
+      )}
+    </>
   );
 };
 

--- a/frontend/src/components/backlog/EpicUpdateBox.tsx
+++ b/frontend/src/components/backlog/EpicUpdateBox.tsx
@@ -24,20 +24,19 @@ const EpicUpdateBox = ({
   const { open, close } = useModal();
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitEpicDeleteEvent, emitEpicUpdateEvent } = useEpicEmitEvent(socket);
-  const boxRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const colorList = Object.entries(CATEGORY_COLOR);
 
-  const handleConfirmButtonClick = (event?: React.MouseEvent) => {
-    event?.stopPropagation();
+  const handleConfirmButtonClick = () => {
+    // event?.stopPropagation();
     onEpicChange(undefined);
     emitEpicDeleteEvent({ id: epic.id });
     onBoxClose();
     close();
   };
 
-  const handleDeleteButtonClick = (event: React.MouseEvent) => {
-    event.stopPropagation();
+  const handleDeleteButtonClick = () => {
+    // event.stopPropagation();
     open(
       <ConfirmModal
         title="에픽을 삭제하시겠습니까?"
@@ -74,28 +73,14 @@ const EpicUpdateBox = ({
     emitEpicUpdateEvent({ id: epic.id, color });
   };
 
-  const handleOutsideClick = ({ target }: MouseEvent) => {
-    if (boxRef.current && !boxRef.current.contains(target as Node)) {
-      onBoxClose();
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener("click", handleOutsideClick);
-
-    return () => {
-      window.removeEventListener("click", handleOutsideClick);
-    };
-  }, []);
-
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
   return (
     <div
-      ref={boxRef}
       className="absolute top-0 z-10 p-2 bg-white rounded-md left-3/4 w-fit shadow-box"
+      onClick={(event) => event.stopPropagation()}
     >
       <p className="text-xxs text-text-gray">에픽 수정</p>
       <input

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -111,7 +111,8 @@ const StoryBlock = ({
   }
 
   function updateEpic(data: number | undefined) {
-    if (data === epic.id) {
+    if (!data || data === epic.id) {
+      handleEpicUpdateClose();
       return;
     }
 

--- a/frontend/src/components/backlog/TaskBlock.tsx
+++ b/frontend/src/components/backlog/TaskBlock.tsx
@@ -13,6 +13,7 @@ import { useModal } from "../../hooks/common/modal/useModal";
 import { MOUSE_KEY } from "../../constants/event";
 import ConfirmModal from "../common/ConfirmModal";
 import TrashCan from "../../assets/icons/trash-can.svg?react";
+import isIntegerOrOneDecimalPlace from "../../utils/isIntegerOrOneDecimalPlace";
 
 const TaskBlock = ({
   id,
@@ -64,7 +65,7 @@ const TaskBlock = ({
   const { open, close } = useModal();
 
   const assignedMemberName = useMemo(() => {
-    if (assignedMemberId === null) {
+    if (assignedMemberId === null || myInfo.id === -1) {
       return "";
     }
 
@@ -89,7 +90,10 @@ const TaskBlock = ({
     emitTaskUpdateEvent({ id, title: data as string });
   }
   function updateExpectedTime<T>(data: T) {
-    if (!data || data === String(expectedTime)) {
+    if (
+      data === String(expectedTime) ||
+      (data === "" && expectedTime === null)
+    ) {
       return;
     }
 
@@ -98,7 +102,12 @@ const TaskBlock = ({
       return;
     }
 
-    if (!isNaN(Number(data)) && (Number(data) >= 100 || Number(data) < 0)) {
+    if (
+      !isNaN(Number(data)) &&
+      (Number(data) >= 100 ||
+        Number(data) < 0 ||
+        !isIntegerOrOneDecimalPlace(Number(data)))
+    ) {
       alert(
         "예상 시간은 0이상, 100미만의 정수 또는 소수점 한 자릿수여야 합니다."
       );
@@ -108,7 +117,7 @@ const TaskBlock = ({
     emitTaskUpdateEvent({ id, expectedTime: Number(data) });
   }
   function updateActualTime<T>(data: T) {
-    if (!data || data === String(actualTime)) {
+    if (data === String(actualTime) || (data === "" && actualTime === null)) {
       return;
     }
 
@@ -117,7 +126,12 @@ const TaskBlock = ({
       return;
     }
 
-    if (!isNaN(Number(data)) && (Number(data) >= 100 || Number(data) < 0)) {
+    if (
+      !isNaN(Number(data)) &&
+      (Number(data) >= 100 ||
+        Number(data) < 0 ||
+        !isIntegerOrOneDecimalPlace(Number(data)))
+    ) {
       alert(
         "실제 시간은 0이상, 100미만의 정수 또는 소수점 한 자릿수여야 합니다."
       );
@@ -177,7 +191,7 @@ const TaskBlock = ({
       >
         <p className="w-[4rem]">Task-{displayId}</p>
         <div
-          className="w-[25rem] min-h-[1.5rem] hover:cursor-pointer"
+          className="w-[25rem] min-h-[1.5rem] hover:cursor-pointer truncate"
           ref={titleRef}
           onClick={() => handleTitleUpdating(true)}
         >
@@ -189,15 +203,19 @@ const TaskBlock = ({
               type="text"
             />
           ) : (
-            <span>{title}</span>
+            <span title={title}>{title}</span>
           )}
         </div>
         <div
           className="w-12 min-h-[1.5rem] hover:cursor-pointer relative"
           onClick={handleAssignedMemberUpdateOpen}
         >
-          <div className="w-full min-h-[1.5rem]" ref={assignedMemberRef}>
-            {assignedMemberId && <p>{assignedMemberName}</p>}
+          <div className="w-full min-h-[1.5rem] " ref={assignedMemberRef}>
+            {assignedMemberId && (
+              <p className="truncate" title={assignedMemberName}>
+                {assignedMemberName}
+              </p>
+            )}
           </div>
           {assignedMemberUpdating && (
             <AssignedMemberDropdown onOptionClick={updateAssignedMember} />

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -75,6 +75,36 @@ const useBacklogSocket = (socket: Socket) => {
         });
         break;
       case BacklogSocketStoryAction.UPDATE:
+        if (content.epicId) {
+          let targetStory: StoryDTO;
+          backlog.epicList.forEach((epic) => {
+            epic.storyList.forEach((story) => {
+              if (story.id === content.id) {
+                targetStory = { ...story };
+              }
+            });
+          });
+
+          setBacklog((prevBacklog) => {
+            const newEpicList = prevBacklog.epicList.map((epic) => {
+              const newStoryList = epic.storyList.filter((story) => {
+                if (story.id === content.id) {
+                  targetStory = { ...story, epicId: content.epicId };
+                }
+                return story.id !== content.id;
+              });
+
+              if (epic.id === content.epicId) {
+                newStoryList.push(targetStory);
+              }
+              return { ...epic, storyList: newStoryList };
+            });
+
+            return { epicList: newEpicList };
+          });
+
+          break;
+        }
         setBacklog((prevBacklog) => {
           const newEpicList = prevBacklog.epicList.map((epic) => {
             const newStoryList = epic.storyList.map((story) => {
@@ -85,7 +115,6 @@ const useBacklogSocket = (socket: Socket) => {
             });
             return { ...epic, storyList: newStoryList };
           });
-
           return { epicList: newEpicList };
         });
 

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -76,14 +76,21 @@ const useBacklogSocket = (socket: Socket) => {
         break;
       case BacklogSocketStoryAction.UPDATE:
         if (content.epicId) {
-          let targetStory: StoryDTO;
-          backlog.epicList.forEach((epic) => {
-            epic.storyList.forEach((story) => {
-              if (story.id === content.id) {
-                targetStory = { ...story };
-              }
-            });
+          let targetStory: StoryDTO | null = null;
+          backlog.epicList.some((epic) => {
+            const foundStory = epic.storyList.find(
+              (story) => story.id === content.id
+            );
+            if (foundStory) {
+              targetStory = { ...foundStory };
+              return true;
+            }
+            return false;
           });
+
+          if (!targetStory) {
+            break;
+          }
 
           setBacklog((prevBacklog) => {
             const newEpicList = prevBacklog.epicList.map((epic) => {
@@ -95,7 +102,7 @@ const useBacklogSocket = (socket: Socket) => {
               });
 
               if (epic.id === content.epicId) {
-                newStoryList.push(targetStory);
+                newStoryList.push(targetStory as StoryDTO);
               }
               return { ...epic, storyList: newStoryList };
             });
@@ -105,6 +112,7 @@ const useBacklogSocket = (socket: Socket) => {
 
           break;
         }
+
         setBacklog((prevBacklog) => {
           const newEpicList = prevBacklog.epicList.map((epic) => {
             const newStoryList = epic.storyList.map((story) => {

--- a/frontend/src/utils/isIntegerOrOneDecimalPlace.ts
+++ b/frontend/src/utils/isIntegerOrOneDecimalPlace.ts
@@ -1,0 +1,14 @@
+const isIntegerOrOneDecimalPlace = (number: number) => {
+  const numberString = number.toString();
+  const dotIndex = numberString.indexOf(".");
+
+  if (dotIndex === -1) {
+    return true;
+  }
+
+  const decimalPart = numberString.slice(dotIndex + 1);
+
+  return decimalPart.length === 1;
+};
+
+export default isIntegerOrOneDecimalPlace;


### PR DESCRIPTION
## 🎟️ 태스크

[태스크 생성, 수정, 삭제 API 연결](https://plastic-toad-cb0.notion.site/API-9967c3b1ef5d4610bbcbeb4c2b2f887b)

## ✅ 작업 내용

- 태스크 수정 디테일 요구사항 반영
  - 타이틀 길이 제한
  - 예상 시간, 실제 시간 범위 제한
- 스토리 에픽 수정 문제 해결

## 🖊️ 구체적인 작업

### 스토리 에픽 수정 문제 해결

- 상태 관리의 오류로 발생하던 에픽 수정 시 한 가지의 에픽만 수정되던 문제를 해결했습니다.
- 스토리의 에픽을 수정해도 반영되지 않던 문제를, 반영 로직을 추가해 해결했습니다.
- 스토리 및 태스크의 상태 드롭다운이 상태 컴포넌트에 가려지는 문제를 해결했습니다.

### 태스크 수정 디테일 요구사항 반영

- 타이틀 길이, 예상 시간, 실제 시간의 범위를 제한해 이를 어길 시 알람을 띄우도록 했습니다.