### PR TITLE
feat: 세팅페이지 접속 API, 프로젝트 이름,주제 수정 API 구현

### DIFF
--- a/backend/src/project/dto/project-info/ProjectInfoUpdateNotify.dto.ts
+++ b/backend/src/project/dto/project-info/ProjectInfoUpdateNotify.dto.ts
@@ -1,0 +1,21 @@
+class projectInfo {
+  title: string;
+  subject: string;
+}
+
+export class ProjectInfoUpdateNotifyDto {
+  domain: string;
+  action: string;
+  content: projectInfo;
+
+  static of(title: string, subject: string) {
+    const dto = new ProjectInfoUpdateNotifyDto();
+    dto.domain = 'projectInfo';
+    dto.action = 'update';
+    dto.content = {
+      title,
+      subject,
+    };
+    return dto;
+  }
+}

--- a/backend/src/project/dto/project-info/ProjectInfoUpdateRequest.dto.ts
+++ b/backend/src/project/dto/project-info/ProjectInfoUpdateRequest.dto.ts
@@ -1,0 +1,30 @@
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+class ProjectInfo {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(256, { message: 'Title is too long' })
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(256, { message: 'Subject is too long' })
+  subject: string;
+}
+
+export class ProjectInfoUpdateRequestDto {
+  @Matches(/^update$/)
+  action: string;
+
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => ProjectInfo)
+  content: ProjectInfo;
+}

--- a/backend/src/project/dto/setting-page/InitSettingResponse.dto.ts
+++ b/backend/src/project/dto/setting-page/InitSettingResponse.dto.ts
@@ -1,0 +1,57 @@
+import { Member } from 'src/member/entity/member.entity';
+import { Project } from 'src/project/entity/project.entity';
+import { MemberRole } from 'src/project/enum/MemberRole.enum';
+
+class ProjectMemberDto {
+  id: number;
+  username: string;
+  imageUrl: string;
+  role: MemberRole;
+
+  static of(member: Member): ProjectMemberDto {
+    const dto = new ProjectMemberDto();
+    dto.id = member.id;
+    dto.username = member.username;
+    dto.imageUrl = member.github_image_url;
+    dto.role = member.projectToMember[0].role;
+    return dto;
+  }
+}
+
+class ProjectDto {
+  title: string;
+  subject: string;
+
+  static of(project: Project): ProjectDto {
+    const dto = new ProjectDto();
+    dto.title = project.title;
+    dto.subject = project.subject;
+    return dto;
+  }
+}
+
+class ProjectInfoDto {
+  project: ProjectDto;
+  member: ProjectMemberDto[];
+
+  static of(project: Project, memberList: Member[]): ProjectInfoDto {
+    const dto = new ProjectInfoDto();
+    dto.project = ProjectDto.of(project);
+    dto.member = memberList.map((member) => ProjectMemberDto.of(member));
+    return dto;
+  }
+}
+
+export class InitSettingResponseDto {
+  domain: string;
+  action: string;
+  content: ProjectInfoDto;
+
+  static of(project: Project, memberList: Member[]): InitSettingResponseDto {
+    const dto = new InitSettingResponseDto();
+    dto.domain = 'setting';
+    dto.action = 'init';
+    dto.content = ProjectInfoDto.of(project, memberList);
+    return dto;
+  }
+}

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -22,6 +22,7 @@ import { Story } from './entity/story.entity';
 import { WsProjectStoryController } from './ws-controller/ws-project-story.controller';
 import { Task } from './entity/task.entity';
 import { WsProjectTaskController } from './ws-controller/ws-project-task.controller';
+import { WsProjectInfoController } from './ws-controller/ws-project-info.controller';
 
 @Module({
   imports: [
@@ -33,8 +34,8 @@ import { WsProjectTaskController } from './ws-controller/ws-project-task.control
       Memo,
       Link,
       Epic,
-	  Story,
-	  Task
+      Story,
+      Task,
     ]),
   ],
   controllers: [ProjectController],
@@ -49,8 +50,9 @@ import { WsProjectTaskController } from './ws-controller/ws-project-task.control
     WsProjectLinkController,
     WsProjectController,
     WsProjectEpicController,
-	WsProjectStoryController,
-	WsProjectTaskController,
+    WsProjectStoryController,
+    WsProjectTaskController,
+    WsProjectInfoController,
   ],
 })
 export class ProjectModule {}

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -37,6 +37,29 @@ export class ProjectRepository {
     return this.projectRepository.save(project);
   }
 
+  async updateProjectInfo(
+    project: Project,
+    title: string,
+    subject: string,
+  ): Promise<boolean> {
+    const updateData: Partial<Project> = {};
+
+    if (title !== undefined) {
+      updateData.title = title;
+    }
+    if (subject !== undefined) {
+      updateData.subject = subject;
+    }
+
+    const result = await this.projectRepository.update(
+      {
+        id: project.id,
+      },
+      updateData,
+    );
+    return !!result.affected;
+  }
+
   addProjectMember(
     project: Project,
     member: Member,

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -59,6 +59,14 @@ export class ProjectService {
     return true;
   }
 
+  async isProjectLeader(project: Project, member: Member): Promise<boolean> {
+    const projectToMember = await this.projectRepository.getProjectToMember(
+      project,
+      member,
+    );
+    return projectToMember?.role === MemberRole.LEADER;
+  }
+
   getProjectByLinkId(projectLinkId: string): Promise<Project | null> {
     return this.projectRepository.getProjectByLinkId(projectLinkId);
   }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -26,6 +26,18 @@ export class ProjectService {
     );
   }
 
+  async updateProjectInfo(
+    project: Project,
+    member: Member,
+    title: string,
+    subject: string,
+  ): Promise<boolean> {
+    if (!(await this.isProjectLeader(project, member))) {
+      throw new Error('Member is not the project leader');
+    }
+    return this.projectRepository.updateProjectInfo(project, title, subject);
+  }
+
   async getProjectList(member: Member): Promise<Project[]> {
     return await this.projectRepository.getProjectList(member);
   }

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -21,6 +21,7 @@ import { ClientSocket } from './type/ClientSocket.type';
 import { WsProjectEpicController } from './ws-controller/ws-project-epic.controller';
 import { WsProjectStoryController } from './ws-controller/ws-project-story.controller';
 import { WsProjectTaskController } from './ws-controller/ws-project-task.controller';
+import { WsProjectInfoController } from './ws-controller/ws-project-info.controller';
 
 @WebSocketGateway({
   namespace: /project-\d+/,
@@ -40,6 +41,7 @@ export class ProjectWebsocketGateway
     private readonly wsProjectEpicController: WsProjectEpicController,
     private readonly wsProjectStoryController: WsProjectStoryController,
     private readonly wsProjectTaskController: WsProjectTaskController,
+    private readonly wsProjectInfoController: WsProjectInfoController,
   ) {
     this.namespaceMap = new Map();
   }
@@ -179,6 +181,16 @@ export class ProjectWebsocketGateway
   @SubscribeMessage('joinSetting')
   async handleJoinSettingEvent(@ConnectedSocket() client: ClientSocket) {
     this.wsProjectController.joinSettingPage(client);
+  }
+
+  @SubscribeMessage('projectInfo')
+  async handleProjectInfoEvent(
+    @ConnectedSocket() client: ClientSocket,
+    @MessageBody() data: any,
+  ) {
+    if (data.action === 'update') {
+      this.wsProjectInfoController.updateProjectInfo(client, data);
+    }
   }
 
   notifyJoinToConnectedMembers(projectId: number, member: Member) {

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -176,6 +176,10 @@ export class ProjectWebsocketGateway
       this.wsProjectTaskController.updateTask(client, data);
     }
   }
+  @SubscribeMessage('joinSetting')
+  async handleJoinSettingEvent(@ConnectedSocket() client: ClientSocket) {
+    this.wsProjectController.joinSettingPage(client);
+  }
 
   notifyJoinToConnectedMembers(projectId: number, member: Member) {
     const projectNamespace = this.namespaceMap.get(projectId);

--- a/backend/src/project/ws-controller/ws-project-info.controller.ts
+++ b/backend/src/project/ws-controller/ws-project-info.controller.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { ClientSocket } from '../type/ClientSocket.type';
+import { validate } from 'class-validator';
+import { plainToClass } from 'class-transformer';
+import { getRecursiveErrorMsgList } from '../util/validation.util';
+import { ProjectService } from '../service/project.service';
+import { ProjectInfoUpdateRequestDto } from '../dto/project-info/ProjectInfoUpdateRequest.dto';
+import { ProjectInfoUpdateNotifyDto } from '../dto/project-info/ProjectInfoUpdateNotify.dto';
+
+@Injectable()
+export class WsProjectInfoController {
+  constructor(private readonly projectService: ProjectService) {}
+  async updateProjectInfo(client: ClientSocket, data: any) {
+    const errors = await validate(
+      plainToClass(ProjectInfoUpdateRequestDto, data),
+    );
+    if (errors.length > 0) {
+      const errorList = getRecursiveErrorMsgList(errors);
+      client.emit('error', { errorList });
+      return;
+    }
+    try {
+      const { content } = data as ProjectInfoUpdateRequestDto;
+      const isUpdate = await this.projectService.updateProjectInfo(
+        client.project,
+        client.member,
+        content.title,
+        content.subject,
+      );
+      if (isUpdate) {
+        const data = ProjectInfoUpdateNotifyDto.of(
+          content.title,
+          content.subject,
+        );
+        client.nsp.to('landing').emit('landing', data);
+        client.nsp.to('setting').emit('setting', data);
+      }
+    } catch (e) {
+      if (e.message === 'Member is not the project leader') {
+        client.disconnect(true);
+      } else throw e;
+    }
+  }
+}

--- a/backend/src/project/ws-controller/ws-project.controller.ts
+++ b/backend/src/project/ws-controller/ws-project.controller.ts
@@ -65,6 +65,16 @@ export class WsProjectController {
   }
 
   async joinSettingPage(client: ClientSocket) {
+    if (
+      !(await this.projectService.isProjectLeader(
+        client.project,
+        client.member,
+      ))
+    ) {
+      client.disconnect(true);
+      return;
+    }
+
     client.leave('landing');
     client.leave('backlog');
     client.join('setting');

--- a/backend/test/project/ws-setting-page/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-setting-page/ws-project-landing-page.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { Socket } from 'socket.io-client';
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getMemberByAccessToken,
+  getProjectLinkId,
+  joinProject,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import { emitJoinLanding, handleConnectErrorWithReject } from '../ws-common';
+import { MemberRole } from 'src/project/enum/MemberRole.enum';
+
+describe('WS Setting', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+
+  it('Should return project setting data when leader enters setting page', async () => {
+    let socket1: Socket;
+
+    return new Promise<void>(async (resolve, reject) => {
+      const accessToken1 = (await createMember(memberFixture, app)).accessToken;
+      const member1 = await getMemberByAccessToken(accessToken1);
+      const project = await createProject(accessToken1, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken1, project.id);
+
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      const member2 = await getMemberByAccessToken(accessToken2);
+      await joinProject(accessToken2, projectLinkId);
+
+      socket1 = connectServer(project.id, accessToken1);
+      handleConnectErrorWithReject(socket1, reject);
+      await emitJoinLanding(socket1);
+
+      socket1.emit('joinSetting');
+      socket1.on('error', (e) => reject(e));
+
+      socket1.on('setting', (data) => {
+        const { action, domain, content } = data;
+        expect(domain).toBe('setting');
+        expect(action).toBe('init');
+
+        expect(content.project.title).toBe(projectPayload.title);
+        expect(content.project.subject).toBe(projectPayload.subject);
+        expect(content.member.length).toBe(2);
+
+        const responseMember1 = content.member.find(
+          (member) => member.id === member1.id,
+        );
+        expect(responseMember1.username).toBe(member1.username);
+        expect(responseMember1.imageUrl).toBe(member1.github_image_url);
+        expect(responseMember1.role).toBe(MemberRole.LEADER);
+
+        const responseMember2 = content.member.find(
+          (member) => member.id === member2.id,
+        );
+        expect(responseMember2.username).toBe(member2.username);
+        expect(responseMember2.imageUrl).toBe(member2.github_image_url);
+        expect(responseMember2.role).toBe(MemberRole.MEMBER);
+        resolve();
+      });
+    }).finally(() => {
+      socket1.close();
+    });
+  });
+});

--- a/backend/test/project/ws-setting-page/ws-project-landing-page.e2e-spec.ts
+++ b/backend/test/project/ws-setting-page/ws-project-landing-page.e2e-spec.ts
@@ -72,4 +72,26 @@ describe('WS Setting', () => {
       socket1.close();
     });
   });
+
+  it('Should close connection when member(not leader) enters setting page', async () => {
+    let socket2: Socket;
+
+    return new Promise<void>(async (resolve) => {
+      const accessToken1 = (await createMember(memberFixture, app)).accessToken;
+      const project = await createProject(accessToken1, projectPayload, app);
+      const projectLinkId = await getProjectLinkId(accessToken1, project.id);
+
+      const accessToken2 = (await createMember(memberFixture2, app))
+        .accessToken;
+      await joinProject(accessToken2, projectLinkId);
+
+      socket2 = connectServer(project.id, accessToken2);
+      socket2.emit('joinSetting');
+      socket2.on('disconnect', () => {
+        resolve();
+      });
+    }).finally(() => {
+      socket2.close();
+    });
+  });
 });

--- a/backend/test/project/ws-setting-page/ws-update-project-info.e2e-spec.ts
+++ b/backend/test/project/ws-setting-page/ws-update-project-info.e2e-spec.ts
@@ -1,0 +1,106 @@
+import { Socket } from 'socket.io-client';
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  joinProject,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import { handleConnectErrorWithReject } from '../ws-common';
+
+describe('WS projectInfo', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+
+  describe('update projectInfo', () => {
+    it('Should return project setting data when leader enters setting page', async () => {
+      let socket1: Socket;
+      let socket2: Socket;
+
+      await new Promise<void>(async (resolve, reject) => {
+        const accessToken1 = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken1, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken1, project.id);
+
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
+
+        socket1 = connectServer(project.id, accessToken1);
+        handleConnectErrorWithReject(socket1, reject);
+        await joinSettingPage(socket1);
+
+        socket2 = connectServer(project.id, accessToken2);
+        handleConnectErrorWithReject(socket2, reject);
+        await joinLandingPage(socket2);
+
+        const newTitle = '새로운 제목';
+        const newSubject = '새로운 주제';
+        socket1.emit('projectInfo', {
+          action: 'update',
+          content: { title: newTitle, subject: newSubject },
+        });
+        await Promise.all([
+          expectUpdateProjectInfo(socket1, 'setting', newTitle, newSubject),
+          expectUpdateProjectInfo(socket2, 'landing', newTitle, newSubject),
+        ]);
+        resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
+      });
+    });
+
+    const joinSettingPage = (socket: Socket) => {
+      return new Promise<void>((resolve) => {
+        socket.emit('joinSetting');
+        socket.once('setting', (data) => {
+          const { action, domain } = data;
+          if (domain === 'setting' && action === 'init') {
+            resolve();
+          }
+        });
+      });
+    };
+
+    const joinLandingPage = (socket: Socket) => {
+      return new Promise<void>((resolve) => {
+        socket.emit('joinLanding');
+        socket.once('landing', (data) => {
+          const { action, domain } = data;
+          if (domain === 'landing' && action === 'init') {
+            resolve();
+          }
+        });
+      });
+    };
+
+    const expectUpdateProjectInfo = (
+      socket: Socket,
+      eventPage: string,
+      title: string,
+      subject: string,
+    ) => {
+      return new Promise<void>((resolve) => {
+        socket.on(eventPage, (data) => {
+          const { action, domain, content } = data;
+          if (domain === 'projectInfo' && action === 'update') {
+            expect(content.title).toBe(title);
+            expect(content.subject).toBe(subject);
+            resolve();
+          }
+        });
+      });
+    };
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[세팅페이지 접속, 프로젝트 정보 수정 API 구현](https://plastic-toad-cb0.notion.site/API-82679bea56dd4eb9914edeb40ce5aabd?pvs=4)

## ✅ 작업 내용

ex)

- 설정 페이지 입장 API 구현
- 프로젝트 리더가 아닌 회원이 설정페이지를 접속시 웹소켓 연결을 끊도록 구현
- 프로젝트 이름, 주제 수정 API 구현

## 🖊️ 구체적인 작업

### 설정 페이지 입장 API 구현
- joinSetting 이벤트 추가
- 설정 페이지 입장시 프로젝트의 이름, 주제, 회원 데이터 응답 구현
- 설정페이지 응답 DTO 추가
- E2E테스트 추가

### 프로젝트 리더가 아닌 회원이 설정페이지를 접속시 웹소켓 연결을 끊도록 구현
- 프로젝트 리더인지 확인하는 서비스 구현
- 프로젝트 리더가 아닌 회원이 설정 페이지 접속시 웹소켓 연결 끊도록 구현
- 리더가 아닌 회원이 설정페이지 입장 하는 E2E 테스트 추가

### 프로젝트 이름, 주제 수정 API 구현
- 프로젝트 이름, 주제 수정 레포지토리, 서비스 구현
- 리더가 아닌 인원이 수정시 웹소켓 연결을 끊도록 구현
- 프로젝트 이름, 주제 수정 시 랜딩, 설정 페이지에 있는 회원들에게 알림을 주도록 구현
- 프로젝트 이름, 주제 수정 DTO 추가
- 프로젝트 이름, 주제 수정 E2E테스트 추가
