### PR TITLE
feat: 완료된 스토리 페이지 구현

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -21,6 +21,7 @@ import LandingPage from "./pages/landing/LandingPage";
 import InvitePage from "./pages/invite/InvitePage";
 import UnfinishedStoryPage from "./pages/backlog/UnfinishedStoryPage";
 import BacklogPage from "./pages/backlog/BacklogPage";
+import FinishedStoryPage from "./pages/backlog/FinishedStoryPage";
 
 type RouteType = "PRIVATE" | "PUBLIC";
 
@@ -89,7 +90,7 @@ const router = createBrowserRouter([
                 },
                 {
                   path: ROUTER_URL.BACKLOG.COMPLETED,
-                  element: <div>backlog completed story Page</div>,
+                  element: <FinishedStoryPage />,
                 },
               ],
               element: <BacklogPage />,

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -30,6 +30,7 @@ interface StoryBlockProps {
   children: React.ReactNode;
   taskExist: boolean;
   epicList: EpicCategoryDTO[];
+  finished?: boolean;
 }
 
 const StoryBlock = ({
@@ -41,6 +42,7 @@ const StoryBlock = ({
   status,
   taskExist,
   epicList,
+  finished = false,
   children,
 }: StoryBlockProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
@@ -277,7 +279,7 @@ const StoryBlock = ({
         <TaskContainer>
           <TaskHeader />
           {children}
-          <TaskCreateBlock storyId={id} />
+          {!finished && <TaskCreateBlock storyId={id} />}
         </TaskContainer>
       )}
     </>

--- a/frontend/src/pages/backlog/FinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/FinishedStoryPage.tsx
@@ -38,6 +38,7 @@ const FinishedStoryPage = () => {
               progress={progress}
               taskExist={taskList.length > 0}
               epicList={epicCategoryList}
+              finished={true}
             >
               {...taskList.map((task) => <TaskBlock {...task} />)}
             </StoryBlock>

--- a/frontend/src/pages/backlog/FinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/FinishedStoryPage.tsx
@@ -1,0 +1,51 @@
+import { useOutletContext } from "react-router-dom";
+import { BacklogDTO } from "../../types/DTO/backlogDTO";
+import { useMemo } from "react";
+import StoryBlock from "../../components/backlog/StoryBlock";
+import changeEpicListToStoryList from "../../utils/changeEpicListToStoryList";
+import TaskBlock from "../../components/backlog/TaskBlock";
+
+const FinishedStoryPage = () => {
+  const { backlog }: { backlog: BacklogDTO } = useOutletContext();
+  const storyList = useMemo(
+    () =>
+      changeEpicListToStoryList(backlog.epicList).filter(
+        ({ status }) => status === "완료"
+      ),
+    [backlog.epicList]
+  );
+  const epicCategoryList = useMemo(
+    () => backlog.epicList.map(({ id, name, color }) => ({ id, name, color })),
+    [backlog.epicList]
+  );
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="w-full border-b">
+        {...storyList.map(({ id, epic, title, point, status, taskList }) => {
+          const progress = taskList.length
+            ? Math.round(
+                (taskList.filter(({ status }) => status === "완료").length /
+                  taskList.length) *
+                  100
+              )
+            : 0;
+
+          return (
+            <StoryBlock
+              {...{ id, title, point, status }}
+              epic={epic}
+              progress={progress}
+              taskExist={taskList.length > 0}
+              epicList={epicCategoryList}
+            >
+              {...taskList.map((task) => <TaskBlock {...task} />)}
+            </StoryBlock>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default FinishedStoryPage;

--- a/frontend/src/stores/useMemberStore.ts
+++ b/frontend/src/stores/useMemberStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { LandingMemberDTO, MemberStatus } from "../types/DTO/landingDTO";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 interface InitialMemberState {
   myInfo: LandingMemberDTO;
@@ -18,14 +19,19 @@ const initialState: InitialMemberState = {
   memberList: [],
 };
 
-const useMemberStore = create<MemberState>((set) => ({
-  ...initialState,
-  updateMyInfo: (newMyInfo) => set(() => ({ myInfo: newMyInfo })),
-  updateMyStatus: (status) =>
-    set((state) => ({ myInfo: { ...state.myInfo, status } })),
-  updateMemberList: (newMember) => set({ memberList: newMember }),
-  addMember: (member) =>
-    set((state) => ({ memberList: [...state.memberList, member] })),
-}));
+const useMemberStore = create<MemberState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      updateMyInfo: (newMyInfo) => set(() => ({ myInfo: newMyInfo })),
+      updateMyStatus: (status) =>
+        set((state) => ({ myInfo: { ...state.myInfo, status } })),
+      updateMemberList: (newMember) => set({ memberList: newMember }),
+      addMember: (member) =>
+        set((state) => ({ memberList: [...state.memberList, member] })),
+    }),
+    { name: "member-storage", storage: createJSONStorage(() => sessionStorage) }
+  )
+);
 
 export default useMemberStore;


### PR DESCRIPTION
## 🎟️ 태스크

[완료된 스토리 조회 페이지 구현](https://plastic-toad-cb0.notion.site/f6dcfd3d584a4343b8019b453a1a655c)

## ✅ 작업 내용

- 완료된 스토리 페이지 구현
- 새로고침 시 참가자 모달에 참가자가 없어지는 문제 해결

## 🖊️ 구체적인 작업

### 완료된 스토리 페이지 구현

- 스토리 페이지와 동일한 형식으로 구현했습니다. 다만 완료된 스토리 페이지에서는 스토리를 생성할 수 없고, 이미 완료된 스토리에 태스크를 추가하는 일이 부자연스럽게 느껴지기 때문에 태스크 또한 생성할 수 없도록 했습니다. 