### PR TITLE
feat: 프로젝트에 팀장 추가

### DIFF
--- a/backend/src/member/entity/member.entity.ts
+++ b/backend/src/member/entity/member.entity.ts
@@ -32,7 +32,7 @@ export class Member {
   tech_stack: { stacks: string[] };
 
   @OneToMany(() => ProjectToMember, (projectToMember) => projectToMember.member)
-  projectToMember: ProjectToMember;
+  projectToMember: ProjectToMember[];
 
   @CreateDateColumn({ type: 'timestamp' })
   created_at: Date;

--- a/backend/src/project/dto/InitLandingResponse.dto.ts
+++ b/backend/src/project/dto/InitLandingResponse.dto.ts
@@ -4,6 +4,7 @@ import { Memo, memoColor } from '../entity/memo.entity';
 import { Project } from '../entity/project.entity';
 import { MemberStatus } from '../enum/MemberStatus.enum';
 import { ClientSocket } from '../type/ClientSocket.type';
+import { MemberRole } from '../enum/MemberRole.enum';
 
 class MemoDto {
   id: number;
@@ -57,6 +58,7 @@ class MemberInfo {
   id: number;
   username: string;
   imageUrl: string;
+  role: MemberRole;
   status: MemberStatus;
 
   static of(member: Member, status: MemberStatus) {
@@ -65,6 +67,7 @@ class MemberInfo {
     newMemberInfo.username = member.username;
     newMemberInfo.imageUrl = member.github_image_url;
     newMemberInfo.status = status;
+    newMemberInfo.role = member.projectToMember[0].role;
     return newMemberInfo;
   }
 }
@@ -89,7 +92,10 @@ class ProjectLandingPageContentDto {
   ) {
     const dto = new ProjectLandingPageContentDto();
     dto.project = ProjectDto.of(project);
-    dto.myInfo = MemberInfo.of(myInfo, status);
+    dto.myInfo = MemberInfo.of(
+      projectMemberList.find((member) => member.id === myInfo.id),
+      status,
+    );
     dto.member = projectMemberList
       .filter((member) => member.id !== myInfo.id)
       .map((member) => {

--- a/backend/src/project/entity/project-member.entity.ts
+++ b/backend/src/project/entity/project-member.entity.ts
@@ -5,9 +5,11 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  Column,
 } from 'typeorm';
 import { Project } from './project.entity';
 import { Member } from 'src/member/entity/member.entity';
+import { MemberRole } from '../enum/MemberRole.enum';
 
 @Entity()
 export class ProjectToMember {
@@ -28,16 +30,20 @@ export class ProjectToMember {
   @JoinColumn({ name: 'member_id' })
   member: Member;
 
+  @Column({ type: 'enum', enum: MemberRole, nullable: false })
+  role: MemberRole;
+
   @CreateDateColumn({ type: 'timestamp' })
   created_at: Date;
 
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
 
-  static of(project: Project, member: Member) {
+  static of(project: Project, member: Member, role: MemberRole) {
     const newProjectToMember = new ProjectToMember();
     newProjectToMember.project = project;
     newProjectToMember.member = member;
+    newProjectToMember.role = role;
     return newProjectToMember;
   }
 }

--- a/backend/src/project/enum/MemberRole.enum.ts
+++ b/backend/src/project/enum/MemberRole.enum.ts
@@ -1,0 +1,4 @@
+export enum MemberRole {
+  LEADER = 'LEADER',
+  MEMBER = 'MEMBER',
+}

--- a/backend/src/project/enum/MemberStatus.enum.ts
+++ b/backend/src/project/enum/MemberStatus.enum.ts
@@ -1,5 +1,5 @@
 export enum MemberStatus {
-	ON = 'on',
-	OFF = 'off',
-	AWAY = 'away',
-  }
+  ON = 'on',
+  OFF = 'off',
+  AWAY = 'away',
+}

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -1,5 +1,5 @@
 import { InjectRepository } from '@nestjs/typeorm';
-import { Connection, DataSource, MoreThan, Repository } from 'typeorm';
+import { DataSource, MoreThan, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { Project } from './entity/project.entity';
 import { ProjectToMember } from './entity/project-member.entity';
@@ -9,7 +9,7 @@ import { Link } from './entity/link.entity.';
 import { Epic, EpicColor } from './entity/epic.entity';
 import { Story, StoryStatus } from './entity/story.entity';
 import { Task, TaskStatus } from './entity/task.entity';
-import { LexoRank } from 'lexorank';
+import { MemberRole } from './enum/MemberRole.enum';
 
 @Injectable()
 export class ProjectRepository {
@@ -37,9 +37,13 @@ export class ProjectRepository {
     return this.projectRepository.save(project);
   }
 
-  addProjectMember(project: Project, member: Member): Promise<ProjectToMember> {
+  addProjectMember(
+    project: Project,
+    member: Member,
+    role: MemberRole,
+  ): Promise<ProjectToMember> {
     return this.projectToMemberRepository.save(
-      ProjectToMember.of(project, member),
+      ProjectToMember.of(project, member, role),
     );
   }
 

--- a/backend/src/project/service/project.service.spec.ts
+++ b/backend/src/project/service/project.service.spec.ts
@@ -6,6 +6,7 @@ import { Project } from '../entity/project.entity';
 import { ProjectToMember } from '../entity/project-member.entity';
 import { Memo, memoColor } from '../entity/memo.entity';
 import { Link } from '../entity/link.entity.';
+import { MemberRole } from '../enum/MemberRole.enum';
 
 describe('ProjectService', () => {
   let projectService: ProjectService;
@@ -62,6 +63,7 @@ describe('ProjectService', () => {
       expect(projectRepository.addProjectMember).toHaveBeenCalledWith(
         project,
         member,
+        MemberRole.LEADER,
       );
     });
   });
@@ -113,13 +115,16 @@ describe('ProjectService', () => {
       expect(projectRepository.addProjectMember).toHaveBeenCalledWith(
         project,
         member,
+        MemberRole.MEMBER,
       );
     });
 
     it('should throw when already joined member', async () => {
       jest
         .spyOn(projectRepository, 'getProjectToMember')
-        .mockResolvedValue(ProjectToMember.of(project, member));
+        .mockResolvedValue(
+          ProjectToMember.of(project, member, MemberRole.LEADER),
+        );
 
       jest
         .spyOn(projectRepository, 'getProjectMemberList')

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -8,8 +8,8 @@ import { Link } from '../entity/link.entity.';
 import { Epic, EpicColor } from '../entity/epic.entity';
 import { Story, StoryStatus } from '../entity/story.entity';
 import { Task, TaskStatus } from '../entity/task.entity';
-import e from 'express';
 import { LexoRank } from 'lexorank';
+import { MemberRole } from '../enum/MemberRole.enum';
 
 @Injectable()
 export class ProjectService {
@@ -19,7 +19,11 @@ export class ProjectService {
     const createdProject = await this.projectRepository.create(
       Project.of(title, subject),
     );
-    await this.projectRepository.addProjectMember(createdProject, member);
+    await this.projectRepository.addProjectMember(
+      createdProject,
+      member,
+      MemberRole.LEADER,
+    );
   }
 
   async getProjectList(member: Member): Promise<Project[]> {
@@ -37,7 +41,11 @@ export class ProjectService {
     if ((await this.getProjectMemberList(project)).length >= 10)
       throw new Error('Project reached its maximum member capacity');
 
-    await this.projectRepository.addProjectMember(project, member);
+    await this.projectRepository.addProjectMember(
+      project,
+      member,
+      MemberRole.MEMBER,
+    );
   }
 
   async getProjectMemberList(project: Project) {

--- a/backend/test/project/ws-landing-page/ws-role.e2e-spec.ts
+++ b/backend/test/project/ws-landing-page/ws-role.e2e-spec.ts
@@ -1,0 +1,77 @@
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  joinProject,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import {
+  emitJoinLanding,
+  handleConnectErrorWithReject,
+  handleErrorWithReject,
+} from '../ws-common';
+import { Socket } from 'socket.io-client';
+import { MemberRole } from 'src/project/enum/MemberRole.enum';
+
+describe('WS role', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+  describe('role', () => {
+    it('should return LEADER role for the member who creates the project and MEMBER role for the member who joins the project', async () => {
+      let socket1;
+      let socket2;
+      return new Promise<void>(async (resolve, reject) => {
+        // 회원1 회원가입 + 프로젝트 생성
+        const accessToken = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken, project.id);
+
+        // 회원2 회원가입 + 프로젝트 참여
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
+
+        socket1 = connectServer(project.id, accessToken);
+        handleConnectErrorWithReject(socket1, reject);
+        handleErrorWithReject(socket1, reject);
+        await emitJoinLanding(socket1);
+        await expectRole(socket1, MemberRole.LEADER);
+
+        socket2 = connectServer(project.id, accessToken2);
+        handleConnectErrorWithReject(socket2, reject);
+        handleErrorWithReject(socket2, reject);
+        await emitJoinLanding(socket2);
+        await expectRole(socket2, MemberRole.MEMBER);
+
+        resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
+      });
+    });
+    const expectRole = async (socket: Socket, role: string) => {
+      await new Promise<void>((resolve, reject) => {
+        socket.once('landing', async (data) => {
+          const { action, domain, content } = data;
+          if (
+            action === 'init' &&
+            domain === 'landing' &&
+            content.myInfo.role === role
+          ) {
+            resolve();
+          } else reject();
+        });
+      });
+    };
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[팀장 추가하기](https://plastic-toad-cb0.notion.site/7fd2641c9efb4e1e8a45abf984fd1e66?pvs=74)

## ✅ 작업 내용

- feat: 프로젝트의 회원 엔티티에 Role추가
- style: 들여쓰기 수정
- test: 프로젝트의 회원 role 추가로 인한 테스트 변경

## 🖊️ 구체적인 작업

### feat: 프로젝트의 회원 엔티티에 Role추가
- 프로젝트 생성 시 해당 회원의 role이 LEADER가 되도록 구현
- 프로젝트 생성 시 해당 회원의 role이 MEMBER가 되도록 구현
- MemberRole Enum 추가
- project-member Entity에 role 추가
- 서비스, 레포지토리에 role추가
- InitLandingResponse DTO에서 role 정보를 함께 반환하도록 구현
- role관련 E2E 테스트 추가

### style: 들여쓰기 수정
### test: 프로젝트의 회원 role 추가로 인한 테스트 변경

## 🤔 고민 및 의논할 거리
- 개발서버에서 기존의 데이터에도 일관된 role 규칙을 부여하기 위해 개발서버에 접속해 아래의 쿼리를 실행시켰습니다.
  - 테이블에 role 컬럼 추가
      
      ```jsx
      ALTER TABLE project_to_member
      ADD COLUMN role ENUM('LEADER', 'MEMBER') NOT NULL;
      ```
      
  - 첫 번째로 참여한 회원은 `LEADER`, 나머지는 `MEMBER`로 설정하는 쿼리 작성
      - 모든 회원의 role을 MEMBER로 설정한다.
          
          ```jsx
          UPDATE project_to_member SET role = 'MEMBER';
          ```
          
      - 프로젝트에 가장 먼저 가입한 회원을 LEADER로 만든다.
          - 서브쿼리는 project별 가장 먼저 가입한 시간을 찾는 쿼리임
          
          ```jsx
          UPDATE project_to_member ptm
          JOIN (
              SELECT project_id, MIN(created_at) AS first_join
              FROM project_to_member
              GROUP BY project_id
          ) first_members ON ptm.project_id = first_members.project_id
          AND ptm.created_at = first_members.first_join
          SET ptm.role = 'LEADER';
          ```