### PR TITLE
feat: 스토리 드래그 앤 드롭 기능, 에픽별 백로그 페이지 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.28.14",
     "axios": "^1.6.7",
+    "lexorank": "^1.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -22,6 +22,7 @@ import InvitePage from "./pages/invite/InvitePage";
 import UnfinishedStoryPage from "./pages/backlog/UnfinishedStoryPage";
 import BacklogPage from "./pages/backlog/BacklogPage";
 import FinishedStoryPage from "./pages/backlog/FinishedStoryPage";
+import EpicPage from "./pages/backlog/EpicPage";
 
 type RouteType = "PRIVATE" | "PUBLIC";
 
@@ -86,7 +87,7 @@ const router = createBrowserRouter([
                 },
                 {
                   path: ROUTER_URL.BACKLOG.EPIC,
-                  element: <div>backlog epic Page</div>,
+                  element: <EpicPage />,
                 },
                 {
                   path: ROUTER_URL.BACKLOG.COMPLETED,

--- a/frontend/src/components/backlog/EpicBlock.tsx
+++ b/frontend/src/components/backlog/EpicBlock.tsx
@@ -1,0 +1,50 @@
+import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
+import ChevronDown from "../../assets/icons/chevron-down.svg?react";
+import ChevronRight from "../../assets/icons/chevron-right.svg?react";
+import CategoryChip from "./CategoryChip";
+import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+
+interface EpicBlockProps {
+  storyExist: boolean;
+  epic: EpicCategoryDTO;
+  children: React.ReactNode;
+}
+
+const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
+  const { showDetail, handleShowDetail } = useShowDetail();
+
+  return (
+    <>
+      <div className="flex items-center justify-start py-1 border-t border-b text-s">
+        <button
+          className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            handleShowDetail(!showDetail);
+          }}
+        >
+          {showDetail ? (
+            <ChevronDown
+              width={16}
+              height={16}
+              fill={storyExist ? "black" : "#C5C5C5"}
+            />
+          ) : (
+            <ChevronRight
+              width={16}
+              height={16}
+              fill={storyExist ? "black" : "#C5C5C5"}
+            />
+          )}
+        </button>
+        <div className="h-[2.25rem]">
+          <CategoryChip content={epic.name} bgColor={epic.color} />
+        </div>
+      </div>
+      {showDetail && <div className="w-[65rem] ml-auto">{children}</div>}
+    </>
+  );
+};
+
+export default EpicBlock;

--- a/frontend/src/components/backlog/EpicBlock.tsx
+++ b/frontend/src/components/backlog/EpicBlock.tsx
@@ -9,16 +9,10 @@ import EpicDropdown from "./EpicDropdown";
 interface EpicBlockProps {
   storyExist: boolean;
   epic: EpicCategoryDTO;
-  epicList: EpicCategoryDTO[];
   children: React.ReactNode;
 }
 
-const EpicBlock = ({
-  storyExist,
-  epic,
-  epicList,
-  children,
-}: EpicBlockProps) => {
+const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
   const { showDetail, handleShowDetail } = useShowDetail();
   const {
     open: epicUpdating,
@@ -66,7 +60,7 @@ const EpicBlock = ({
           {epicUpdating && (
             <EpicDropdown
               selectedEpic={epic}
-              epicList={epicList}
+              epicList={[epic]}
               onEpicChange={() => {}}
             />
           )}

--- a/frontend/src/components/backlog/EpicBlock.tsx
+++ b/frontend/src/components/backlog/EpicBlock.tsx
@@ -3,15 +3,34 @@ import ChevronDown from "../../assets/icons/chevron-down.svg?react";
 import ChevronRight from "../../assets/icons/chevron-right.svg?react";
 import CategoryChip from "./CategoryChip";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
+import EpicDropdown from "./EpicDropdown";
 
 interface EpicBlockProps {
   storyExist: boolean;
   epic: EpicCategoryDTO;
+  epicList: EpicCategoryDTO[];
   children: React.ReactNode;
 }
 
-const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
+const EpicBlock = ({
+  storyExist,
+  epic,
+  epicList,
+  children,
+}: EpicBlockProps) => {
   const { showDetail, handleShowDetail } = useShowDetail();
+  const {
+    open: epicUpdating,
+    handleOpen: handleEpicUpdateOpen,
+    dropdownRef: epicRef,
+  } = useDropdownState();
+
+  const handleEpicColumnClick = () => {
+    if (!epicUpdating) {
+      handleEpicUpdateOpen();
+    }
+  };
 
   return (
     <>
@@ -38,8 +57,19 @@ const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
             />
           )}
         </button>
-        <div className="h-[2.25rem]">
+        <div
+          className="h-[2.25rem] hover:cursor-pointer"
+          ref={epicRef}
+          onClick={handleEpicColumnClick}
+        >
           <CategoryChip content={epic.name} bgColor={epic.color} />
+          {epicUpdating && (
+            <EpicDropdown
+              selectedEpic={epic}
+              epicList={epicList}
+              onEpicChange={() => {}}
+            />
+          )}
         </div>
       </div>
       {showDetail && <div className="w-[65rem] ml-auto">{children}</div>}

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -13,6 +13,7 @@ import {
   BacklogSocketEpicAction,
 } from "../../types/common/backlog";
 import EpicDropdownOption from "./EpicDropdownOption";
+import { LexoRank } from "lexorank";
 
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
@@ -53,8 +54,14 @@ const EpicDropdown = ({
         return;
       }
 
+      const rankValue = epicList.length
+        ? LexoRank.parse(epicList[epicList.length - 1].rankValue)
+            .genNext()
+            .toString()
+        : LexoRank.middle().toString();
+
       setValue("");
-      emitEpicCreateEvent({ name: value, color: epicColor });
+      emitEpicCreateEvent({ name: value, color: epicColor, rankValue });
     }
   };
 

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -29,7 +29,7 @@ interface StoryBlockProps {
   status: BacklogStatusType;
   children: React.ReactNode;
   taskExist: boolean;
-  epicList: EpicCategoryDTO[];
+  epicList?: EpicCategoryDTO[];
   finished?: boolean;
   lastTaskRankValue?: string;
 }
@@ -172,21 +172,24 @@ const StoryBlock = ({
         onContextMenu={(event) => event.preventDefault()}
         ref={blockRef}
       >
-        <div
-          className="w-[5rem] mr-5 hover:cursor-pointer"
-          onClick={handleEpicColumnClick}
-          ref={epicRef}
-        >
-          <CategoryChip content={epic.name} bgColor={epic.color} />
+        {epicList && (
+          <div
+            className="w-[5rem] mr-5 hover:cursor-pointer"
+            onClick={handleEpicColumnClick}
+            ref={epicRef}
+          >
+            <CategoryChip content={epic.name} bgColor={epic.color} />
 
-          {epicUpdating && (
-            <EpicDropdown
-              selectedEpic={epic}
-              epicList={epicList}
-              onEpicChange={updateEpic}
-            />
-          )}
-        </div>
+            {epicUpdating && (
+              <EpicDropdown
+                selectedEpic={epic}
+                epicList={epicList}
+                onEpicChange={updateEpic}
+              />
+            )}
+          </div>
+        )}
+
         <div
           className="flex items-center gap-1 w-[40.9rem] mr-4 hover:cursor-pointer"
           onClick={() => handleTitleUpdatingOpen(true)}

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -31,6 +31,7 @@ interface StoryBlockProps {
   taskExist: boolean;
   epicList: EpicCategoryDTO[];
   finished?: boolean;
+  lastTaskRankValue?: string;
 }
 
 const StoryBlock = ({
@@ -43,6 +44,7 @@ const StoryBlock = ({
   taskExist,
   epicList,
   finished = false,
+  lastTaskRankValue,
   children,
 }: StoryBlockProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
@@ -279,7 +281,9 @@ const StoryBlock = ({
         <TaskContainer>
           <TaskHeader />
           {children}
-          {!finished && <TaskCreateBlock storyId={id} />}
+          {!finished && (
+            <TaskCreateBlock storyId={id} {...{ lastTaskRankValue }} />
+          )}
         </TaskContainer>
       )}
     </>

--- a/frontend/src/components/backlog/StoryCreateForm.tsx
+++ b/frontend/src/components/backlog/StoryCreateForm.tsx
@@ -9,33 +9,42 @@ import { useOutletContext } from "react-router-dom";
 import EpicDropdown from "./EpicDropdown";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
+import { LexoRank } from "lexorank";
 
 interface StoryCreateFormProps {
   onCloseClick: () => void;
   epicList: EpicCategoryDTO[];
+  lastStoryRankValue?: string;
 }
 
-const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
+const StoryCreateForm = ({
+  onCloseClick,
+  epicList,
+  lastStoryRankValue,
+}: StoryCreateFormProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
-  const [{ title, point, epicId, status }, setStoryFormData] =
+  const [{ title, point, epicId, status, rankValue }, setStoryFormData] =
     useState<StoryForm>({
       title: "",
       point: undefined,
       status: "시작전",
       epicId: undefined,
+      rankValue: lastStoryRankValue
+        ? LexoRank.parse(lastStoryRankValue).genNext().toString()
+        : LexoRank.middle().toString(),
     });
   const { open, handleClose, handleOpen, dropdownRef } = useDropdownState();
   const { emitStoryCreateEvent } = useStoryEmitEvent(socket);
 
   const handleTitleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const { value } = target;
-    setStoryFormData({ title: value, point, epicId, status });
+    setStoryFormData({ title: value, point, epicId, status, rankValue });
   };
 
   const handlePointChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const { value } = target;
     const newPoint = value === "" ? undefined : Number(value);
-    setStoryFormData({ title, point: newPoint, epicId, status });
+    setStoryFormData({ title, point: newPoint, epicId, status, rankValue });
   };
 
   const handleSubmit = (event: FormEvent) => {
@@ -71,12 +80,18 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
       return;
     }
 
-    emitStoryCreateEvent({ title, status, epicId, point });
+    emitStoryCreateEvent({ title, status, epicId, point, rankValue });
     onCloseClick();
   };
 
   const handleEpicChange = (selectedEpicId: number | undefined) => {
-    setStoryFormData({ title, status, point, epicId: selectedEpicId });
+    setStoryFormData({
+      title,
+      status,
+      point,
+      epicId: selectedEpicId,
+      rankValue,
+    });
     handleClose();
   };
 
@@ -93,7 +108,7 @@ const StoryCreateForm = ({ onCloseClick, epicList }: StoryCreateFormProps) => {
 
   useEffect(() => {
     if (!epicList.filter(({ id }) => id === epicId).length) {
-      setStoryFormData({ title, point, status, epicId: undefined });
+      setStoryFormData({ title, point, status, epicId: undefined, rankValue });
     }
   }, [epicList]);
 

--- a/frontend/src/components/backlog/StoryCreateForm.tsx
+++ b/frontend/src/components/backlog/StoryCreateForm.tsx
@@ -14,12 +14,14 @@ import { LexoRank } from "lexorank";
 interface StoryCreateFormProps {
   onCloseClick: () => void;
   epicList: EpicCategoryDTO[];
+  epic?: EpicCategoryDTO;
   lastStoryRankValue?: string;
 }
 
 const StoryCreateForm = ({
   onCloseClick,
   epicList,
+  epic,
   lastStoryRankValue,
 }: StoryCreateFormProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
@@ -28,7 +30,7 @@ const StoryCreateForm = ({
       title: "",
       point: undefined,
       status: "시작전",
-      epicId: undefined,
+      epicId: epic?.id,
       rankValue: lastStoryRankValue
         ? LexoRank.parse(lastStoryRankValue).genNext().toString()
         : LexoRank.middle().toString(),
@@ -117,32 +119,39 @@ const StoryCreateForm = ({
       className="flex items-center w-full py-1 border-t border-b"
       onSubmit={handleSubmit}
     >
-      <div
-        className="w-[5rem] min-h-[1.75rem] bg-light-gray rounded-md mr-7 hover:cursor-pointer relative"
-        onClick={handleEpicColumnClick}
-        ref={dropdownRef}
-      >
-        {epicId && (
-          <CategoryChip
-            content={selectedEpic?.name}
-            bgColor={selectedEpic?.color}
-          />
-        )}
-        {open && (
-          <EpicDropdown
-            selectedEpic={selectedEpic}
-            epicList={epicList}
-            onEpicChange={handleEpicChange}
-          />
-        )}
-      </div>
+      {!epic ? (
+        <div
+          className="w-[5rem] min-h-[1.75rem] bg-light-gray rounded-md mr-7 hover:cursor-pointer relative"
+          onClick={handleEpicColumnClick}
+          ref={dropdownRef}
+        >
+          {epicId && (
+            <CategoryChip
+              content={selectedEpic?.name}
+              bgColor={selectedEpic?.color}
+            />
+          )}
+          {open && (
+            <EpicDropdown
+              selectedEpic={selectedEpic}
+              epicList={epicList}
+              onEpicChange={handleEpicChange}
+            />
+          )}
+        </div>
+      ) : (
+        <div className="w-[1.45rem]" />
+      )}
+
       <input
         className="w-[34.7rem] h-[1.75rem] mr-[1.5rem] bg-light-gray rounded-md focus:outline-none"
         type="text"
         value={title}
         onChange={handleTitleChange}
       />
-      <div className="flex items-center mr-[2.8rem] ">
+      <div
+        className={`flex items-center ${epic ? "mr-[1.85rem]" : "mr-[2.8rem]"}`}
+      >
         <input
           className="w-24 h-[1.75rem] mr-1 text-right rounded-md bg-light-gray no-arrows focus:outline-none"
           type="number"

--- a/frontend/src/components/backlog/TaskCreateBlock.tsx
+++ b/frontend/src/components/backlog/TaskCreateBlock.tsx
@@ -4,15 +4,19 @@ import TaskCreateForm from "./TaskCreateForm";
 
 interface TaskCreateBlockProps {
   storyId: number;
+  lastTaskRankValue?: string;
 }
 
-const TaskCreateBlock = ({ storyId }: TaskCreateBlockProps) => {
+const TaskCreateBlock = ({
+  storyId,
+  lastTaskRankValue,
+}: TaskCreateBlockProps) => {
   const { showDetail, handleShowDetail } = useShowDetail();
   return (
     <>
       {showDetail ? (
         <TaskCreateForm
-          {...{ storyId }}
+          {...{ storyId, lastTaskRankValue }}
           onCloseClick={() => handleShowDetail(false)}
         />
       ) : (

--- a/frontend/src/components/backlog/TaskCreateForm.tsx
+++ b/frontend/src/components/backlog/TaskCreateForm.tsx
@@ -5,13 +5,19 @@ import Check from "../../assets/icons/check.svg?react";
 import Closed from "../../assets/icons/closed.svg?react";
 import useTaskEmitEvent from "../../hooks/pages/backlog/useTaskEmitEvent";
 import { TaskForm } from "../../types/common/backlog";
+import { LexoRank } from "lexorank";
 
 interface TaskCreateFormProps {
   onCloseClick: () => void;
   storyId: number;
+  lastTaskRankValue?: string;
 }
 
-const TaskCreateForm = ({ onCloseClick, storyId }: TaskCreateFormProps) => {
+const TaskCreateForm = ({
+  onCloseClick,
+  storyId,
+  lastTaskRankValue,
+}: TaskCreateFormProps) => {
   const [taskFormData, setTaskFormData] = useState<TaskForm>({
     title: "",
     expectedTime: null,
@@ -19,6 +25,9 @@ const TaskCreateForm = ({ onCloseClick, storyId }: TaskCreateFormProps) => {
     status: "시작전",
     assignedMemberId: null,
     storyId,
+    rankValue: lastTaskRankValue
+      ? LexoRank.parse(lastTaskRankValue).genNext().toString()
+      : LexoRank.middle().toString(),
   });
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitTaskCreateEvent } = useTaskEmitEvent(socket);

--- a/frontend/src/hooks/pages/backlog/useEpicEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useEpicEmitEvent.ts
@@ -5,6 +5,7 @@ const useEpicEmitEvent = (socket: Socket) => {
   const emitEpicCreateEvent = (content: {
     name: string;
     color: BacklogCategoryColor;
+    rankValue: string;
   }) => {
     socket.emit("epic", { action: "create", content });
   };

--- a/frontend/src/hooks/pages/backlog/useStoryEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useStoryEmitEvent.ts
@@ -17,6 +17,7 @@ const useStoryEmitEvent = (socket: Socket) => {
     status?: BacklogStatusType;
     epicId?: number;
     point?: number;
+    rankValue?: string;
   }) => {
     socket.emit("story", { action: "update", content });
   };

--- a/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useTaskEmitEvent.ts
@@ -15,13 +15,14 @@ const useTaskEmitEvent = (socket: Socket) => {
     assignedMemberId?: number;
     storyId?: number;
     status?: BacklogStatusType;
+    rankValue?: string;
   }) => {
     socket.emit("task", { action: "update", content });
   };
 
-  const emitTaskDeleteEvent = (content: {id: number}) => {
-    socket.emit("task", {action: "delete", content})
-  }
+  const emitTaskDeleteEvent = (content: { id: number }) => {
+    socket.emit("task", { action: "delete", content });
+  };
 
   return { emitTaskCreateEvent, emitTaskUpdateEvent, emitTaskDeleteEvent };
 };

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -28,6 +28,7 @@ const EpicPage = () => {
         ({ id: epicId, name, color, rankValue, storyList }) => (
           <EpicBlock
             storyExist={storyList.length > 1}
+            epicList={epicCategoryList}
             epic={{ id: epicId, name, color, rankValue }}
           >
             {...storyList.map(({ id, title, point, status, taskList }) => {

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -28,7 +28,6 @@ const EpicPage = () => {
         ({ id: epicId, name, color, rankValue, storyList }) => (
           <EpicBlock
             storyExist={storyList.length > 1}
-            epicList={epicCategoryList}
             epic={{ id: epicId, name, color, rankValue }}
           >
             {...storyList.map(({ id, title, point, status, taskList }) => {

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+import { useOutletContext } from "react-router-dom";
+import { BacklogDTO } from "../../types/DTO/backlogDTO";
+import StoryCreateButton from "../../components/backlog/StoryCreateButton";
+import StoryCreateForm from "../../components/backlog/StoryCreateForm";
+import StoryBlock from "../../components/backlog/StoryBlock";
+import TaskBlock from "../../components/backlog/TaskBlock";
+import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
+import EpicBlock from "../../components/backlog/EpicBlock";
+
+const EpicPage = () => {
+  const { backlog }: { backlog: BacklogDTO } = useOutletContext();
+  const { showDetail, handleShowDetail } = useShowDetail();
+  const epicCategoryList = useMemo(
+    () =>
+      backlog.epicList.map(({ id, name, color, rankValue }) => ({
+        id,
+        name,
+        color,
+        rankValue,
+      })),
+    [backlog.epicList]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {...backlog.epicList.map(
+        ({ id: epicId, name, color, rankValue, storyList }) => (
+          <EpicBlock
+            storyExist={storyList.length > 1}
+            epic={{ id: epicId, name, color, rankValue }}
+          >
+            {...storyList.map(({ id, title, point, status, taskList }) => {
+              const progress = taskList.length
+                ? Math.round(
+                    (taskList.filter(({ status }) => status === "완료").length /
+                      taskList.length) *
+                      100
+                  )
+                : 0;
+
+              return (
+                <StoryBlock
+                  {...{ id, title, point, status }}
+                  epic={{ id: epicId, name, color, rankValue }}
+                  progress={progress}
+                  taskExist={taskList.length > 0}
+                  lastTaskRankValue={
+                    taskList.length
+                      ? taskList[taskList.length - 1].rankValue
+                      : undefined
+                  }
+                >
+                  {...taskList.map((task) => <TaskBlock {...task} />)}
+                </StoryBlock>
+              );
+            })}
+            {showDetail ? (
+              <StoryCreateForm
+                epicList={epicCategoryList}
+                epic={{ id: epicId, name, color, rankValue }}
+                onCloseClick={() => handleShowDetail(false)}
+                lastStoryRankValue={
+                  storyList.length
+                    ? storyList[storyList.length - 1].rankValue
+                    : undefined
+                }
+              />
+            ) : (
+              <StoryCreateButton onClick={() => handleShowDetail(true)} />
+            )}
+          </EpicBlock>
+        )
+      )}
+    </div>
+  );
+};
+
+export default EpicPage;

--- a/frontend/src/pages/backlog/FinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/FinishedStoryPage.tsx
@@ -15,7 +15,13 @@ const FinishedStoryPage = () => {
     [backlog.epicList]
   );
   const epicCategoryList = useMemo(
-    () => backlog.epicList.map(({ id, name, color }) => ({ id, name, color })),
+    () =>
+      backlog.epicList.map(({ id, name, color, rankValue }) => ({
+        id,
+        name,
+        color,
+        rankValue,
+      })),
     [backlog.epicList]
   );
 

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -2,7 +2,7 @@ import { useOutletContext } from "react-router-dom";
 import { BacklogDTO } from "../../types/DTO/backlogDTO";
 import StoryCreateButton from "../../components/backlog/StoryCreateButton";
 import StoryCreateForm from "../../components/backlog/StoryCreateForm";
-import { useMemo } from "react";
+import { DragEvent, useMemo, useRef, useState } from "react";
 import changeEpicListToStoryList from "../../utils/changeEpicListToStoryList";
 import StoryBlock from "../../components/backlog/StoryBlock";
 import TaskBlock from "../../components/backlog/TaskBlock";
@@ -11,6 +11,9 @@ import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 const UnfinishedStoryPage = () => {
   const { backlog }: { backlog: BacklogDTO } = useOutletContext();
   const { showDetail, handleShowDetail } = useShowDetail();
+  const [beforeElementIndex, setBeforeElementIndex] = useState<number>();
+  const storyComponentRefList = useRef<HTMLDivElement[]>([]);
+  const draggingComponentIndexRef = useRef<number>();
   const storyList = useMemo(
     () => changeEpicListToStoryList(backlog.epicList),
     [backlog.epicList]
@@ -20,30 +23,83 @@ const UnfinishedStoryPage = () => {
     [backlog.epicList]
   );
 
+  const setStoryComponentRef = (index: number) => (element: HTMLDivElement) => {
+    storyComponentRefList.current[index] = element;
+  };
+
+  const handleDragOver = (event: DragEvent) => {
+    event.preventDefault();
+    const index = getDragBeforeElement(event.clientY);
+    setBeforeElementIndex(index);
+  };
+
+  const handleDragStart = (index: number) => {
+    draggingComponentIndexRef.current = index;
+  };
+
+  const handleDragEnd = (event: DragEvent) => {
+    event.stopPropagation();
+    draggingComponentIndexRef.current = undefined;
+    setBeforeElementIndex(undefined);
+  };
+
+  function getDragBeforeElement(y: number) {
+    return storyComponentRefList.current.reduce(
+      (closest, child, index) => {
+        const box = child.getBoundingClientRect();
+        const offset = y - box.top - box.height / 2;
+        if (offset < 0 && offset > closest.offset) {
+          return { offset, index };
+        } else {
+          return closest;
+        }
+      },
+      {
+        offset: Number.NEGATIVE_INFINITY,
+        index: draggingComponentIndexRef.current,
+      }
+    ).index;
+  }
+
   return (
     <div className="flex flex-col items-center gap-4">
-      <div className="w-full border-b">
-        {...storyList.map(({ id, epic, title, point, status, taskList }) => {
-          const progress = taskList.length
-            ? Math.round(
-                (taskList.filter(({ status }) => status === "완료").length /
-                  taskList.length) *
-                  100
-              )
-            : 0;
+      <div className="w-full border-b" onDragOver={handleDragOver}>
+        {...storyList.map(
+          ({ id, epic, title, point, status, taskList }, index) => {
+            const progress = taskList.length
+              ? Math.round(
+                  (taskList.filter(({ status }) => status === "완료").length /
+                    taskList.length) *
+                    100
+                )
+              : 0;
 
-          return (
-            <StoryBlock
-              {...{ id, title, point, status }}
-              epic={epic}
-              progress={progress}
-              taskExist={taskList.length > 0}
-              epicList={epicCategoryList}
-            >
-              {...taskList.map((task) => <TaskBlock {...task} />)}
-            </StoryBlock>
-          );
-        })}
+            return (
+              <div
+                className="relative"
+                ref={setStoryComponentRef(index)}
+                draggable={true}
+                onDragStart={() => handleDragStart(index)}
+                onDragEnd={handleDragEnd}
+              >
+                <div
+                  className={`${
+                    index === beforeElementIndex ? "w-full h-1 bg-blue-400" : ""
+                  } absolute`}
+                />
+                <StoryBlock
+                  {...{ id, title, point, status }}
+                  epic={epic}
+                  progress={progress}
+                  taskExist={taskList.length > 0}
+                  epicList={epicCategoryList}
+                >
+                  {...taskList.map((task) => <TaskBlock {...task} />)}
+                </StoryBlock>
+              </div>
+            );
+          }
+        )}
       </div>
       {showDetail ? (
         <StoryCreateForm

--- a/frontend/src/types/DTO/backlogDTO.ts
+++ b/frontend/src/types/DTO/backlogDTO.ts
@@ -18,6 +18,7 @@ export interface TaskDTO {
   status: BacklogStatusType;
   assignedMemberId: number | null;
   storyId: number;
+  rankValue: string;
 }
 
 export interface StoryDTO {
@@ -27,12 +28,14 @@ export interface StoryDTO {
   status: BacklogStatusType;
   taskList: TaskDTO[];
   epicId: number;
+  rankValue: string;
 }
 
 export interface EpicCategoryDTO {
   id: number;
   name: string;
   color: EpicColor;
+  rankValue: string;
 }
 
 export interface EpicDTO extends EpicCategoryDTO {

--- a/frontend/src/types/common/backlog.ts
+++ b/frontend/src/types/common/backlog.ts
@@ -28,6 +28,7 @@ export interface StoryForm {
   title: string;
   point: number | undefined;
   status: "시작전";
+  rankValue: string;
 }
 
 export interface TaskForm {
@@ -37,6 +38,7 @@ export interface TaskForm {
   actualTime: number | null | "";
   status: "시작전";
   assignedMemberId: null;
+  rankValue: string;
 }
 
 export enum BacklogSocketDomain {

--- a/frontend/src/utils/changeEpicListToStoryList.ts
+++ b/frontend/src/utils/changeEpicListToStoryList.ts
@@ -3,9 +3,9 @@ import { EpicDTO } from "../types/DTO/backlogDTO";
 
 const changeEpicListToStoryList = (epicList: EpicDTO[]) => {
   const newStoryList: UnfinishedStory[] = [];
-  epicList.forEach(({ id, name, color, storyList }) => {
+  epicList.forEach(({ id, name, color, rankValue, storyList }) => {
     storyList.forEach((story) => {
-      const newStory = { ...story, epic: { id, name, color } };
+      const newStory = { ...story, epic: { id, name, color, rankValue } };
       if (!newStory.taskList) {
         newStory.taskList = [];
       }

--- a/frontend/src/utils/getDragElementIndex.ts
+++ b/frontend/src/utils/getDragElementIndex.ts
@@ -1,0 +1,24 @@
+const getDragElementIndex = (
+  list: HTMLDivElement[],
+  initialIndex: number | undefined,
+  y: number
+) =>
+  list.reduce(
+    (closest, child, index) => {
+      const box = child.getBoundingClientRect();
+      const offset = y - box.top - box.height / 2;
+      console.log(offset);
+
+      if (offset < 0 && offset > closest.offset) {
+        return { offset, index };
+      } else {
+        return closest;
+      }
+    },
+    {
+      offset: Number.NEGATIVE_INFINITY,
+      index: initialIndex,
+    }
+  ).index;
+
+export default getDragElementIndex;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4363,6 +4363,11 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lexorank@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/lexorank/-/lexorank-1.0.5.tgz#6d0a22efd0dc0a32cf2ec128e3cba48ef58c4201"
+  integrity sha512-K1B/Yr/gIU0wm68hk/yB0p/mv6xM3ShD5aci42vOwcjof8slG8Kpo3Q7+1WTv7DaRHKWRgLPqrFDt+4GtuFAtA==
+
 lilconfig@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"


### PR DESCRIPTION
## 🎟️ 태스크

[스토리 우선순위 변경 API 연동](https://plastic-toad-cb0.notion.site/API-015c9c6183d84b00997cbc79b4fa1520?pvs=74)
[드래그 앤 드롭 기능 구현](https://plastic-toad-cb0.notion.site/5f1810e74910420cbb7ef52a831711c3)
[에픽 별 스토리 조회 페이지 구현](https://plastic-toad-cb0.notion.site/2d852abad9ac4fc4a77a388392b8ea16)

## ✅ 작업 내용

- 스토리 드래그 앤 드롭 기능 구현(우선순위 변경 기능)
- 에픽별 백로그 페이지 구현

## 🖊️ 구체적인 작업

### 스토리 드래그 앤 드롭 기능

- 이전 버전에서 드래그 앤 드롭 기능을 구현할 때 라이브러리를 사용했지만 이번에는 직접 구현해보고자 라이브러리 사용 없이 구현해봤습니다. UI 상으로는 잘 동작하지만 아직 모듈화를 하지 않아서 태스크, 에픽 드래그 앤 드롭 기능까지 적용하지는 못했습니다. 좀 더 설계하고 모듈화 하는 것이 필요합니다.
