### PR TITLE
test: 백엔드 E2E 테스트 시간 단축

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.5.0",
+        "portfinder": "^1.0.32",
         "prettier": "^3.0.0",
         "socket.io-client": "^4.7.5",
         "source-map-support": "^0.5.21",
@@ -3038,6 +3039,15 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -7429,6 +7439,29 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"
+    "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.5.0",
+    "portfinder": "^1.0.32",
     "prettier": "^3.0.0",
     "socket.io-client": "^4.7.5",
     "source-map-support": "^0.5.21",

--- a/backend/test/project/join-project.e2e-spec.ts
+++ b/backend/test/project/join-project.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
   createMember,
   createProject,
   getProjectLinkId,
+  listenAppAndSetPortEnv,
   memberFixture,
   memberFixture2,
   projectPayload,
@@ -14,7 +15,7 @@ describe('Join Project', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
 
   it('should return 201', async () => {

--- a/backend/test/project/ws-backlog-page/ws-epic.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-epic.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { LexoRank } from 'lexorank';
 import { resolve } from 'path';
 import { Socket } from 'socket.io-client';
-import { app, appInit } from 'test/setup';
+import { app, appInit, listenAppAndSetPortEnv } from 'test/setup';
 import {
   getMemberJoinedLandingPage,
   getTwoMemberJoinedLandingPage,
@@ -11,7 +11,7 @@ describe('WS epic', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+	await listenAppAndSetPortEnv(app);
   });
 
   describe('epic create', () => {

--- a/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-init-backlog.e2e-spec.ts
@@ -1,13 +1,13 @@
 import { LexoRank } from 'lexorank';
 import { Socket } from 'socket.io-client';
-import { app, appInit } from 'test/setup';
+import { app, appInit, listenAppAndSetPortEnv } from 'test/setup';
 import { getTwoMemberJoinedLandingPage } from '../ws-common';
 
 describe('WS epic', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
 
   describe('backlog init', () => {

--- a/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-story.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { LexoRank } from 'lexorank';
 import { Socket } from 'socket.io-client';
-import { app, appInit } from 'test/setup';
+import { app, appInit, listenAppAndSetPortEnv } from 'test/setup';
 import {
   getMemberJoinedLandingPage,
   getTwoMemberJoinedLandingPage,
@@ -10,7 +10,7 @@ describe('WS story', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+	await listenAppAndSetPortEnv(app);
   });
 
   describe('story create', () => {

--- a/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
+++ b/backend/test/project/ws-backlog-page/ws-task.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { LexoRank } from 'lexorank';
 import { Socket } from 'socket.io-client';
-import { app, appInit } from 'test/setup';
+import { app, appInit, listenAppAndSetPortEnv } from 'test/setup';
 import {
   getMemberJoinedLandingPage,
   getTwoMemberJoinedLandingPage,
@@ -10,7 +10,7 @@ describe('WS task', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
 
   describe('task create', () => {

--- a/backend/test/project/ws-landing-page/ws-connection.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-connection.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
   createMember,
   createProject,
   githubApiService,
+  listenAppAndSetPortEnv,
   memberFixture,
   memberFixture2,
   projectPayload,
@@ -12,13 +13,14 @@ import {
 import { io } from 'socket.io-client';
 
 describe('WS landing', () => {
-  const serverUrl = 'http://localhost:3000/project';
+  let serverUrl;
   let socket;
 
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
+    serverUrl = `http://localhost:${process.env.PORT}/project`;
   });
 
   afterEach(async () => {

--- a/backend/test/project/ws-landing-page/ws-join-project.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-join-project.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   getProjectLinkId,
   memberFixture2,
   joinProject,
+  listenAppAndSetPortEnv,
 } from 'test/setup';
 import {
   emitJoinLanding,
@@ -23,7 +24,7 @@ describe('WS join project', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
 
   it('should return joined member', async () => {

--- a/backend/test/project/ws-landing-page/ws-link.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-link.e2e-spec.ts
@@ -6,6 +6,7 @@ import {
   createProject,
   getProjectLinkId,
   joinProject,
+  listenAppAndSetPortEnv,
   memberFixture,
   memberFixture2,
   projectPayload,
@@ -23,7 +24,7 @@ describe('WS link', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
   describe('link create', () => {
     it('should return created link data when received create link request', async () => {

--- a/backend/test/project/ws-landing-page/ws-memo.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-memo.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   createProject,
   getProjectLinkId,
   joinProject,
+  listenAppAndSetPortEnv,
   memberFixture,
   memberFixture2,
   projectPayload,
@@ -23,7 +24,7 @@ describe('WS memo', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
   describe('memo create', () => {
     it('should return created memo data when received create memo request', async () => {

--- a/backend/test/project/ws-landing-page/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-project-landing-page.e2e-spec.ts
@@ -8,6 +8,7 @@ import {
   getMemberByAccessToken,
   getProjectLinkId,
   joinProject,
+  listenAppAndSetPortEnv,
   memberFixture,
   memberFixture2,
   projectPayload,
@@ -22,7 +23,7 @@ describe('WS landing', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
 
   it('should return project landing page data', async () => {

--- a/backend/test/project/ws-landing-page/ws-update-member-status.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-update-member-status.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   getProjectLinkId,
   memberFixture2,
   joinProject,
+  listenAppAndSetPortEnv,
 } from 'test/setup';
 import {
   emitJoinLanding,
@@ -24,7 +25,7 @@ describe('WS update member status', () => {
   beforeEach(async () => {
     await app.close();
     await appInit();
-    await app.listen(3000);
+    await listenAppAndSetPortEnv(app);
   });
 
   it('should return updated member status', async () => {


### PR DESCRIPTION
## 🎟️ 태스크

[백엔드 E2E 테스트 시간 단축하기](https://plastic-toad-cb0.notion.site/E2E-6e0c0a9029d54b9ea2ad36a741be68bf?pvs=74)

## ✅ 작업 내용

- 테스트에서 가용한 포트를 직접 찾도록 구현
- E2E 테스트가 병렬적으로 수행될 수 있도록 구현

## 🖊️ 구체적인 작업


### 테스트에서 가용한 포트를 직접 찾도록 구현
- portfinder 라이브러리 추가
- 가용한 포트를 찾아 listen하고, 환경변수로 지정하는 listenAppAndSetPortEnv 메서드 추가
- 테스트에서 사용할 포트를 환경변수로 받도록 변경
### E2E 테스트가 병렬적으로 수행될 수 있도록 구현
- E2E 테스트 속도 54.32% 증가
- 각 테스트가 uuid값으로 임시 테스트 데이터베이스를 생성하고 테스트 완료 후 삭제
- test:e2e명령어 runInBand(순차적 테스트 실행)삭제
## 🤔 고민 및 의논할 거리
- E2E 테스트 시간을 줄이기 위해 테스트케이스마다 서버를 종료했다 다시 실행하는 재실행 로직을 없애는 방법과 병렬적으로 테스트파일을 테스트하는 방법을 고민해 보았습니다.
- 고민의 결론은 아래와 같습니다.
- 테스트케이스 별 서버 재실행 로직은 유지한다.
    - 테스트 케이스 마다 서버를 재실행하지 않아도 현재 테스트에서 문재가 발생하지 않으나, 문제가 발생하지 않은 원인이 특정 구현에 의존한다. 따라서 해당 구현이 바뀌거나 메모리의 저장하는 정보가 늘어났을때 테스트가 실패할 수 있고, 실패할 경우 디버깅이 어려울 가능성이 높다고 생각해 테스트케이스별 서버 재실행 로직을 유지하기로 결정함
- 병렬적으로 테스트 파일을 테스트하려면 세가지 조건을 만족해야한다.
    - 테스트들이 서버를 공유하면 안된다.
        - 기본적인 세팅이 서버를 공유하지 않는것으로 확인됨
    - 테스트들이 서로 다른 포트를 사용해야한다.
        - 유효한 포트를 찾아주는 라이브러리를 사용하고, 이를 공통 테스트 셋업에 적용해 해결
    - 테스트들이 DB를 공유하면 안된다.
        - 공통 테스트 셋업에서 각 테스트가 사용할 DB의 이름을 uuid로 생성하고 환경변수로 셋팅해 해결
- 병렬적으로 테스트 파일을 테스트하는 것을 성공
- 최종적으로 E2E테스트 실행 시간을 로컬환경기준으로 23.36초에서 10.67초로 약 55% 빠르게 테스트할 수 있습니다.

## 📸 결과 화면(선택)
![image](https://github.com/user-attachments/assets/d3b5f2fb-a616-40ad-a007-fe020915c11c)
