### PR TITLE
feaT: 태스크 드래그 앤 드롭 기능 구현

### DIFF
--- a/frontend/src/components/backlog/DragContainer.tsx
+++ b/frontend/src/components/backlog/DragContainer.tsx
@@ -1,0 +1,36 @@
+import React, { DragEvent } from "react";
+
+interface DragContainerProps {
+  index: number;
+  setRef: (index: number) => (element: HTMLDivElement) => void;
+  onDragStart: () => void;
+  onDragEnd: (event: DragEvent) => void;
+  currentlyDraggedOver: boolean;
+  children: React.ReactNode;
+}
+
+const DragContainer = ({
+  index,
+  setRef,
+  onDragStart,
+  onDragEnd,
+  currentlyDraggedOver,
+  children,
+}: DragContainerProps) => (
+  <div
+    className="relative"
+    ref={setRef(index)}
+    draggable={true}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+  >
+    <div
+      className={`${
+        currentlyDraggedOver ? "w-full h-1 bg-blue-400" : ""
+      } absolute`}
+    />
+    {children}
+  </div>
+);
+
+export default DragContainer;

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -1,29 +1,21 @@
+import { MouseEvent } from "react";
 import { Socket } from "socket.io-client";
 import { useOutletContext } from "react-router-dom";
-import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
-import {
-  BacklogStatusType,
-  EpicCategoryDTO,
-  TaskDTO,
-} from "../../types/DTO/backlogDTO";
+import EpicDropdown from "./EpicDropdown";
 import BacklogStatusChip from "./BacklogStatusChip";
 import CategoryChip from "./CategoryChip";
-import ChevronDown from "../../assets/icons/chevron-down.svg?react";
-import ChevronRight from "../../assets/icons/chevron-right.svg?react";
-import TaskContainer from "./TaskContainer";
-import TaskHeader from "./TaskHeader";
 import BacklogStatusDropdown from "./BacklogStatusDropdown";
-import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
-import useBacklogInputChange from "../../hooks/pages/backlog/useBacklogInputChange";
-import { MouseEvent } from "react";
-import { MOUSE_KEY } from "../../constants/event";
-import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
-import TrashCan from "../../assets/icons/trash-can.svg?react";
-import { useModal } from "../../hooks/common/modal/useModal";
 import ConfirmModal from "../common/ConfirmModal";
-import EpicDropdown from "./EpicDropdown";
-import TaskCreateBlock from "./TaskCreateBlock";
-import TaskBlock from "./TaskBlock";
+import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
+import useBacklogInputChange from "../../hooks/pages/backlog/useBacklogInputChange";
+import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
+import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
+import { useModal } from "../../hooks/common/modal/useModal";
+import ChevronRight from "../../assets/icons/chevron-right.svg?react";
+import ChevronDown from "../../assets/icons/chevron-down.svg?react";
+import TrashCan from "../../assets/icons/trash-can.svg?react";
+import { MOUSE_KEY } from "../../constants/event";
+import { BacklogStatusType, EpicCategoryDTO } from "../../types/DTO/backlogDTO";
 
 interface StoryBlockProps {
   id: number;
@@ -34,9 +26,6 @@ interface StoryBlockProps {
   status: BacklogStatusType;
   taskExist: boolean;
   epicList?: EpicCategoryDTO[];
-  finished?: boolean;
-  lastTaskRankValue?: string;
-  taskList: TaskDTO[];
 }
 
 const StoryBlock = ({
@@ -48,9 +37,6 @@ const StoryBlock = ({
   status,
   taskExist,
   epicList,
-  finished = false,
-  lastTaskRankValue,
-  taskList,
 }: StoryBlockProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
   const { showDetail, handleShowDetail } = useShowDetail();
@@ -284,15 +270,6 @@ const StoryBlock = ({
             <span>삭제</span>
           </button>
         </div>
-      )}
-      {showDetail && (
-        <TaskContainer>
-          <TaskHeader />
-          {...taskList.map((task) => <TaskBlock {...task} />)}
-          {!finished && (
-            <TaskCreateBlock storyId={id} {...{ lastTaskRankValue }} />
-          )}
-        </TaskContainer>
       )}
     </>
   );

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -1,7 +1,11 @@
 import { Socket } from "socket.io-client";
 import { useOutletContext } from "react-router-dom";
 import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
-import { BacklogStatusType, EpicCategoryDTO } from "../../types/DTO/backlogDTO";
+import {
+  BacklogStatusType,
+  EpicCategoryDTO,
+  TaskDTO,
+} from "../../types/DTO/backlogDTO";
 import BacklogStatusChip from "./BacklogStatusChip";
 import CategoryChip from "./CategoryChip";
 import ChevronDown from "../../assets/icons/chevron-down.svg?react";
@@ -19,6 +23,7 @@ import { useModal } from "../../hooks/common/modal/useModal";
 import ConfirmModal from "../common/ConfirmModal";
 import EpicDropdown from "./EpicDropdown";
 import TaskCreateBlock from "./TaskCreateBlock";
+import TaskBlock from "./TaskBlock";
 
 interface StoryBlockProps {
   id: number;
@@ -27,11 +32,11 @@ interface StoryBlockProps {
   point: number | null;
   progress: number;
   status: BacklogStatusType;
-  children: React.ReactNode;
   taskExist: boolean;
   epicList?: EpicCategoryDTO[];
   finished?: boolean;
   lastTaskRankValue?: string;
+  taskList: TaskDTO[];
 }
 
 const StoryBlock = ({
@@ -45,7 +50,7 @@ const StoryBlock = ({
   epicList,
   finished = false,
   lastTaskRankValue,
-  children,
+  taskList,
 }: StoryBlockProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
   const { showDetail, handleShowDetail } = useShowDetail();
@@ -283,7 +288,7 @@ const StoryBlock = ({
       {showDetail && (
         <TaskContainer>
           <TaskHeader />
-          {children}
+          {...taskList.map((task) => <TaskBlock {...task} />)}
           {!finished && (
             <TaskCreateBlock storyId={id} {...{ lastTaskRankValue }} />
           )}

--- a/frontend/src/components/backlog/StoryDragContainer.tsx
+++ b/frontend/src/components/backlog/StoryDragContainer.tsx
@@ -1,0 +1,36 @@
+import React, { DragEvent } from "react";
+
+interface StoryDragContainerProps {
+  index: number;
+  setRef: (index: number) => (element: HTMLDivElement) => void;
+  onDragStart: () => void;
+  onDragEnd: (event: DragEvent) => void;
+  currentlyDraggedOver: boolean;
+  children: React.ReactNode;
+}
+
+const StoryDragContainer = ({
+  index,
+  setRef,
+  onDragStart,
+  onDragEnd,
+  currentlyDraggedOver,
+  children,
+}: StoryDragContainerProps) => (
+  <div
+    className="relative"
+    ref={setRef(index)}
+    draggable={true}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+  >
+    <div
+      className={`${
+        currentlyDraggedOver ? "w-full h-1 bg-blue-400" : ""
+      } absolute`}
+    />
+    {children}
+  </div>
+);
+
+export default StoryDragContainer;

--- a/frontend/src/components/backlog/TaskDragContainer.tsx
+++ b/frontend/src/components/backlog/TaskDragContainer.tsx
@@ -1,25 +1,30 @@
-import React, { DragEvent } from "react";
+import { DragEvent } from "react";
 
-interface DragContainerProps {
-  index: number;
-  setRef: (index: number) => (element: HTMLDivElement) => void;
+interface TaskDragContainerProps {
+  storyIndex: number;
+  taskIndex: number;
+  setRef: (
+    storyIndex: number,
+    taskIndex: number
+  ) => (element: HTMLDivElement) => void;
   onDragStart: () => void;
   onDragEnd: (event: DragEvent) => void;
   currentlyDraggedOver: boolean;
   children: React.ReactNode;
 }
 
-const DragContainer = ({
-  index,
+const TaskDragContainer = ({
+  storyIndex,
+  taskIndex,
   setRef,
   onDragStart,
   onDragEnd,
   currentlyDraggedOver,
   children,
-}: DragContainerProps) => (
+}: TaskDragContainerProps) => (
   <div
     className="relative"
-    ref={setRef(index)}
+    ref={setRef(storyIndex, taskIndex)}
     draggable={true}
     onDragStart={onDragStart}
     onDragEnd={onDragEnd}
@@ -33,4 +38,4 @@ const DragContainer = ({
   </div>
 );
 
-export default DragContainer;
+export default TaskDragContainer;

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -27,7 +27,7 @@ const EpicPage = () => {
       {...backlog.epicList.map(
         ({ id: epicId, name, color, rankValue, storyList }) => (
           <EpicBlock
-            storyExist={storyList.length > 1}
+            storyExist={storyList.length > 0}
             epic={{ id: epicId, name, color, rankValue }}
           >
             {...storyList.map(({ id, title, point, status, taskList }) => {

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -40,19 +40,15 @@ const EpicPage = () => {
                 : 0;
 
               return (
-                <StoryBlock
-                  {...{ id, title, point, status }}
-                  epic={{ id: epicId, name, color, rankValue }}
-                  progress={progress}
-                  taskExist={taskList.length > 0}
-                  lastTaskRankValue={
-                    taskList.length
-                      ? taskList[taskList.length - 1].rankValue
-                      : undefined
-                  }
-                >
+                <>
+                  <StoryBlock
+                    {...{ id, title, point, status }}
+                    epic={{ id: epicId, name, color, rankValue }}
+                    progress={progress}
+                    taskExist={taskList.length > 0}
+                  />
                   {...taskList.map((task) => <TaskBlock {...task} />)}
-                </StoryBlock>
+                </>
               );
             })}
             {showDetail ? (

--- a/frontend/src/pages/backlog/FinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/FinishedStoryPage.tsx
@@ -38,16 +38,16 @@ const FinishedStoryPage = () => {
             : 0;
 
           return (
-            <StoryBlock
-              {...{ id, title, point, status }}
-              epic={epic}
-              progress={progress}
-              taskExist={taskList.length > 0}
-              epicList={epicCategoryList}
-              finished={true}
-            >
+            <>
+              <StoryBlock
+                {...{ id, title, point, status }}
+                epic={epic}
+                progress={progress}
+                taskExist={taskList.length > 0}
+                epicList={epicCategoryList}
+              />
               {...taskList.map((task) => <TaskBlock {...task} />)}
-            </StoryBlock>
+            </>
           );
         })}
       </div>

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -1,17 +1,17 @@
+import { DragEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import { Socket } from "socket.io-client";
 import { LexoRank } from "lexorank";
-import { BacklogDTO } from "../../types/DTO/backlogDTO";
 import StoryCreateButton from "../../components/backlog/StoryCreateButton";
 import StoryCreateForm from "../../components/backlog/StoryCreateForm";
-import { DragEvent, useEffect, useMemo, useRef, useState } from "react";
-import changeEpicListToStoryList from "../../utils/changeEpicListToStoryList";
 import StoryBlock from "../../components/backlog/StoryBlock";
-import TaskBlock from "../../components/backlog/TaskBlock";
 import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
+import changeEpicListToStoryList from "../../utils/changeEpicListToStoryList";
 import getDragElementIndex from "../../utils/getDragElementIndex";
 import { BacklogSocketData } from "../../types/common/backlog";
+import { BacklogDTO } from "../../types/DTO/backlogDTO";
+import DragContainer from "../../components/backlog/DragContainer";
 
 const UnfinishedStoryPage = () => {
   const { socket, backlog }: { socket: Socket; backlog: BacklogDTO } =
@@ -140,22 +140,15 @@ const UnfinishedStoryPage = () => {
               : 0;
 
             return (
-              <div
-                className="relative"
-                ref={setStoryComponentRef(index)}
-                draggable={true}
+              <DragContainer
+                index={index}
+                setRef={setStoryComponentRef}
                 onDragStart={() => handleDragStart(id)}
                 onDragEnd={handleDragEnd}
+                currentlyDraggedOver={index === storyElementIndex}
               >
-                <div
-                  className={`${
-                    index === storyElementIndex ? "w-full h-1 bg-blue-400" : ""
-                  } absolute`}
-                />
                 <StoryBlock
-                  {...{ id, title, point, status }}
-                  epic={epic}
-                  progress={progress}
+                  {...{ id, title, point, status, epic, progress, taskList }}
                   taskExist={taskList.length > 0}
                   epicList={epicCategoryList}
                   lastTaskRankValue={
@@ -163,10 +156,8 @@ const UnfinishedStoryPage = () => {
                       ? taskList[taskList.length - 1].rankValue
                       : undefined
                   }
-                >
-                  {...taskList.map((task) => <TaskBlock {...task} />)}
-                </StoryBlock>
-              </div>
+                />
+              </DragContainer>
             );
           }
         )}

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -294,7 +294,7 @@ const UnfinishedStoryPage = () => {
                     className={`${
                       id === taskElementIndex.storyId &&
                       taskElementIndex.taskIndex === taskList.length
-                        ? "w-[67.9rem] h-1 bg-blue-400"
+                        ? "w-[60.13rem] h-1 bg-blue-400"
                         : ""
                     } absolute`}
                   />


### PR DESCRIPTION
## 🎟️ 태스크

[드래그 앤 드롭 기능 구현](https://plastic-toad-cb0.notion.site/5f1810e74910420cbb7ef52a831711c3)
[태스크 우선순위 변경 API 연동](https://plastic-toad-cb0.notion.site/API-e34b275feccc4e368dd9a63995f43572)

## ✅ 작업 내용

- 태스크 드래그 앤 드롭 로직 작성
- 태스크 우선순위 변경 API 연동

## 🖊️ 구체적인 작업

### 태스크 드래그 앤 드롭 기능

- 태스크의 우선순위를 변경할 수도 있으며, 드래그 앤 드롭으로 해당 태스크의 스토리도 변경되도록 했습니다.
- 현재 한 페이지에 스토리 우선순위 변경, 태스크 우선순위 변경 로직이 모두 들어가 있어서 코드 분리가 필요합니다.

## 📸 결과 화면
![녹화_2024_08_13_23_44_18_706](https://github.com/user-attachments/assets/bb840953-3a81-47e1-9fff-c0b1e94ca9a8)
