### PR TITLE
feat: 에픽, 스토리, 태스크 우선순위 API 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "cookie-parser": "^1.4.6",
+        "lexorank": "^1.0.5",
         "mysql2": "^3.9.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
@@ -3044,6 +3045,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.1.tgz",
+      "integrity": "sha512-+H+kuK34PfMaI9PNU/NSjBKL5hh/KDM9J72kwYeYEm0A8B1AC4fuCy3qsjnA7lxklgyXsB68yn8Z2xoZEjgwCQ==",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -3271,12 +3280,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4187,9 +4196,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
-      "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -4200,22 +4209,22 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "engines": {
         "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
@@ -4785,9 +4794,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6551,6 +6560,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lexorank": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lexorank/-/lexorank-1.0.5.tgz",
+      "integrity": "sha512-K1B/Yr/gIU0wm68hk/yB0p/mv6xM3ShD5aci42vOwcjof8slG8Kpo3Q7+1WTv7DaRHKWRgLPqrFDt+4GtuFAtA=="
+    },
     "node_modules/libphonenumber-js": {
       "version": "1.10.58",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.58.tgz",
@@ -6892,10 +6906,11 @@
       "dev": true
     },
     "node_modules/mysql2": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.1.tgz",
-      "integrity": "sha512-3njoWAAhGBYy0tWBabqUQcLtczZUxrmmtc2vszQUekg3kTJyZ5/IeLC3Fo04u6y6Iy5Sba7pIIa2P/gs8D3ZeQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.0.tgz",
+      "integrity": "sha512-J9phbsXGvTOcRVPR95YedzVSxJecpW5A5+cQ57rhHIFXteTP10HCs+VBjS7DHIKfEaI1zQ5tlVrquCd64A6YvA==",
       "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
@@ -8214,12 +8229,12 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
-      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dependencies": {
         "debug": "~4.3.4",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       }
     },
     "node_modules/socket.io-client": {
@@ -9481,15 +9496,15 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.6",
+    "lexorank": "^1.0.5",
     "mysql2": "^3.9.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/backend/src/common/decorator/IsLexoRankValue.ts
+++ b/backend/src/common/decorator/IsLexoRankValue.ts
@@ -1,0 +1,18 @@
+import { registerDecorator } from 'class-validator';
+
+export function IsLexoRankValue() {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'IsLexoRankValue',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: { message: 'invalid LexoRank format' },
+      validator: {
+        validate(value: any) {
+          const lexorankPattern = new RegExp(`^[012]\\|.*`, 'i');
+          return lexorankPattern.test(value);
+        },
+      },
+    });
+  };
+}

--- a/backend/src/project/dto/InitBacklogResponse.dto.ts
+++ b/backend/src/project/dto/InitBacklogResponse.dto.ts
@@ -10,6 +10,7 @@ class TaskDto {
   actualTime: number | null;
   status: TaskStatus;
   assignedMemberId: number | null;
+  rankValue: string;
 
   static of(task: Task): TaskDto {
     const dto = new TaskDto();
@@ -20,6 +21,7 @@ class TaskDto {
     dto.actualTime = task.actualTime;
     dto.status = task.status;
     dto.assignedMemberId = task.assignedMemberId;
+    dto.rankValue = task.rankValue;
     return dto;
   }
 }
@@ -29,6 +31,7 @@ class StoryDto {
   title: string;
   point: number | null;
   status: StoryStatus;
+  rankValue: string;
   taskList: TaskDto[];
 
   static of(story: Story): StoryDto {
@@ -37,6 +40,7 @@ class StoryDto {
     dto.title = story.title;
     dto.point = story.point;
     dto.status = story.status;
+    dto.rankValue = story.rankValue;
     dto.taskList = story.taskList.map(TaskDto.of);
     return dto;
   }
@@ -46,6 +50,7 @@ class EpicDto {
   id: number;
   name: string;
   color: EpicColor;
+  rankValue: string;
   storyList: StoryDto[];
 
   static of(epic: Epic): EpicDto {
@@ -53,6 +58,7 @@ class EpicDto {
     dto.id = epic.id;
     dto.name = epic.name;
     dto.color = epic.color;
+    dto.rankValue = epic.rankValue;
     dto.storyList = epic.storyList.map(StoryDto.of);
     return dto;
   }

--- a/backend/src/project/dto/epic/EpicCreateNotify.dto.ts
+++ b/backend/src/project/dto/epic/EpicCreateNotify.dto.ts
@@ -4,11 +4,14 @@ class Epic {
   id: number;
   name: string;
   color: EpicColor;
-  static of(id: number, name: string, color: EpicColor) {
+  rankValue: string;
+
+  static of(id: number, name: string, color: EpicColor, rankValue: string) {
     const dto = new Epic();
     dto.id = id;
     dto.name = name;
     dto.color = color;
+    dto.rankValue = rankValue;
     return dto;
   }
 }
@@ -18,11 +21,11 @@ export class EpicCreateNotifyDto {
   action: string;
   content: Epic;
 
-  static of(id: number, name: string, color: EpicColor) {
+  static of(id: number, name: string, color: EpicColor, rankValue: string) {
     const dto = new EpicCreateNotifyDto();
     dto.domain = 'epic';
     dto.action = 'create';
-    dto.content = Epic.of(id, name, color);
+    dto.content = Epic.of(id, name, color, rankValue);
     return dto;
   }
 }

--- a/backend/src/project/dto/epic/EpicCreateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicCreateRequest.dto.ts
@@ -7,6 +7,7 @@ import {
   Matches,
   ValidateNested,
 } from 'class-validator';
+import { IsLexoRankValue } from 'src/common/decorator/IsLexoRankValue';
 import { EpicColor } from 'src/project/entity/epic.entity';
 
 class Epic {
@@ -16,6 +17,11 @@ class Epic {
 
   @IsEnum(EpicColor)
   color: EpicColor;
+
+  @IsString()
+  @IsLexoRankValue()
+  @Length(2, 255)
+  rankValue: string;
 }
 
 export class EpicCreateRequestDto {

--- a/backend/src/project/dto/epic/EpicUpdateNotify.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateNotify.dto.ts
@@ -4,11 +4,13 @@ class Epic {
   id: number;
   name?: string;
   color?: EpicColor;
-  static of(id: number, name: string, color: EpicColor) {
+  rankValue?: string;
+  static of(id: number, name: string, color: EpicColor, rankValue: string) {
     const dto = new Epic();
     dto.id = id;
     if (name !== undefined) dto.name = name;
     if (color !== undefined) dto.color = color;
+    if (rankValue !== undefined) dto.rankValue = rankValue;
     return dto;
   }
 }
@@ -18,11 +20,11 @@ export class EpicUpdateNotifyDto {
   action: string;
   content: Epic;
 
-  static of(id: number, name: string, color: EpicColor) {
+  static of(id: number, name: string, color: EpicColor, rankValue: string) {
     const dto = new EpicUpdateNotifyDto();
     dto.domain = 'epic';
     dto.action = 'update';
-    dto.content = Epic.of(id, name, color);
+    dto.content = Epic.of(id, name, color, rankValue);
     return dto;
   }
 }

--- a/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
+++ b/backend/src/project/dto/epic/EpicUpdateRequest.dto.ts
@@ -9,13 +9,14 @@ import {
   ValidateNested,
   Length,
 } from 'class-validator';
+import { IsLexoRankValue } from 'src/common/decorator/IsLexoRankValue';
 import { EpicColor } from 'src/project/entity/epic.entity';
 import { AtLeastOneProperty } from 'src/project/util/validation.util';
 
 class Epic {
   @IsNotEmpty()
   @IsInt()
-  @AtLeastOneProperty(['name', 'color'])
+  @AtLeastOneProperty(['name', 'color', 'rankValue'])
   id: number;
 
   @IsOptional()
@@ -26,6 +27,11 @@ class Epic {
   @IsOptional()
   @IsEnum(EpicColor)
   color?: EpicColor;
+
+  @IsOptional()
+  @IsLexoRankValue()
+  @Length(2, 255)
+  rankValue?: string;
 }
 
 export class EpicUpdateRequestDto {

--- a/backend/src/project/dto/story/StoryCreateNotify.dto.ts
+++ b/backend/src/project/dto/story/StoryCreateNotify.dto.ts
@@ -5,6 +5,8 @@ class StoryDto {
   point: number;
   status: StoryStatus;
   epicId: number;
+  rankValue: string;
+
   static of(story: Story) {
     const dto = new StoryDto();
     dto.id = story.id;
@@ -12,6 +14,7 @@ class StoryDto {
     dto.point = story.point;
     dto.status = story.status;
     dto.epicId = story.epicId;
+    dto.rankValue = story.rankValue;
     return dto;
   }
 }

--- a/backend/src/project/dto/story/StoryCreateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryCreateRequest.dto.ts
@@ -10,6 +10,7 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { IsLexoRankValue } from 'src/common/decorator/IsLexoRankValue';
 import { StoryStatus } from 'src/project/entity/story.entity';
 
 class Story {
@@ -27,6 +28,11 @@ class Story {
 
   @IsInt()
   epicId: number;
+
+  @IsString()
+  @IsLexoRankValue()
+  @Length(2, 255)
+  rankValue: string;
 }
 
 export class StoryCreateRequestDto {

--- a/backend/src/project/dto/story/StoryUpdateNotify.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateNotify.dto.ts
@@ -6,6 +6,7 @@ class Story {
   title?: string;
   point?: number;
   status?: StoryStatus;
+  rankValue?: string;
 
   static of(
     id: number,
@@ -13,6 +14,7 @@ class Story {
     title: string | undefined,
     point: number | undefined,
     status: StoryStatus | undefined,
+    rankValue: string | undefined,
   ) {
     const dto = new Story();
     dto.id = id;
@@ -20,6 +22,7 @@ class Story {
     if (point !== undefined) dto.point = point;
     if (status !== undefined) dto.status = status;
     if (epicId !== undefined) dto.epicId = epicId;
+    if (rankValue !== undefined) dto.rankValue = rankValue;
     return dto;
   }
 }
@@ -35,11 +38,12 @@ export class StoryUpdateNotifyDto {
     title: string | undefined,
     point: number | undefined,
     status: StoryStatus | undefined,
+    rankValue: string | undefined,
   ) {
     const dto = new StoryUpdateNotifyDto();
     dto.domain = 'story';
     dto.action = 'update';
-    dto.content = Story.of(id, epicId, title, point, status);
+    dto.content = Story.of(id, epicId, title, point, status, rankValue);
     return dto;
   }
 }

--- a/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
+++ b/backend/src/project/dto/story/StoryUpdateRequest.dto.ts
@@ -11,17 +11,13 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { IsLexoRankValue } from 'src/common/decorator/IsLexoRankValue';
 import { StoryStatus } from 'src/project/entity/story.entity';
 import { AtLeastOneProperty } from 'src/project/util/validation.util';
 
 class Story {
   @IsInt()
-  @AtLeastOneProperty([
-	'epicId',
-	'title',
-	'point',
-	'status'
-  ])
+  @AtLeastOneProperty(['epicId', 'title', 'point', 'status', 'rankValue'])
   id: number;
 
   @IsOptional()
@@ -32,7 +28,7 @@ class Story {
   @IsString()
   @Length(1, 100)
   title?: string;
-  
+
   @IsOptional()
   @IsInt()
   @Min(0)
@@ -42,6 +38,12 @@ class Story {
   @IsOptional()
   @IsEnum(StoryStatus)
   status?: StoryStatus;
+
+  @IsOptional()
+  @IsString()
+  @IsLexoRankValue()
+  @Length(2, 255)
+  rankValue?: string;
 }
 
 export class StoryUpdateRequestDto {

--- a/backend/src/project/dto/task/TaskCreateNotify.dto.ts
+++ b/backend/src/project/dto/task/TaskCreateNotify.dto.ts
@@ -8,6 +8,8 @@ class TaskDto {
   status: TaskStatus;
   assignedMemberId: number|null;
   storyId: number;
+  rankValue: string;
+
   static of(task: Task) {
     const dto = new TaskDto();
     dto.id = task.id;
@@ -18,6 +20,7 @@ class TaskDto {
     dto.status = task.status;
     dto.assignedMemberId = task.assignedMemberId;
     dto.storyId = task.storyId;
+    dto.rankValue = task.rankValue;
     return dto;
   }
 }

--- a/backend/src/project/dto/task/TaskCreateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskCreateRequest.dto.ts
@@ -16,6 +16,7 @@ import {
   ValidationOptions,
   ValidationArguments,
 } from 'class-validator';
+import { IsLexoRankValue } from 'src/common/decorator/IsLexoRankValue';
 
 export function IsOneDecimalPlace(validationOptions?: ValidationOptions) {
   return function (object: Object, propertyName: string) {
@@ -61,6 +62,11 @@ class Task {
 
   @IsInt()
   storyId: number;
+
+  @IsString()
+  @IsLexoRankValue()
+  @Length(2, 255)
+  rankValue: string;
 }
 
 export class TaskCreateRequestDto {

--- a/backend/src/project/dto/task/TaskUpdateNotify.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateNotify.dto.ts
@@ -8,6 +8,7 @@ class Task {
   actualTime?: number;
   status?: TaskStatus;
   assignedMemberId?: number;
+  rankValue?: string;
 
   static of(
     id: number,
@@ -17,6 +18,7 @@ class Task {
     actualTime: number | undefined,
     status: TaskStatus | undefined,
     assignedMemberId: number | undefined,
+    rankValue: string | undefined,
   ) {
     const dto = new Task();
     dto.id = id;
@@ -26,6 +28,7 @@ class Task {
     if (actualTime !== undefined) dto.actualTime = actualTime;
     if (status !== undefined) dto.status = status;
     if (assignedMemberId !== undefined) dto.assignedMemberId = assignedMemberId;
+    if (rankValue !== undefined) dto.rankValue = rankValue;
     return dto;
   }
 }
@@ -43,6 +46,7 @@ export class TaskUpdateNotifyDto {
     actualTime: number | undefined,
     status: TaskStatus | undefined,
     assignedMemberId: number | undefined,
+    rankValue: string | undefined,
   ) {
     const dto = new TaskUpdateNotifyDto();
     dto.domain = 'task';
@@ -55,6 +59,7 @@ export class TaskUpdateNotifyDto {
       actualTime,
       status,
       assignedMemberId,
+      rankValue,
     );
     return dto;
   }

--- a/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
+++ b/backend/src/project/dto/task/TaskUpdateRequest.dto.ts
@@ -9,6 +9,7 @@ import {
   Matches,
   ValidateNested,
 } from 'class-validator';
+import { IsLexoRankValue } from 'src/common/decorator/IsLexoRankValue';
 import { TaskStatus } from 'src/project/entity/task.entity';
 import { AtLeastOneProperty } from 'src/project/util/validation.util';
 import { IsOneDecimalPlace } from './TaskCreateRequest.dto';
@@ -22,6 +23,7 @@ class Task {
     'actualTime',
     'assignedMemberId',
     'status',
+    'rankValue',
   ])
   id: number;
 
@@ -49,6 +51,12 @@ class Task {
   @IsOptional()
   @IsEnum(TaskStatus)
   status?: TaskStatus;
+
+  @IsOptional()
+  @IsString()
+  @IsLexoRankValue()
+  @Length(2, 255)
+  rankValue?: string;
 }
 
 export class TaskUpdateRequestDto {

--- a/backend/src/project/entity/epic.entity.ts
+++ b/backend/src/project/entity/epic.entity.ts
@@ -23,7 +23,7 @@ export enum EpicColor {
 }
 
 @Entity()
-@Unique(['rankValue', 'projectId'])
+@Unique('EPIC_UQ_RANK_VALUE_AND_PROJECT_ID', ['rankValue', 'projectId'])
 export class Epic {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;

--- a/backend/src/project/entity/epic.entity.ts
+++ b/backend/src/project/entity/epic.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  Unique,
   UpdateDateColumn,
 } from 'typeorm';
 import { Project } from './project.entity';
@@ -22,6 +23,7 @@ export enum EpicColor {
 }
 
 @Entity()
+@Unique(['rankValue', 'projectId'])
 export class Epic {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
@@ -51,11 +53,20 @@ export class Epic {
   @OneToMany(() => Story, (story) => story.epic)
   storyList: Story[];
 
-  static of(project: Project, name: string, color: EpicColor) {
+  @Column({ type: 'varchar', length: 255, nullable: false, name: 'rank_value' })
+  rankValue: string;
+
+  static of(
+    project: Project,
+    name: string,
+    color: EpicColor,
+    rankValue: string,
+  ) {
     const newEpic = new Epic();
     newEpic.project = project;
     newEpic.name = name;
     newEpic.color = color;
+    newEpic.rankValue = rankValue;
     return newEpic;
   }
 }

--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 import { Epic } from './epic.entity';
 import { Project } from './project.entity';
@@ -17,6 +18,7 @@ export enum StoryStatus {
 }
 
 @Entity()
+@Unique(['rankValue', 'epicId'])
 export class Story {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
@@ -50,12 +52,16 @@ export class Story {
   @OneToMany(() => Task, (task) => task.story)
   taskList: Task[];
 
+  @Column({ type: 'varchar', length: 255, nullable: false, name: 'rank_value' })
+  rankValue: string;
+
   static of(
     project: Project,
     epicId: number,
     title: string,
     point: number,
     status: StoryStatus,
+    rankValue: string,
   ) {
     const newStory = new Story();
     newStory.project = project;
@@ -63,6 +69,7 @@ export class Story {
     newStory.title = title;
     newStory.point = point;
     newStory.status = status;
+    newStory.rankValue = rankValue;
     return newStory;
   }
 }

--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -18,7 +18,7 @@ export enum StoryStatus {
 }
 
 @Entity()
-@Unique(['rankValue', 'epicId'])
+@Unique('STORY_UQ_RANK_VALUE_AND_EPIC_ID', ['rankValue', 'epicId'])
 export class Story {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;

--- a/backend/src/project/entity/task.entity.ts
+++ b/backend/src/project/entity/task.entity.ts
@@ -5,6 +5,7 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 import { Project } from './project.entity';
 import { Story } from './story.entity';
@@ -16,6 +17,7 @@ export enum TaskStatus {
 }
 
 @Entity()
+@Unique(['rankValue', 'storyId'])
 export class Task {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;
@@ -62,6 +64,9 @@ export class Task {
   @JoinColumn({ name: 'member_id' })
   member: Member;
 
+  @Column({ type: 'varchar', length: 255, nullable: false, name: 'rank_value' })
+  rankValue: string;
+
   static of(
     project: Project,
     storyId: number,
@@ -71,17 +76,18 @@ export class Task {
     actualTime: number,
     memberId: number,
     status: TaskStatus,
+    rankValue: string,
   ) {
     const newTask = new Task();
     newTask.project = project;
     newTask.storyId = storyId;
     newTask.title = title;
     newTask.displayId = displayId;
-
     newTask.expectedTime = expectedTime;
     newTask.actualTime = actualTime;
     newTask.assignedMemberId = memberId;
     newTask.status = status;
+    newTask.rankValue = rankValue;
     return newTask;
   }
 }

--- a/backend/src/project/entity/task.entity.ts
+++ b/backend/src/project/entity/task.entity.ts
@@ -17,7 +17,7 @@ export enum TaskStatus {
 }
 
 @Entity()
-@Unique(['rankValue', 'storyId'])
+@Unique('TASK_UQ_RANK_VALUE_AND_STORY_ID', ['rankValue', 'storyId'])
 export class Task {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -134,6 +134,7 @@ export class ProjectRepository {
     id: number,
     name?: string,
     color?: EpicColor,
+    rankValue?: string,
   ): Promise<boolean> {
     const updateData: any = {};
 
@@ -142,6 +143,10 @@ export class ProjectRepository {
     }
     if (color !== undefined) {
       updateData.color = color;
+    }
+
+    if (rankValue !== undefined) {
+      updateData.rankValue = rankValue;
     }
 
     const result = await this.epicRepository.update(

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -245,6 +245,7 @@ export class ProjectRepository {
     actualTime: number | undefined,
     status: TaskStatus | undefined,
     assignedMemberId: number | undefined,
+    rankValue: string | undefined,
   ): Promise<boolean> {
     const updateData: any = {};
 
@@ -265,6 +266,9 @@ export class ProjectRepository {
     }
     if (assignedMemberId !== undefined) {
       updateData.assignedMemberId = assignedMemberId;
+    }
+    if (rankValue !== undefined) {
+      updateData.rankValue = rankValue;
     }
 
     const result = await this.taskRepository.update(

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -181,6 +181,7 @@ export class ProjectRepository {
     title: string | undefined,
     point: number | undefined,
     status: StoryStatus | undefined,
+    rankValue: string | undefined,
   ): Promise<boolean> {
     const updateData: any = {};
 
@@ -195,6 +196,9 @@ export class ProjectRepository {
     }
     if (status !== undefined) {
       updateData.status = status;
+    }
+    if (rankValue !== undefined) {
+      updateData.rankValue = rankValue;
     }
 
     const result = await this.storyRepository.update(

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -132,10 +132,11 @@ export class ProjectService {
     title: string,
     point: number,
     status: StoryStatus,
+    rankValue: string,
   ) {
     const epic = await this.projectRepository.getEpicById(project, epicId);
     if (!epic) throw new Error('epic id not found');
-    const newStory = Story.of(project, epicId, title, point, status);
+    const newStory = Story.of(project, epicId, title, point, status, rankValue);
     return this.projectRepository.createStory(newStory);
   }
 
@@ -151,6 +152,7 @@ export class ProjectService {
     title: string | undefined,
     point: number | undefined,
     status: StoryStatus | undefined,
+    rankValue: string | undefined,
   ): Promise<boolean> {
     if (epicId !== undefined) {
       const epic = await this.projectRepository.getEpicById(project, epicId);
@@ -163,6 +165,7 @@ export class ProjectService {
       title,
       point,
       status,
+      rankValue,
     );
   }
 

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -95,8 +95,13 @@ export class ProjectService {
     return result ? true : false;
   }
 
-  createEpic(project: Project, name: string, color: EpicColor) {
-    const newEpic = Epic.of(project, name, color);
+  createEpic(
+    project: Project,
+    name: string,
+    color: EpicColor,
+    rankValue: string,
+  ) {
+    const newEpic = Epic.of(project, name, color, rankValue);
     return this.projectRepository.createEpic(newEpic);
   }
 
@@ -110,8 +115,15 @@ export class ProjectService {
     id: number,
     name?: string,
     color?: EpicColor,
+    rankValue?: string,
   ): Promise<boolean> {
-    return this.projectRepository.updateEpic(project, id, name, color);
+    return this.projectRepository.updateEpic(
+      project,
+      id,
+      name,
+      color,
+      rankValue,
+    );
   }
 
   async createStory(
@@ -211,8 +223,8 @@ export class ProjectService {
       assignedMemberId,
     );
   }
-  
-  getProjectBacklog(project: Project){
-	return this.projectRepository.getProjectBacklog(project);
+
+  getProjectBacklog(project: Project) {
+    return this.projectRepository.getProjectBacklog(project);
   }
 }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -177,6 +177,7 @@ export class ProjectService {
     status: TaskStatus,
     assignedMemberId: number,
     storyId: number,
+    rankValue: string,
   ) {
     const story = await this.projectRepository.getStoryById(project, storyId);
     if (!story) throw new Error('Story id not found');
@@ -192,6 +193,7 @@ export class ProjectService {
       actualTime,
       assignedMemberId,
       status,
+      rankValue,
     );
     return this.projectRepository.createTask(newTask);
   }
@@ -210,6 +212,7 @@ export class ProjectService {
     actualTime: number | undefined,
     status: TaskStatus | undefined,
     assignedMemberId: number | undefined,
+    rankValue: string | undefined,
   ): Promise<boolean> {
     if (storyId !== undefined) {
       const story = await this.projectRepository.getStoryById(project, storyId);
@@ -224,6 +227,7 @@ export class ProjectService {
       actualTime,
       status,
       assignedMemberId,
+      rankValue,
     );
   }
 

--- a/backend/src/project/ws-controller/ws-project-epic.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-epic.controller.ts
@@ -68,13 +68,14 @@ export class WsProjectEpicController {
       return;
     }
     const { content } = data as EpicUpdateRequestDto;
-    const isUpdated = await this.projectService.updateEpic(
-      client.project,
-      content.id,
-      content.name,
-      content.color,
-      content.rankValue,
-    );
+    const { isUpdated, updatedRankValue } =
+      await this.projectService.updateEpic(
+        client.project,
+        content.id,
+        content.name,
+        content.color,
+        content.rankValue,
+      );
 
     if (isUpdated) {
       client.nsp
@@ -85,7 +86,7 @@ export class WsProjectEpicController {
             content.id,
             content.name,
             content.color,
-            content.rankValue,
+            updatedRankValue,
           ),
         );
     }

--- a/backend/src/project/ws-controller/ws-project-epic.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-epic.controller.ts
@@ -26,6 +26,7 @@ export class WsProjectEpicController {
       client.project,
       content.name,
       content.color,
+      content.rankValue,
     );
     client.nsp
       .to('backlog')
@@ -35,6 +36,7 @@ export class WsProjectEpicController {
           createdEpic.id,
           createdEpic.name,
           createdEpic.color,
+          createdEpic.rankValue,
         ),
       );
   }
@@ -71,6 +73,7 @@ export class WsProjectEpicController {
       content.id,
       content.name,
       content.color,
+      content.rankValue,
     );
 
     if (isUpdated) {
@@ -78,7 +81,12 @@ export class WsProjectEpicController {
         .to('backlog')
         .emit(
           'backlog',
-          EpicUpdateNotifyDto.of(content.id, content.name, content.color),
+          EpicUpdateNotifyDto.of(
+            content.id,
+            content.name,
+            content.color,
+            content.rankValue,
+          ),
         );
     }
   }

--- a/backend/src/project/ws-controller/ws-project-story.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-story.controller.ts
@@ -28,6 +28,7 @@ export class WsProjectStoryController {
       content.title,
       content.point,
       content.status,
+      content.rankValue,
     );
     client.nsp
       .to('backlog')
@@ -68,6 +69,7 @@ export class WsProjectStoryController {
       content.title,
       content.point,
       content.status,
+      content.rankValue,
     );
 
     if (isUpdated) {
@@ -81,6 +83,7 @@ export class WsProjectStoryController {
             content.title,
             content.point,
             content.status,
+            content.rankValue,
           ),
         );
     }

--- a/backend/src/project/ws-controller/ws-project-story.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-story.controller.ts
@@ -62,15 +62,16 @@ export class WsProjectStoryController {
       return;
     }
     const { content } = data as StoryUpdateRequestDto;
-    const isUpdated = await this.projectService.updateStory(
-      client.project,
-      content.id,
-      content.epicId,
-      content.title,
-      content.point,
-      content.status,
-      content.rankValue,
-    );
+    const { isUpdated, updatedRankValue } =
+      await this.projectService.updateStory(
+        client.project,
+        content.id,
+        content.epicId,
+        content.title,
+        content.point,
+        content.status,
+        content.rankValue,
+      );
 
     if (isUpdated) {
       client.nsp
@@ -83,7 +84,7 @@ export class WsProjectStoryController {
             content.title,
             content.point,
             content.status,
-            content.rankValue,
+            updatedRankValue,
           ),
         );
     }

--- a/backend/src/project/ws-controller/ws-project-task.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-task.controller.ts
@@ -31,6 +31,7 @@ export class WsProjectTaskController {
       content.status,
       content.assignedMemberId,
       content.storyId,
+      content.rankValue,
     );
     client.nsp
       .to('backlog')
@@ -73,6 +74,7 @@ export class WsProjectTaskController {
       content.actualTime,
       content.status,
       content.assignedMemberId,
+      content.rankValue,
     );
 
     if (isUpdated) {
@@ -88,6 +90,7 @@ export class WsProjectTaskController {
             content.actualTime,
             content.status,
             content.assignedMemberId,
+            content.rankValue,
           ),
         );
     }

--- a/backend/src/project/ws-controller/ws-project-task.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-task.controller.ts
@@ -65,17 +65,18 @@ export class WsProjectTaskController {
       return;
     }
     const { content } = data as TaskUpdateRequestDto;
-    const isUpdated = await this.projectService.updateTask(
-      client.project,
-      content.id,
-      content.storyId,
-      content.title,
-      content.expectedTime,
-      content.actualTime,
-      content.status,
-      content.assignedMemberId,
-      content.rankValue,
-    );
+    const { isUpdated, updatedRankValue } =
+      await this.projectService.updateTask(
+        client.project,
+        content.id,
+        content.storyId,
+        content.title,
+        content.expectedTime,
+        content.actualTime,
+        content.status,
+        content.assignedMemberId,
+        content.rankValue,
+      );
 
     if (isUpdated) {
       client.nsp
@@ -90,7 +91,7 @@ export class WsProjectTaskController {
             content.actualTime,
             content.status,
             content.assignedMemberId,
-            content.rankValue,
+            updatedRankValue,
           ),
         );
     }

--- a/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
@@ -1,8 +1,7 @@
+import { LexoRank } from 'lexorank';
 import { Socket } from 'socket.io-client';
 import { app, appInit } from 'test/setup';
-import {
-  getTwoMemberJoinedLandingPage,
-} from '../ws-common';
+import { getTwoMemberJoinedLandingPage } from '../ws-common';
 
 describe('WS epic', () => {
   beforeEach(async () => {
@@ -18,9 +17,10 @@ describe('WS epic', () => {
       await initBacklog(socket1);
       const epicName = '회원';
       const epicColor = 'yellow';
+      const epicRankValue = LexoRank.middle().toString();
       socket1.emit('epic', {
         action: 'create',
-        content: { name: epicName, color: epicColor },
+        content: { name: epicName, color: epicColor, rankValue: epicRankValue },
       });
       const epicId = await getEpicId(socket1);
       const storyTitle = '타이틀';

--- a/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
@@ -75,12 +75,16 @@ describe('WS epic', () => {
               expect(epic.id).toBe(epicId);
               expect(epic.name).toBe(epicName);
               expect(epic.color).toBe(epicColor);
+              expect(epic.rankValue).toBe(middleRankValue);
+
               expect(epic.storyList).toHaveLength(1);
               const story = epic.storyList[0];
               expect(story.id).toBe(storyId);
               expect(story.title).toBe(storyTitle);
               expect(story.point).toBe(storyPoint);
               expect(story.status).toBe(storyStatus);
+              expect(story.rankValue).toBe(middleRankValue);
+
               expect(story.taskList).toHaveLength(1);
               const task = story.taskList[0];
               expect(task.id).toBe(taskId);
@@ -90,6 +94,7 @@ describe('WS epic', () => {
               expect(task.actualTime).toBe(taskActualTime);
               expect(task.status).toBe(taskStatus);
               expect(task.assignedMemberId).toBe(taskAssignedMemberId);
+              expect(task.rankValue).toBe(middleRankValue);
             } catch (e) {
               reject(e);
             }

--- a/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
@@ -56,6 +56,7 @@ describe('WS epic', () => {
           status: taskStatus,
           assignedMemberId: taskAssignedMemberId,
           storyId,
+          rankValue: middleRankValue,
         },
       });
 

--- a/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
@@ -17,10 +17,14 @@ describe('WS epic', () => {
       await initBacklog(socket1);
       const epicName = '회원';
       const epicColor = 'yellow';
-      const epicRankValue = LexoRank.middle().toString();
+      const middleRankValue = LexoRank.middle().toString();
       socket1.emit('epic', {
         action: 'create',
-        content: { name: epicName, color: epicColor, rankValue: epicRankValue },
+        content: {
+          name: epicName,
+          color: epicColor,
+          rankValue: middleRankValue,
+        },
       });
       const epicId = await getEpicId(socket1);
       const storyTitle = '타이틀';
@@ -33,6 +37,7 @@ describe('WS epic', () => {
           point: storyPoint,
           status: storyStatus,
           epicId,
+          rankValue: middleRankValue,
         },
       });
       const storyId = await getStoryId(socket1);

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { LexoRank } from 'lexorank';
 import { Socket } from 'socket.io-client';
 import { app, appInit } from 'test/setup';
 import {
@@ -21,9 +22,10 @@ describe('WS story', () => {
 
       const name = '회원';
       const color = 'yellow';
+      const rankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket1.emit('epic', requestData);
       const [epicId] = await Promise.all([
@@ -72,9 +74,11 @@ describe('WS story', () => {
 
       const name = '회원';
       const color = 'yellow';
+      const rankValue = LexoRank.middle().toString();
+
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -119,9 +123,11 @@ describe('WS story', () => {
 
       const name = '회원';
       const color = 'yellow';
+      const rankValue = LexoRank.middle().toString();
+
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -167,9 +173,10 @@ describe('WS story', () => {
 
       const name = '회원';
       const color = 'yellow';
+      const rankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);

--- a/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
@@ -22,10 +22,10 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
-      const rankValue = LexoRank.middle().toString();
+      const middleRankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color, rankValue },
+        content: { name, color, rankValue: middleRankValue },
       };
       socket1.emit('epic', requestData);
       const [epicId] = await Promise.all([
@@ -43,6 +43,7 @@ describe('WS task', () => {
           point: storyPoint,
           status: storyStatus,
           epicId,
+          rankValue: middleRankValue,
         },
       };
       socket1.emit('story', requestData);
@@ -180,11 +181,11 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
-	  const rankValue = LexoRank.middle().toString();
+      const middleRankValue = LexoRank.middle().toString();
 
       let requestData: any = {
         action: 'create',
-        content: { name, color, rankValue },
+        content: { name, color, rankValue: middleRankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -194,7 +195,7 @@ describe('WS task', () => {
       const status = '시작전';
       requestData = {
         action: 'create',
-        content: { title, point, status, epicId },
+        content: { title, point, status, epicId, rankValue: middleRankValue },
       };
       socket.emit('story', requestData);
       const storyId = await getStoryId(socket);
@@ -249,10 +250,10 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
-	  const rankValue = LexoRank.middle().toString();
+      const middleRankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color, rankValue },
+        content: { name, color, rankValue: middleRankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -262,7 +263,7 @@ describe('WS task', () => {
       const status = '시작전';
       requestData = {
         action: 'create',
-        content: { title, point, status, epicId },
+        content: { title, point, status, epicId, rankValue: middleRankValue },
       };
       socket.emit('story', requestData);
       const storyId = await getStoryId(socket);
@@ -358,10 +359,10 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
-	  const rankValue = LexoRank.middle().toString();
+      const middleRankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color, rankValue },
+        content: { name, color, rankValue: middleRankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -371,7 +372,7 @@ describe('WS task', () => {
       const status = '시작전';
       requestData = {
         action: 'create',
-        content: { title, point, status, epicId },
+        content: { title, point, status, epicId, rankValue: middleRankValue },
       };
       socket.emit('story', requestData);
       const storyId = await getStoryId(socket);

--- a/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { LexoRank } from 'lexorank';
 import { Socket } from 'socket.io-client';
 import { app, appInit } from 'test/setup';
 import {
@@ -21,9 +22,10 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
+      const rankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket1.emit('epic', requestData);
       const [epicId] = await Promise.all([
@@ -178,9 +180,11 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
+	  const rankValue = LexoRank.middle().toString();
+
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -245,9 +249,10 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
+	  const rankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);
@@ -353,9 +358,10 @@ describe('WS task', () => {
 
       const name = '회원';
       const color = 'yellow';
+	  const rankValue = LexoRank.middle().toString();
       let requestData: any = {
         action: 'create',
-        content: { name, color },
+        content: { name, color, rankValue },
       };
       socket.emit('epic', requestData);
       const [epicId] = await Promise.all([getEpicId(socket)]);


### PR DESCRIPTION
## 🎟️ 태스크

[우선순위 API  구현](https://plastic-toad-cb0.notion.site/API-b243d8a8a8da4287b821fbb199ad995f?pvs=74)

## ✅ 작업 내용

- 에픽 생성, 수정 API에 우선순위 데이터(rankValue)추가
- 스토리 생성, 수정 API에 우선순위 데이터(rankValue)추가
- 태스크 생성, 수정 API에 우선순위 데이터(rankValue)추가
- 백로그 조회 API에 우선순위 데이터(rankValue)추가
-  Epic, Task, Story 생성, 수정시 중복된 rankValue를 서버가 조정해, 조정된 rankValue를 반환하는 로직 구현

## 🖊️ 구체적인 작업

### 에픽 생성, 수정 API에 우선순위 데이터(rankValue)추가
- lexorank 패키지 설치
- epic 엔티티
  - rankValue 프로퍼티 추가
  - 에픽의 rankValue가 project에서 고유하도록 유니크 제약조건 추가
- project 레포지토리, project 서비스, epic컨트롤러에 rankValue 정보 추가
- Epic DTO에 rankValue 정보 추가
- LexoRank형식인지 검증할 수 있는 IsLexoRankValue 데코레이터 추가
- E2E 테스트
  - 에픽, 스토리, 태스크, 백로그 테스트에 rankValue정보 추가
  - 에픽 테스트에 rankValue update테스트 추가
### 스토리 생성, 수정 API에 우선순위 데이터(rankValue)추가
- story 엔티티
  - rankValue 프로퍼티 추가
  - 스토리의 rankValue가 project에서 고유하도록 유니크 제약조건 추가
- project 레포지토리, project 서비스의 story 관련 update, create 메서드에 rankValue정보 추가
- story 컨트롤러에 rankValue 정보 추가
- Story DTO에 rankValue 정보 추가
- E2E 테스트
  - 스토리, 태스크, 백로그 테스트에 스토리의 rankValue정보 추가
  - 스토리 테스트에 같은 에픽 내 rankValue 업데이트 테스트 추가
  - 스토리 테스트에 다른 에픽으로의 rankValue 업데이트 테스트 추가
### 태스크 생성, 수정 API에 우선순위 데이터(rankValue)추가
- task 엔티티
  - rankValue 프로퍼티 추가
  - task의 rankValue가 project에서 고유하도록 유니크 제약조건 추가
- project 레포지토리, project 서비스의 task 관련 update, create 메서드에 rankValue정보 추가
- task 컨트롤러에 rankValue 정보 추가
- task DTO에 rankValue 정보 추가
- E2E 테스트
  - 태스크, init 백로그 테스트에 태스크의 rankValue정보 추가
  - 태스크 테스트에 같은 스토리 내 rankValue 업데이트 테스트 추가
  - 태스크 테스트에 다른 스토리으로의 rankValue 업데이트 테스트 추가
### 백로그 조회 API에 우선순위 데이터(rankValue)추가
- initBacklog 테스트에 rankValue 정보 추가
- initBacklog Response DTO에 rankValue 정보 추가
### Epic, Task, Story 생성, 수정시 중복된 rankValue를 서버가 조정해, 조정된 rankValue를 반환하는 로직 구현
- Entity
  - 유니크 제약조건 이름 명시
- Repository
  - Create 메서드를 Unique오류이며, RankValue중복일 경우 커스텀 에러를 throw하게 변경
  - Update 메서드를 Unique오류이며, RankValue중복일 경우 커스텀 에러를 throw하게 변경
  - getNext[Epic/Task/Story]ByRankValue 메서드 구현
    - 특정 rankValue값 다음 순서의 rankValue를 가진 엔티티 반환
- Controller
  - update시 조정된 rankValue값을 반영해 유저에게 반환하도록 수정
- Test
  - Epic/Task/Story 생성 시 동시에 중복된 rankValue를 전송했을때 조정되는것 테스트
  - Epic/Task/Story 변경 시 동시에 중복된 rankValue를 전송했을때 조정되는것 테스트
## 🤔 고민 및 의논할 거리
