### PR TITLE
fix: 스토리 우선순위 변경 로직 수정

### DIFF
--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -89,7 +89,7 @@ const EpicDropdown = ({
   }, []);
 
   return (
-    <div className="absolute z-10 p-1 bg-white rounded-md w-72 shadow-box">
+    <div className="max-h-[18.7rem] overflow-y-auto absolute z-10 p-1 bg-white rounded-md w-72 shadow-box">
       <div className="flex p-1 border-b-2">
         {selectedEpic && (
           <div className="min-w-[5rem]">
@@ -109,27 +109,28 @@ const EpicDropdown = ({
           ref={inputElementRef}
         />
       </div>
-      <ul className="pt-1">
-        {...epicList.map((epic) => (
-          <li
-            key={epic.id}
-            onClick={() => {
-              handleEpicChange(epic.id);
-            }}
-          >
-            <EpicDropdownOption
-              key={epic.id}
-              epic={epic}
-              onEpicChange={handleEpicChange}
-            />
-          </li>
-        ))}
-      </ul>
-      {value && (
+      {value ? (
         <div className="flex items-center gap-2 p-1">
           <span>생성</span>
           <CategoryChip content={value} bgColor={epicColor} />
         </div>
+      ) : (
+        <ul className="pt-1">
+          {...epicList.map((epic) => (
+            <li
+              key={epic.id}
+              onClick={() => {
+                handleEpicChange(epic.id);
+              }}
+            >
+              <EpicDropdownOption
+                key={epic.id}
+                epic={epic}
+                onEpicChange={handleEpicChange}
+              />
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -1,19 +1,18 @@
-import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import { Socket } from "socket.io-client";
 import { EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 import CategoryChip from "./CategoryChip";
 import useEpicEmitEvent from "../../hooks/pages/backlog/useEpicEmitEvent";
 import { CATEGORY_COLOR } from "../../constants/backlog";
-import getRandomNumber from "../../utils/getRandomNumber";
 import {
-  BacklogCategoryColor,
   BacklogSocketData,
   BacklogSocketDomain,
   BacklogSocketEpicAction,
 } from "../../types/common/backlog";
 import EpicDropdownOption from "./EpicDropdownOption";
 import { LexoRank } from "lexorank";
+import getNewColor from "../../utils/getNewColor";
 
 interface EpicDropdownProps {
   selectedEpic?: EpicCategoryDTO;
@@ -29,13 +28,10 @@ const EpicDropdown = ({
   const { socket }: { socket: Socket } = useOutletContext();
   const { emitEpicCreateEvent } = useEpicEmitEvent(socket);
   const [value, setValue] = useState("");
+  const [epicColor, setEpicColor] = useState(
+    getNewColor(Object.keys(CATEGORY_COLOR))
+  );
   const inputElementRef = useRef<HTMLInputElement | null>(null);
-  const epicColor = useMemo(() => {
-    const colors = Object.keys(CATEGORY_COLOR);
-    return colors[
-      getRandomNumber(0, colors.length - 1)
-    ] as BacklogCategoryColor;
-  }, []);
 
   const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
     const { value } = target;
@@ -60,8 +56,9 @@ const EpicDropdown = ({
             .toString()
         : LexoRank.middle().toString();
 
-      setValue("");
       emitEpicCreateEvent({ name: value, color: epicColor, rankValue });
+      setValue("");
+      setEpicColor(getNewColor(Object.keys(CATEGORY_COLOR)));
     }
   };
 

--- a/frontend/src/components/backlog/EpicDropdown.tsx
+++ b/frontend/src/components/backlog/EpicDropdown.tsx
@@ -86,7 +86,7 @@ const EpicDropdown = ({
   }, []);
 
   return (
-    <div className="max-h-[18.7rem] overflow-y-auto absolute z-10 p-1 bg-white rounded-md w-72 shadow-box">
+    <div className="absolute z-10 p-1 bg-white rounded-md w-72 shadow-box">
       <div className="flex p-1 border-b-2">
         {selectedEpic && (
           <div className="min-w-[5rem]">
@@ -112,7 +112,7 @@ const EpicDropdown = ({
           <CategoryChip content={value} bgColor={epicColor} />
         </div>
       ) : (
-        <ul className="pt-1">
+        <ul className="max-h-[16rem] overflow-y-auto scrollbar-thin pt-1">
           {...epicList.map((epic) => (
             <li
               key={epic.id}

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -22,15 +22,17 @@ const UnfinishedStoryPage = () => {
   const draggingComponentIdRef = useRef<number>();
   const storyList = useMemo(
     () =>
-      changeEpicListToStoryList(backlog.epicList).sort((storyA, storyB) => {
-        if (storyA.rankValue < storyB.rankValue) {
-          return -1;
-        }
-        if (storyA.rankValue > storyB.rankValue) {
-          return 1;
-        }
-        return 0;
-      }),
+      changeEpicListToStoryList(backlog.epicList)
+        .sort((storyA, storyB) => {
+          if (storyA.rankValue < storyB.rankValue) {
+            return -1;
+          }
+          if (storyA.rankValue > storyB.rankValue) {
+            return 1;
+          }
+          return 0;
+        })
+        .filter(({ status }) => status !== "완료"),
     [backlog.epicList]
   );
   const epicCategoryList = useMemo(

--- a/frontend/src/utils/getDragElementIndex.ts
+++ b/frontend/src/utils/getDragElementIndex.ts
@@ -7,7 +7,6 @@ const getDragElementIndex = (
     (closest, child, index) => {
       const box = child.getBoundingClientRect();
       const offset = y - box.top - box.height / 2;
-      console.log(offset);
 
       if (offset < 0 && offset > closest.offset) {
         return { offset, index };

--- a/frontend/src/utils/getNewColor.ts
+++ b/frontend/src/utils/getNewColor.ts
@@ -1,0 +1,7 @@
+import { BacklogCategoryColor } from "../types/common/backlog";
+import getRandomNumber from "./getRandomNumber";
+
+const getNewColor = (colors: string[]) =>
+  colors[getRandomNumber(0, colors.length - 1)] as BacklogCategoryColor;
+
+export default getNewColor;


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 회원은 백로그에서 스토리 우선순위를 변경할 수 있다.](https://plastic-toad-cb0.notion.site/43fe3dccfa494dada7fde3588b7389e5)

## ✅ 작업 내용

- 스토리 우선순위 변경 로직 수정
- 스토리별 페이지에서 완료된 스토리 제거
- 에픽 색상 랜덤 지정 로직 수정
- 에픽 드롭다운 길이 설정

## 🖊️ 구체적인 작업

### 스토리 우선순위 변경 로직 수정

- 이전 로직은 index를 기반으로 우선순위를 변경할 스토리를 식별해서 여러 사람이 동시에 다른 스토리의 우선순위를 변경하면 의도하지 않은 스토리가 변경되는 문제가 발생했습니다. 이를 방지하기 위해 스토리의 아이디를 기반으로 식별하는 로직으로 변경했습니다.

### 에픽 색상 랜덤 지정 로직 수정

- useMemo를 사용해 에픽 색상을 생성하고 있었어서 하나의 에픽을 생성하고 난후 에픽 드롭다운이 닫히지 않으면 계속 똑같은 색상으로 에픽이 생성되었습니다. 이를 상태로 관리하도록 해서 새로운 에픽 생성 시 다시 랜덤한 색상이 배정되도록 했습니다.