### PR TITLE
feat: 에픽별 페이지 드래그 앤 드롭 기능 구현

### DIFF
--- a/frontend/src/components/backlog/EpicBlock.tsx
+++ b/frontend/src/components/backlog/EpicBlock.tsx
@@ -1,4 +1,3 @@
-import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import ChevronDown from "../../assets/icons/chevron-down.svg?react";
 import ChevronRight from "../../assets/icons/chevron-right.svg?react";
 import CategoryChip from "./CategoryChip";
@@ -9,11 +8,16 @@ import EpicDropdown from "./EpicDropdown";
 interface EpicBlockProps {
   storyExist: boolean;
   epic: EpicCategoryDTO;
-  children: React.ReactNode;
+  showStoryList: boolean;
+  onShowStoryList: () => void;
 }
 
-const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
-  const { showDetail, handleShowDetail } = useShowDetail();
+const EpicBlock = ({
+  storyExist,
+  epic,
+  showStoryList,
+  onShowStoryList,
+}: EpicBlockProps) => {
   const {
     open: epicUpdating,
     handleOpen: handleEpicUpdateOpen,
@@ -28,16 +32,16 @@ const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
 
   return (
     <>
-      <div className="flex items-center justify-start py-1 border-t border-b text-s">
+      <div className="flex items-center justify-start pb-1 text-s">
         <button
           className="flex items-center justify-center w-5 h-5 rounded-md hover:bg-dark-gray hover:bg-opacity-20"
           type="button"
           onClick={(event) => {
             event.stopPropagation();
-            handleShowDetail(!showDetail);
+            onShowStoryList();
           }}
         >
-          {showDetail ? (
+          {showStoryList ? (
             <ChevronDown
               width={16}
               height={16}
@@ -66,7 +70,6 @@ const EpicBlock = ({ storyExist, epic, children }: EpicBlockProps) => {
           )}
         </div>
       </div>
-      {showDetail && <div className="w-[65rem] ml-auto">{children}</div>}
     </>
   );
 };

--- a/frontend/src/components/backlog/EpicDragContainer.tsx
+++ b/frontend/src/components/backlog/EpicDragContainer.tsx
@@ -1,0 +1,36 @@
+import React, { DragEvent } from "react";
+
+interface EpicDragContainerProps {
+  epicIndex: number;
+  setRef: (epicIndex: number) => (element: HTMLDivElement) => void;
+  onDragStart: () => void;
+  onDragEnd: (event: DragEvent) => void;
+  currentlyDraggedOver: boolean;
+  children: React.ReactNode;
+}
+
+const EpicDragContainer = ({
+  epicIndex,
+  setRef,
+  onDragStart,
+  onDragEnd,
+  currentlyDraggedOver,
+  children,
+}: EpicDragContainerProps) => (
+  <div
+    className="relative"
+    ref={setRef(epicIndex)}
+    draggable={true}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+  >
+    <div
+      className={`${
+        currentlyDraggedOver ? "w-full h-1 bg-blue-400" : ""
+      } absolute`}
+    />
+    {children}
+  </div>
+);
+
+export default EpicDragContainer;

--- a/frontend/src/components/backlog/EpicPageStoryDragContainer.tsx
+++ b/frontend/src/components/backlog/EpicPageStoryDragContainer.tsx
@@ -1,0 +1,41 @@
+import React, { DragEvent } from "react";
+
+interface EpicPageStoryDragContainerProps {
+  epicIndex: number;
+  storyIndex: number;
+  setRef: (
+    epicIndex: number,
+    storyIndex: number
+  ) => (element: HTMLDivElement) => void;
+  onDragStart: () => void;
+  onDragEnd: (event: DragEvent) => void;
+  currentlyDraggedOver: boolean;
+  children: React.ReactNode;
+}
+
+const EpicPageStoryDragContainer = ({
+  epicIndex,
+  storyIndex,
+  setRef,
+  onDragStart,
+  onDragEnd,
+  currentlyDraggedOver,
+  children,
+}: EpicPageStoryDragContainerProps) => (
+  <div
+    className="relative"
+    ref={setRef(epicIndex, storyIndex)}
+    draggable={true}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+  >
+    <div
+      className={`${
+        currentlyDraggedOver ? "w-full h-1 bg-blue-400" : ""
+      } absolute`}
+    />
+    {children}
+  </div>
+);
+
+export default EpicPageStoryDragContainer;

--- a/frontend/src/components/backlog/EpicPageTaskDragContainer.tsx
+++ b/frontend/src/components/backlog/EpicPageTaskDragContainer.tsx
@@ -1,0 +1,44 @@
+import { DragEvent } from "react";
+
+interface EpicPageTaskDragContainerProps {
+  epicIndex: number;
+  storyIndex: number;
+  taskIndex: number;
+  setRef: (
+    epicIndex: number,
+    storyIndex: number,
+    taskIndex: number
+  ) => (element: HTMLDivElement) => void;
+  onDragStart: () => void;
+  onDragEnd: (event: DragEvent) => void;
+  currentlyDraggedOver: boolean;
+  children: React.ReactNode;
+}
+
+const EpicPageTaskDragContainer = ({
+  epicIndex,
+  storyIndex,
+  taskIndex,
+  setRef,
+  onDragStart,
+  onDragEnd,
+  currentlyDraggedOver,
+  children,
+}: EpicPageTaskDragContainerProps) => (
+  <div
+    className="relative"
+    ref={setRef(epicIndex, storyIndex, taskIndex)}
+    draggable={true}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+  >
+    <div
+      className={`${
+        currentlyDraggedOver ? "w-full h-1 bg-blue-400" : ""
+      } absolute`}
+    />
+    {children}
+  </div>
+);
+
+export default EpicPageTaskDragContainer;

--- a/frontend/src/components/backlog/StoryBlock.tsx
+++ b/frontend/src/components/backlog/StoryBlock.tsx
@@ -6,7 +6,6 @@ import BacklogStatusChip from "./BacklogStatusChip";
 import CategoryChip from "./CategoryChip";
 import BacklogStatusDropdown from "./BacklogStatusDropdown";
 import ConfirmModal from "../common/ConfirmModal";
-import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import useBacklogInputChange from "../../hooks/pages/backlog/useBacklogInputChange";
 import useStoryEmitEvent from "../../hooks/pages/backlog/useStoryEmitEvent";
 import useDropdownState from "../../hooks/common/dropdown/useDropdownState";
@@ -26,6 +25,8 @@ interface StoryBlockProps {
   status: BacklogStatusType;
   taskExist: boolean;
   epicList?: EpicCategoryDTO[];
+  showTaskList: boolean;
+  onShowTaskList: () => void;
 }
 
 const StoryBlock = ({
@@ -37,9 +38,10 @@ const StoryBlock = ({
   status,
   taskExist,
   epicList,
+  showTaskList,
+  onShowTaskList,
 }: StoryBlockProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
-  const { showDetail, handleShowDetail } = useShowDetail();
   const {
     updating: titleUpdating,
     handleUpdating: handleTitleUpdatingOpen,
@@ -191,10 +193,10 @@ const StoryBlock = ({
             type="button"
             onClick={(event) => {
               event.stopPropagation();
-              handleShowDetail(!showDetail);
+              onShowTaskList();
             }}
           >
-            {showDetail ? (
+            {showTaskList ? (
               <ChevronDown
                 width={16}
                 height={16}

--- a/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
+++ b/frontend/src/hooks/pages/backlog/useBacklogSocket.ts
@@ -96,7 +96,7 @@ const useBacklogSocket = (socket: Socket) => {
             const newEpicList = prevBacklog.epicList.map((epic) => {
               const newStoryList = epic.storyList.filter((story) => {
                 if (story.id === content.id) {
-                  targetStory = { ...story, epicId: content.epicId };
+                  targetStory = { ...story, ...content };
                 }
                 return story.id !== content.id;
               });

--- a/frontend/src/hooks/pages/backlog/useEpicEmitEvent.ts
+++ b/frontend/src/hooks/pages/backlog/useEpicEmitEvent.ts
@@ -18,6 +18,7 @@ const useEpicEmitEvent = (socket: Socket) => {
     id: number;
     name?: string;
     color?: BacklogCategoryColor;
+    rankValue?: string;
   }) => {
     socket.emit("epic", { action: "update", content });
   };

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -67,7 +67,6 @@ const EpicPage = () => {
             });
             return { ...story, taskList: newTaskList };
           });
-          console.log(newStoryList);
           newStoryList.sort((storyA, storyB) => {
             if (storyA.rankValue < storyB.rankValue) {
               return -1;
@@ -316,7 +315,6 @@ const EpicPage = () => {
         storyList[storyIndex as number].rankValue
       );
       rankValue = prevStoryRank.between(nextStoryRank).toString();
-      console.log("중간", rankValue);
     }
 
     emitStoryUpdateEvent({

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -67,6 +67,7 @@ const EpicPage = () => {
             });
             return { ...story, taskList: newTaskList };
           });
+          console.log(newStoryList);
           newStoryList.sort((storyA, storyB) => {
             if (storyA.rankValue < storyB.rankValue) {
               return -1;
@@ -302,19 +303,20 @@ const EpicPage = () => {
     if (storyIndex === 0 && !storyList.length) {
       rankValue = LexoRank.middle().toString();
     } else if (storyIndex === 0) {
-      const firstTaskRank = storyList[0].rankValue;
-      rankValue = LexoRank.parse(firstTaskRank).genPrev().toString();
+      const firstStoryRank = storyList[0].rankValue;
+      rankValue = LexoRank.parse(firstStoryRank).genPrev().toString();
     } else if (storyIndex === storyList.length) {
-      const lastTaskRank = storyList[storyList.length - 1].rankValue;
-      rankValue = LexoRank.parse(lastTaskRank).genNext().toString();
+      const lastStoryRank = storyList[storyList.length - 1].rankValue;
+      rankValue = LexoRank.parse(lastStoryRank).genNext().toString();
     } else {
-      const prevTaskRank = LexoRank.parse(
+      const prevStoryRank = LexoRank.parse(
         storyList[(storyIndex as number) - 1].rankValue
       );
-      const nextTaskRank = LexoRank.parse(
+      const nextStoryRank = LexoRank.parse(
         storyList[storyIndex as number].rankValue
       );
-      rankValue = prevTaskRank.between(nextTaskRank).toString();
+      rankValue = prevStoryRank.between(nextStoryRank).toString();
+      console.log("중간", rankValue);
     }
 
     emitStoryUpdateEvent({

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -184,16 +184,18 @@ const EpicPage = () => {
     };
 
   const handleEpicDragOver = (event: DragEvent) => {
+    event.preventDefault();
+
     if (draggingStoryId || draggingTaskId) {
       return;
     }
-    event.preventDefault();
 
     const index = getDragElementIndex(
       epicComponentRefList.current,
       epicList.findIndex(({ id }) => id === draggingEpicId),
       event.clientY
     );
+    console.log(epicComponentRefList.current, index);
 
     setEpicElementIndex(index);
   };
@@ -439,17 +441,14 @@ const EpicPage = () => {
   };
 
   return (
-    <div className="relative flex flex-col gap-4 pb-10">
+    <div className="gap-4 pb-10" onDragOver={handleEpicDragOver}>
       {...epicList.map(
         ({ id: epicId, name, color, rankValue, storyList }, epicIndex) => {
           storyComponentRefList.current[epicIndex] = [];
           taskComponentRefList.current[epicIndex] = [];
 
           return (
-            <div
-              className="py-2 border-t border-b"
-              onDragOver={handleEpicDragOver}
-            >
+            <div className="py-2 border-t border-b">
               <EpicDragContainer
                 {...{ epicIndex }}
                 onDragStart={() => handleEpicDragStart(epicId)}

--- a/frontend/src/pages/backlog/EpicPage.tsx
+++ b/frontend/src/pages/backlog/EpicPage.tsx
@@ -1,16 +1,25 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import { BacklogDTO } from "../../types/DTO/backlogDTO";
 import StoryCreateButton from "../../components/backlog/StoryCreateButton";
 import StoryCreateForm from "../../components/backlog/StoryCreateForm";
 import StoryBlock from "../../components/backlog/StoryBlock";
 import TaskBlock from "../../components/backlog/TaskBlock";
-import useShowDetail from "../../hooks/pages/backlog/useShowDetail";
 import EpicBlock from "../../components/backlog/EpicBlock";
+import TaskContainer from "../../components/backlog/TaskContainer";
+import TaskHeader from "../../components/backlog/TaskHeader";
 
 const EpicPage = () => {
   const { backlog }: { backlog: BacklogDTO } = useOutletContext();
-  const { showDetail, handleShowDetail } = useShowDetail();
+  const [showTaskList, setShowTaskList] = useState(
+    backlog.epicList.map(({ storyList }) => storyList.map(() => false))
+  );
+  const [showStory, setShowStory] = useState(
+    Array.from(new Array(backlog.epicList.length), () => ({
+      showStoryList: false,
+      showStoryForm: false,
+    }))
+  );
   const epicCategoryList = useMemo(
     () =>
       backlog.epicList.map(({ id, name, color, rankValue }) => ({
@@ -22,50 +31,105 @@ const EpicPage = () => {
     [backlog.epicList]
   );
 
-  return (
-    <div className="flex flex-col gap-4">
-      {...backlog.epicList.map(
-        ({ id: epicId, name, color, rankValue, storyList }) => (
-          <EpicBlock
-            storyExist={storyList.length > 0}
-            epic={{ id: epicId, name, color, rankValue }}
-          >
-            {...storyList.map(({ id, title, point, status, taskList }) => {
-              const progress = taskList.length
-                ? Math.round(
-                    (taskList.filter(({ status }) => status === "완료").length /
-                      taskList.length) *
-                      100
-                  )
-                : 0;
+  const handleShowTaskList = (epicIndex: number, storyIndex: number) => {
+    const newShowTaskList = showTaskList.map((innerArray1) => [...innerArray1]);
+    newShowTaskList[epicIndex][storyIndex] =
+      !newShowTaskList[epicIndex][storyIndex];
 
-              return (
-                <>
-                  <StoryBlock
-                    {...{ id, title, point, status }}
+    setShowTaskList(newShowTaskList);
+  };
+
+  const handleShowStoryList = (epicIndex: number) => {
+    const newShowStory = [...showStory];
+    const currentShowStory = newShowStory[epicIndex];
+
+    if (currentShowStory.showStoryList) {
+      newShowStory[epicIndex] = { showStoryList: false, showStoryForm: false };
+    } else {
+      newShowStory[epicIndex] = {
+        ...newShowStory[epicIndex],
+        showStoryList: true,
+      };
+    }
+
+    setShowStory(newShowStory);
+  };
+
+  const handleShowStoryForm = (epicIndex: number) => {
+    const newShowStory = [...showStory];
+    newShowStory[epicIndex] = {
+      ...newShowStory[epicIndex],
+      showStoryForm: !newShowStory[epicIndex].showStoryForm,
+    };
+
+    setShowStory(newShowStory);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 pb-3">
+      {...backlog.epicList.map(
+        ({ id: epicId, name, color, rankValue, storyList }, epicIndex) => (
+          <div className="py-2 border-t border-b">
+            <EpicBlock
+              storyExist={storyList.length > 0}
+              epic={{ id: epicId, name, color, rankValue }}
+              showStoryList={showStory[epicIndex].showStoryList}
+              onShowStoryList={() => handleShowStoryList(epicIndex)}
+            />
+            {showStory[epicIndex].showStoryList && (
+              <div className="w-[65rem] ml-auto">
+                {...storyList.map(
+                  ({ id, title, point, status, taskList }, storyIndex) => {
+                    const progress = taskList.length
+                      ? Math.round(
+                          (taskList.filter(({ status }) => status === "완료")
+                            .length /
+                            taskList.length) *
+                            100
+                        )
+                      : 0;
+
+                    return (
+                      <>
+                        <StoryBlock
+                          {...{ id, title, point, status }}
+                          epic={{ id: epicId, name, color, rankValue }}
+                          progress={progress}
+                          taskExist={taskList.length > 0}
+                          showTaskList={showTaskList[epicIndex][storyIndex]}
+                          onShowTaskList={() =>
+                            handleShowTaskList(epicIndex, storyIndex)
+                          }
+                        />
+                        {showTaskList[epicIndex][storyIndex] && (
+                          <TaskContainer>
+                            <TaskHeader />
+                            {...taskList.map((task) => <TaskBlock {...task} />)}
+                          </TaskContainer>
+                        )}
+                      </>
+                    );
+                  }
+                )}
+                {showStory[epicIndex].showStoryForm ? (
+                  <StoryCreateForm
+                    epicList={epicCategoryList}
                     epic={{ id: epicId, name, color, rankValue }}
-                    progress={progress}
-                    taskExist={taskList.length > 0}
+                    onCloseClick={() => handleShowStoryForm(epicIndex)}
+                    lastStoryRankValue={
+                      storyList.length
+                        ? storyList[storyList.length - 1].rankValue
+                        : undefined
+                    }
                   />
-                  {...taskList.map((task) => <TaskBlock {...task} />)}
-                </>
-              );
-            })}
-            {showDetail ? (
-              <StoryCreateForm
-                epicList={epicCategoryList}
-                epic={{ id: epicId, name, color, rankValue }}
-                onCloseClick={() => handleShowDetail(false)}
-                lastStoryRankValue={
-                  storyList.length
-                    ? storyList[storyList.length - 1].rankValue
-                    : undefined
-                }
-              />
-            ) : (
-              <StoryCreateButton onClick={() => handleShowDetail(true)} />
+                ) : (
+                  <StoryCreateButton
+                    onClick={() => handleShowStoryForm(epicIndex)}
+                  />
+                )}
+              </div>
             )}
-          </EpicBlock>
+          </div>
         )
       )}
     </div>

--- a/frontend/src/pages/backlog/FinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/FinishedStoryPage.tsx
@@ -27,50 +27,48 @@ const FinishedStoryPage = () => {
     [backlog.epicList]
   );
 
-  const [showTaskList, setShowTaskList] = useState(
-    new Array(storyList.length).fill(false)
+  const [showTaskList, setShowTaskList] = useState<{ [key: number]: boolean }>(
+    {}
   );
 
-  const handleShowTaskList = (index: number) => {
-    const newShowTaskList = [...showTaskList];
-    newShowTaskList[index] = !newShowTaskList[index];
+  const handleShowTaskList = (id: number) => {
+    const newShowTaskList = { ...showTaskList };
+    newShowTaskList[id] = !newShowTaskList[id];
     setShowTaskList(newShowTaskList);
   };
 
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="w-full border-b">
-        {...storyList.map(
-          ({ id, epic, title, point, status, taskList }, index) => {
-            const progress = taskList.length
-              ? Math.round(
-                  (taskList.filter(({ status }) => status === "완료").length /
-                    taskList.length) *
-                    100
-                )
-              : 0;
+        {...storyList.map(({ id, epic, title, point, status, taskList }) => {
+          const progress = taskList.length
+            ? Math.round(
+                (taskList.filter(({ status }) => status === "완료").length /
+                  taskList.length) *
+                  100
+              )
+            : 0;
 
-            return (
-              <>
-                <StoryBlock
-                  {...{ id, title, point, status }}
-                  epic={epic}
-                  progress={progress}
-                  taskExist={taskList.length > 0}
-                  epicList={epicCategoryList}
-                  showTaskList={showTaskList[index]}
-                  onShowTaskList={() => handleShowTaskList(index)}
-                />
-                {showTaskList[index] && (
-                  <TaskContainer>
-                    <TaskHeader />
-                    {...taskList.map((task) => <TaskBlock {...task} />)}
-                  </TaskContainer>
-                )}
-              </>
-            );
-          }
-        )}
+          return (
+            <>
+              <StoryBlock
+                {...{ id, title, point, status }}
+                epic={epic}
+                progress={progress}
+                taskExist={taskList.length > 0}
+                epicList={epicCategoryList}
+                showTaskList={showTaskList[id]}
+                onShowTaskList={() => handleShowTaskList(id)}
+              />
+              {showTaskList[id] && (
+                <TaskContainer>
+                  <TaskHeader />
+                  {...taskList.map((task) => <TaskBlock {...task} />)}
+                </TaskContainer>
+              )}
+            </>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/pages/backlog/FinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/FinishedStoryPage.tsx
@@ -1,9 +1,11 @@
 import { useOutletContext } from "react-router-dom";
 import { BacklogDTO } from "../../types/DTO/backlogDTO";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import StoryBlock from "../../components/backlog/StoryBlock";
 import changeEpicListToStoryList from "../../utils/changeEpicListToStoryList";
 import TaskBlock from "../../components/backlog/TaskBlock";
+import TaskContainer from "../../components/backlog/TaskContainer";
+import TaskHeader from "../../components/backlog/TaskHeader";
 
 const FinishedStoryPage = () => {
   const { backlog }: { backlog: BacklogDTO } = useOutletContext();
@@ -25,31 +27,50 @@ const FinishedStoryPage = () => {
     [backlog.epicList]
   );
 
+  const [showTaskList, setShowTaskList] = useState(
+    new Array(storyList.length).fill(false)
+  );
+
+  const handleShowTaskList = (index: number) => {
+    const newShowTaskList = [...showTaskList];
+    newShowTaskList[index] = !newShowTaskList[index];
+    setShowTaskList(newShowTaskList);
+  };
+
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="w-full border-b">
-        {...storyList.map(({ id, epic, title, point, status, taskList }) => {
-          const progress = taskList.length
-            ? Math.round(
-                (taskList.filter(({ status }) => status === "완료").length /
-                  taskList.length) *
-                  100
-              )
-            : 0;
+        {...storyList.map(
+          ({ id, epic, title, point, status, taskList }, index) => {
+            const progress = taskList.length
+              ? Math.round(
+                  (taskList.filter(({ status }) => status === "완료").length /
+                    taskList.length) *
+                    100
+                )
+              : 0;
 
-          return (
-            <>
-              <StoryBlock
-                {...{ id, title, point, status }}
-                epic={epic}
-                progress={progress}
-                taskExist={taskList.length > 0}
-                epicList={epicCategoryList}
-              />
-              {...taskList.map((task) => <TaskBlock {...task} />)}
-            </>
-          );
-        })}
+            return (
+              <>
+                <StoryBlock
+                  {...{ id, title, point, status }}
+                  epic={epic}
+                  progress={progress}
+                  taskExist={taskList.length > 0}
+                  epicList={epicCategoryList}
+                  showTaskList={showTaskList[index]}
+                  onShowTaskList={() => handleShowTaskList(index)}
+                />
+                {showTaskList[index] && (
+                  <TaskContainer>
+                    <TaskHeader />
+                    {...taskList.map((task) => <TaskBlock {...task} />)}
+                  </TaskContainer>
+                )}
+              </>
+            );
+          }
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -73,15 +73,15 @@ const UnfinishedStoryPage = () => {
       })),
     [backlog.epicList]
   );
-  const [showTaskList, setShowTaskList] = useState(
-    new Array(storyList.length).fill(false)
+  const [showTaskList, setShowTaskList] = useState<{ [key: number]: boolean }>(
+    {}
   );
   const { emitStoryUpdateEvent } = useStoryEmitEvent(socket);
   const { emitTaskUpdateEvent } = useTaskEmitEvent(socket);
 
-  const handleShowTaskList = (index: number) => {
-    const newShowTaskList = [...showTaskList];
-    newShowTaskList[index] = !newShowTaskList[index];
+  const handleShowTaskList = (id: number) => {
+    const newShowTaskList = { ...showTaskList };
+    newShowTaskList[id] = !newShowTaskList[id];
     setShowTaskList(newShowTaskList);
   };
 
@@ -277,11 +277,11 @@ const UnfinishedStoryPage = () => {
                     {...{ id, title, point, status, epic, progress }}
                     taskExist={taskList.length > 0}
                     epicList={epicCategoryList}
-                    onShowTaskList={() => handleShowTaskList(index)}
-                    showTaskList={showTaskList[index]}
+                    onShowTaskList={() => handleShowTaskList(id)}
+                    showTaskList={showTaskList[id]}
                   />
                 </StoryDragContainer>
-                {showTaskList[index] && (
+                {showTaskList[id] && (
                   <TaskContainer>
                     <TaskHeader />
                     {...taskList.map((task, taskIndex) => (

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -219,8 +219,6 @@ const UnfinishedStoryPage = () => {
     }
 
     if (taskIndex === 0 && !taskList.length) {
-      console.log("아무 것도 없을 때");
-
       rankValue = LexoRank.middle().toString();
     } else if (taskIndex === 0) {
       const firstTaskRank = taskList[0].rankValue;

--- a/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
+++ b/frontend/src/pages/backlog/UnfinishedStoryPage.tsx
@@ -73,8 +73,17 @@ const UnfinishedStoryPage = () => {
       })),
     [backlog.epicList]
   );
+  const [showTaskList, setShowTaskList] = useState(
+    new Array(storyList.length).fill(false)
+  );
   const { emitStoryUpdateEvent } = useStoryEmitEvent(socket);
   const { emitTaskUpdateEvent } = useTaskEmitEvent(socket);
+
+  const handleShowTaskList = (index: number) => {
+    const newShowTaskList = [...showTaskList];
+    newShowTaskList[index] = !newShowTaskList[index];
+    setShowTaskList(newShowTaskList);
+  };
 
   const setStoryComponentRef = (index: number) => (element: HTMLDivElement) => {
     storyComponentRefList.current[index] = element;
@@ -270,43 +279,47 @@ const UnfinishedStoryPage = () => {
                     {...{ id, title, point, status, epic, progress }}
                     taskExist={taskList.length > 0}
                     epicList={epicCategoryList}
+                    onShowTaskList={() => handleShowTaskList(index)}
+                    showTaskList={showTaskList[index]}
                   />
                 </StoryDragContainer>
-                <TaskContainer>
-                  <TaskHeader />
-                  {...taskList.map((task, taskIndex) => (
-                    <TaskDragContainer
-                      storyIndex={index}
-                      taskIndex={taskIndex}
-                      setRef={setTaskComponentRef}
-                      onDragEnd={handleTaskDragEnd}
-                      onDragStart={() => handleTaskDragStart(task.id)}
-                      currentlyDraggedOver={
+                {showTaskList[index] && (
+                  <TaskContainer>
+                    <TaskHeader />
+                    {...taskList.map((task, taskIndex) => (
+                      <TaskDragContainer
+                        storyIndex={index}
+                        taskIndex={taskIndex}
+                        setRef={setTaskComponentRef}
+                        onDragEnd={handleTaskDragEnd}
+                        onDragStart={() => handleTaskDragStart(task.id)}
+                        currentlyDraggedOver={
+                          id === taskElementIndex.storyId &&
+                          taskIndex === taskElementIndex.taskIndex
+                        }
+                      >
+                        <TaskBlock key={task.id} {...task} />
+                      </TaskDragContainer>
+                    ))}
+                    <div
+                      ref={setTaskComponentRef(index, taskList.length)}
+                      className={`${
                         id === taskElementIndex.storyId &&
-                        taskIndex === taskElementIndex.taskIndex
+                        taskElementIndex.taskIndex === taskList.length
+                          ? "w-[60.13rem] h-1 bg-blue-400"
+                          : ""
+                      } absolute`}
+                    />
+                    <TaskCreateBlock
+                      storyId={id}
+                      lastTaskRankValue={
+                        taskList.length
+                          ? taskList[taskList.length - 1].rankValue
+                          : undefined
                       }
-                    >
-                      <TaskBlock key={task.id} {...task} />
-                    </TaskDragContainer>
-                  ))}
-                  <div
-                    ref={setTaskComponentRef(index, taskList.length)}
-                    className={`${
-                      id === taskElementIndex.storyId &&
-                      taskElementIndex.taskIndex === taskList.length
-                        ? "w-[60.13rem] h-1 bg-blue-400"
-                        : ""
-                    } absolute`}
-                  />
-                  <TaskCreateBlock
-                    storyId={id}
-                    lastTaskRankValue={
-                      taskList.length
-                        ? taskList[taskList.length - 1].rankValue
-                        : undefined
-                    }
-                  />
-                </TaskContainer>
+                    />
+                  </TaskContainer>
+                )}
               </div>
             );
           }


### PR DESCRIPTION
## 🎟️ 태스크

[에픽 우선순위 변경 로직 작성](https://plastic-toad-cb0.notion.site/73ddbe6ed76740faacea23015ce81745)
[스토리별 페이지, 에픽별 페이지 에러 처리](https://plastic-toad-cb0.notion.site/2bdf163f52534920b62e62e89f7be87b)

## ✅ 작업 내용

- 에픽별 페이지 드래그 앤 드롭 기능 구현
- 에픽이 리스트의 마지막 부분으로 드래그되지 않는 문제 해결
- 스토리, 태스크 토글 기능이 동작하도록 수정
- 에픽 별 페이지에서 스토리 드래그 앤 드롭이 제대로 동작하도록 수정

## 🖊️ 구체적인 작업

### 에픽별 페이지 드래그 앤 드롭

- 에픽은 에픽별, 스토리는 스토리별, 태스크는 태스크별로 드래그 앤 드롭을 통해 우선순위를 변경하도록 했습니다.
- 서로 연관된 코드가 많아 한 페이지 내에 드래그 앤 드롭 관련 기능이 모두 들어가 있어 복잡성이 높습니다. 리팩토링이 필요합니다.

### 스토리, 태스크 토글 기능

- 스토리를 드래그할 때 해당 스토리에 속한 태스크도 같이 드래그되지 않기 위해 태스크를 스토리 컴포넌트 외부에 위치하도록 했습니다. 이에 따라 토글된 상태를 리스트로 관리하고 있었는데, 이로 인해 열린 스토리를 드래그하면 원래 열려있던 스토리가 아니라 해당 장소로 드롭된 스토리가 열리는 문제가 발생했습니다. 이를 고치기 위해 리스트를 객체로 변경했고, 겹치지 않기 위해 키를 해당 스토리 또는 태스크를 포함하는 에픽, 스토리의 아이디로 했습니다.

## 📸 결과 화면
![녹화_2024_08_25_18_40_12_358](https://github.com/user-attachments/assets/d2762141-11b6-4353-b0d1-d529d11aa688)
