### PR TITLE
fix: 스토리에서 rankValue가 에픽이 아닌 프로젝트내에서 고유하도록 수정

### DIFF
--- a/backend/src/project/entity/story.entity.ts
+++ b/backend/src/project/entity/story.entity.ts
@@ -18,7 +18,7 @@ export enum StoryStatus {
 }
 
 @Entity()
-@Unique('STORY_UQ_RANK_VALUE_AND_EPIC_ID', ['rankValue', 'epicId'])
+@Unique('STORY_UQ_RANK_VALUE_AND_PROJECT_ID', ['rankValue', 'projectId'])
 export class Story {
   @PrimaryGeneratedColumn('increment', { type: 'int' })
   id: number;

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -198,17 +198,17 @@ export class ProjectRepository {
     } catch (e) {
       if (
         e.code === 'ER_DUP_ENTRY' &&
-        e.sqlMessage.includes('STORY_UQ_RANK_VALUE_AND_EPIC_ID')
+        e.sqlMessage.includes('STORY_UQ_RANK_VALUE_AND_PROJECT_ID')
       )
         throw new Error('DUPLICATED RANK VALUE');
       throw e;
     }
   }
 
-  getNextStoryByRankValue(epicId: number, rankValue: string) {
+  getNextStoryByRankValue(projectId: number, rankValue: string) {
     return this.storyRepository.findOne({
       where: {
-        epicId,
+        projectId,
         rankValue: MoreThan(rankValue),
       },
       order: { rankValue: 'ASC' },
@@ -259,7 +259,7 @@ export class ProjectRepository {
     } catch (e) {
       if (
         e.code === 'ER_DUP_ENTRY' &&
-        e.sqlMessage.includes('STORY_UQ_RANK_VALUE_AND_EPIC_ID')
+        e.sqlMessage.includes('STORY_UQ_RANK_VALUE_AND_PROJECT_ID')
       )
         throw new Error('DUPLICATED RANK VALUE');
       throw e;

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -97,7 +97,7 @@ export class ProjectService {
     return result ? true : false;
   }
 
-  private async getAdjustedEpicRankValue(
+  private async getAdjustedRankValue(
     currentRankValue: string,
     nextRankValue: string | null,
   ): Promise<string> {
@@ -127,7 +127,7 @@ export class ProjectService {
             newEpic.projectId,
             newEpic.rankValue,
           );
-          newEpic.rankValue = await this.getAdjustedEpicRankValue(
+          newEpic.rankValue = await this.getAdjustedRankValue(
             newEpic.rankValue,
             nextEpic?.rankValue,
           );
@@ -173,7 +173,7 @@ export class ProjectService {
             project.id,
             updatedRankValue,
           );
-          updatedRankValue = await this.getAdjustedEpicRankValue(
+          updatedRankValue = await this.getAdjustedRankValue(
             updatedRankValue,
             nextEpic?.rankValue,
           );
@@ -205,10 +205,10 @@ export class ProjectService {
         if (e.message === 'DUPLICATED RANK VALUE') {
           const nextStory =
             await this.projectRepository.getNextStoryByRankValue(
-              newStory.epicId,
+              newStory.projectId,
               newStory.rankValue,
             );
-          newStory.rankValue = await this.getAdjustedEpicRankValue(
+          newStory.rankValue = await this.getAdjustedRankValue(
             newStory.rankValue,
             nextStory?.rankValue,
           );
@@ -239,7 +239,7 @@ export class ProjectService {
       if (!epic) throw new Error('epic id not found');
     }
 
-    const maxRetries = 100;
+    const maxRetries = 10;
     let attempts = 0;
 
     let updatedRankValue = rankValue;
@@ -266,7 +266,7 @@ export class ProjectService {
               updatedRankValue,
             );
 
-          updatedRankValue = await this.getAdjustedEpicRankValue(
+          updatedRankValue = await this.getAdjustedRankValue(
             updatedRankValue,
             nextStory?.rankValue,
           );
@@ -314,7 +314,7 @@ export class ProjectService {
             newTask.storyId,
             newTask.rankValue,
           );
-          newTask.rankValue = await this.getAdjustedEpicRankValue(
+          newTask.rankValue = await this.getAdjustedRankValue(
             newTask.rankValue,
             nextTask?.rankValue,
           );
@@ -347,7 +347,7 @@ export class ProjectService {
       if (!story) throw new Error('story id not found');
     }
 
-    const maxRetries = 100;
+    const maxRetries = 10;
     let attempts = 0;
 
     let updatedRankValue = rankValue;
@@ -375,7 +375,7 @@ export class ProjectService {
             updatedRankValue,
           );
 
-          updatedRankValue = await this.getAdjustedEpicRankValue(
+          updatedRankValue = await this.getAdjustedRankValue(
             updatedRankValue,
             nextTask?.rankValue,
           );

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -294,69 +294,6 @@ describe('WS story', () => {
       socket.close();
     });
 
-    it('should return updated story data when update rankValue within different epic', async () => {
-      const socket = await getMemberJoinedLandingPage();
-      socket.emit('joinBacklog');
-      await initBacklog(socket);
-
-      const name = '회원';
-      const color = 'yellow';
-      const middleRankValue = LexoRank.middle().toString();
-
-      const requestData1: any = {
-        action: 'create',
-        content: { name, color, rankValue: middleRankValue },
-      };
-      socket.emit('epic', requestData1);
-      const epicId1 = await getEpicId(socket);
-
-      const requestData2: any = {
-        action: 'create',
-        content: {
-          name,
-          color,
-          rankValue: LexoRank.parse(middleRankValue).genNext().toString(),
-        },
-      };
-      socket.emit('epic', requestData2);
-      const epicId2 = await getEpicId(socket);
-
-      const title = '타이틀';
-      const point = 2;
-      const status = '시작전';
-      const requestData3 = {
-        action: 'create',
-        content: {
-          title,
-          point,
-          status,
-          epicId: epicId1,
-          rankValue: middleRankValue,
-        },
-      };
-      socket.emit('story', requestData3);
-      const storyId = await getStoryId(socket);
-
-      //변경햘 에픽에서의 첫번째 스토리이기 때문에 middle 메서드를 사용한다.
-      const newRankValue = LexoRank.middle().toString();
-      const requestData4 = {
-        action: 'update',
-        content: { id: storyId, epicId: epicId2, rankValue: newRankValue },
-      };
-      socket.emit('story', requestData4);
-      await new Promise<void>((resolve) => {
-        socket.once('backlog', (data) => {
-          const { content, action, domain } = data;
-          expect(domain).toBe('story');
-          expect(action).toBe('update');
-          expect(content?.id).toBe(storyId);
-          expect(content?.rankValue).toBe(newRankValue);
-          resolve();
-        });
-      });
-      socket.close();
-    });
-
     it('should return updated story data when updating multiple stories simultaneously', async () => {
       const socket = await getMemberJoinedLandingPage();
       socket.emit('joinBacklog');


### PR DESCRIPTION
## 🎟️ 태스크

[우선순위 API  구현](https://plastic-toad-cb0.notion.site/API-b243d8a8a8da4287b821fbb199ad995f?pvs=74)

## ✅ 작업 내용

- 다른 에픽으로의 스토리 rankValue 변경 테스트 삭제
- projectService에서 getAdjustedEpicRankValue함수명을 getAdjustedRankValue으로 변경
- projectService에서 rankValue조정 재시도를 모두 10회로 변경
- 스토리의 rankValue가 프로젝트에서 고유하도록 제약조건 수정