### PR TITLE
feat: 세팅 페이지, 프로젝트 제목, 주제 수정 기능 구현

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -22,6 +22,7 @@ import UnfinishedStoryPage from "./pages/backlog/UnfinishedStoryPage";
 import BacklogPage from "./pages/backlog/BacklogPage";
 import FinishedStoryPage from "./pages/backlog/FinishedStoryPage";
 import EpicPage from "./pages/backlog/EpicPage";
+import SettingPage from "./pages/setting/SettingPage";
 
 type RouteType = "PRIVATE" | "PUBLIC";
 
@@ -96,7 +97,7 @@ const router = createBrowserRouter([
               element: <BacklogPage />,
             },
             { path: ROUTER_URL.SPRINT, element: <div>sprint Page</div> },
-            { path: ROUTER_URL.SETTINGS, element: <div>setting Page</div> },
+            { path: ROUTER_URL.SETTINGS, element: <SettingPage /> },
           ],
         },
       ]),

--- a/frontend/src/components/backlog/BacklogHeader.tsx
+++ b/frontend/src/components/backlog/BacklogHeader.tsx
@@ -14,7 +14,9 @@ const BacklogHeader = () => {
   return (
     <header className="flex items-baseline justify-between">
       <div className="flex items-baseline gap-2">
-        <h1 className="text-m text-dark-green">{TAB_TITLE[lastPath]} 백로그</h1>
+        <h1 className="font-bold text-m text-middle-green">
+          {TAB_TITLE[lastPath]} 백로그
+        </h1>
         <p className="">우선순위 내림차순</p>
       </div>
       <div className="flex gap-1">

--- a/frontend/src/components/landing/member/LandingMember.tsx
+++ b/frontend/src/components/landing/member/LandingMember.tsx
@@ -94,12 +94,20 @@ const LandingMember = ({ projectTitle }: LandingMemberProps) => {
         />
         <div className="flex justify-between text-white">
           <p className="text-xs font-bold">| 함께하는 사람들</p>
-          <button
-            className="text-xxs hover:underline"
-            onClick={handleInviteButtonClick}
-          >
-            초대링크 복사
-          </button>
+          {myInfo.role === "LEADER" && (
+            <div className="flex gap-1">
+              <button
+                className="text-xxs hover:underline"
+                onClick={handleInviteButtonClick}
+              >
+                초대링크 복사
+              </button>
+              <span>|</span>
+              <button className="text-xxs hover:underline" onClick={() => {}}>
+                링크 변경
+              </button>
+            </div>
+          )}
         </div>
         {memberList.map((memberData: LandingMemberDTO) => (
           <UserBlock {...memberData} key={memberData.id} />

--- a/frontend/src/components/setting/InformationInput.tsx
+++ b/frontend/src/components/setting/InformationInput.tsx
@@ -24,7 +24,7 @@ const InformationInput = ({
     </label>
     <div>
       <input
-        className="w-[60.8rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
+        className="w-[60.3rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
         type="text"
         id={inputId}
         autoComplete="off"

--- a/frontend/src/components/setting/InformationInput.tsx
+++ b/frontend/src/components/setting/InformationInput.tsx
@@ -1,0 +1,39 @@
+import { ChangeEvent } from "react";
+
+interface InformationInputProps {
+  label: string;
+  inputId: string;
+  inputValue: string;
+  errorMessage: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const InformationInput = ({
+  label,
+  inputId,
+  inputValue,
+  errorMessage,
+  onChange,
+}: InformationInputProps) => (
+  <div className="flex w-full gap-6 mb-5">
+    <label
+      className="min-w-[6.125rem] text-xs font-semibold text-middle-green"
+      htmlFor={inputId}
+    >
+      {label}
+    </label>
+    <div>
+      <input
+        className="w-[60.8rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
+        type="text"
+        id={inputId}
+        autoComplete="off"
+        value={inputValue}
+        onChange={onChange}
+      />
+      <p className="text-xxxs text-error-red">{errorMessage}</p>
+    </div>
+  </div>
+);
+
+export default InformationInput;

--- a/frontend/src/components/setting/InformationSettingSection.tsx
+++ b/frontend/src/components/setting/InformationSettingSection.tsx
@@ -1,18 +1,19 @@
-import { ChangeEvent, useMemo, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import InformationInput from "./InformationInput";
+import { useOutletContext } from "react-router-dom";
+import { Socket } from "socket.io-client";
+import useSettingProjectInfoSocket from "../../hooks/pages/setting/useSettingProjectInfoSocket";
 
-interface InformationSettingSectionProps {
-  title: string;
-  subject: string;
-}
+interface InformationSettingSectionProps {}
 
-const InformationSettingSection = ({
-  title,
-  subject,
-}: InformationSettingSectionProps) => {
-  const [titleValue, setTitleValue] = useState(title);
+const InformationSettingSection = ({}: InformationSettingSectionProps) => {
+  const { socket }: { socket: Socket } = useOutletContext();
+  const {
+    projectInfo: { title, subject },
+  } = useSettingProjectInfoSocket(socket);
+  const [titleValue, setTitleValue] = useState("");
   const [titleErrorMessage, setTitleErrorMessage] = useState("");
-  const [subjectValue, setSubjectValue] = useState(subject);
+  const [subjectValue, setSubjectValue] = useState("");
   const [subjectErrorMessage, setSubjectErrorMessage] = useState("");
   const submitActivated = useMemo(
     () =>
@@ -61,6 +62,11 @@ const InformationSettingSection = ({
   };
 
   const handleSubmit = () => {};
+
+  useEffect(() => {
+    setTitleValue(title);
+    setSubjectValue(subject);
+  }, [title, subject]);
 
   return (
     <>

--- a/frontend/src/components/setting/InformationSettingSection.tsx
+++ b/frontend/src/components/setting/InformationSettingSection.tsx
@@ -1,0 +1,104 @@
+import { ChangeEvent, useMemo, useState } from "react";
+import InformationInput from "./InformationInput";
+
+interface InformationSettingSectionProps {
+  title: string;
+  subject: string;
+}
+
+const InformationSettingSection = ({
+  title,
+  subject,
+}: InformationSettingSectionProps) => {
+  const [titleValue, setTitleValue] = useState(title);
+  const [titleErrorMessage, setTitleErrorMessage] = useState("");
+  const [subjectValue, setSubjectValue] = useState(subject);
+  const [subjectErrorMessage, setSubjectErrorMessage] = useState("");
+  const submitActivated = useMemo(
+    () =>
+      !(
+        !titleValue ||
+        !subjectValue ||
+        (titleValue === title && subjectValue === subject)
+      ),
+    [titleValue, subjectValue]
+  );
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+
+    setTitleValue(value);
+
+    if (!value.trim()) {
+      setTitleErrorMessage("프로젝트 이름을 입력해주세요.");
+      return;
+    }
+
+    if (value.length > 255) {
+      setTitleErrorMessage("프로젝트 이름이 너무 깁니다.");
+      return;
+    }
+
+    setTitleErrorMessage("");
+  };
+
+  const handleSubjectChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+
+    setSubjectValue(value);
+
+    if (!value.trim()) {
+      setSubjectErrorMessage("프로젝트 주제를 입력해주세요.");
+      return;
+    }
+
+    if (value.length > 255) {
+      setSubjectErrorMessage("프로젝트 주제가 너무 깁니다.");
+      return;
+    }
+
+    setSubjectErrorMessage("");
+  };
+
+  const handleSubmit = () => {};
+
+  return (
+    <>
+      <div className="w-full mb-7">
+        <p className="font-bold text-m text-middle-green">프로젝트 설정</p>
+      </div>
+      <div className="flex flex-col w-full">
+        <InformationInput
+          label="프로젝트 이름"
+          inputId="title"
+          inputValue={titleValue}
+          errorMessage={titleErrorMessage}
+          onChange={handleTitleChange}
+        />
+        <InformationInput
+          label="프로젝트 주제"
+          inputId="subject"
+          inputValue={subjectValue}
+          errorMessage={subjectErrorMessage}
+          onChange={handleSubjectChange}
+        />
+        <div className="self-end relative w-[4.5rem] h-10">
+          {!submitActivated && (
+            <div className="absolute w-full h-full rounded-lg opacity-50 bg-slate-500"></div>
+          )}
+
+          <button
+            className="w-full h-full text-xs text-white rounded-lg bg-middle-green"
+            type="button"
+            disabled={!submitActivated}
+            onClick={handleSubmit}
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default InformationSettingSection;

--- a/frontend/src/components/setting/InformationSettingSection.tsx
+++ b/frontend/src/components/setting/InformationSettingSection.tsx
@@ -4,16 +4,20 @@ import { useOutletContext } from "react-router-dom";
 import { Socket } from "socket.io-client";
 import useSettingProjectInfoSocket from "../../hooks/pages/setting/useSettingProjectInfoSocket";
 
-interface InformationSettingSectionProps {}
+interface InformationSettingSectionProps {
+  title: string;
+  subject: string;
+}
 
-const InformationSettingSection = ({}: InformationSettingSectionProps) => {
+const InformationSettingSection = ({
+  title,
+  subject,
+}: InformationSettingSectionProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
-  const {
-    projectInfo: { title, subject },
-  } = useSettingProjectInfoSocket(socket);
-  const [titleValue, setTitleValue] = useState("");
+  const { emitProjectInfoUpdateEvent } = useSettingProjectInfoSocket(socket);
+  const [titleValue, setTitleValue] = useState(title);
   const [titleErrorMessage, setTitleErrorMessage] = useState("");
-  const [subjectValue, setSubjectValue] = useState("");
+  const [subjectValue, setSubjectValue] = useState(subject);
   const [subjectErrorMessage, setSubjectErrorMessage] = useState("");
   const submitActivated = useMemo(
     () =>
@@ -22,7 +26,7 @@ const InformationSettingSection = ({}: InformationSettingSectionProps) => {
         !subjectValue ||
         (titleValue === title && subjectValue === subject)
       ),
-    [titleValue, subjectValue]
+    [title, subject, titleValue, subjectValue]
   );
 
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -61,7 +65,9 @@ const InformationSettingSection = ({}: InformationSettingSectionProps) => {
     setSubjectErrorMessage("");
   };
 
-  const handleSubmit = () => {};
+  const handleSubmit = () => {
+    emitProjectInfoUpdateEvent({ title: titleValue, subject: subjectValue });
+  };
 
   useEffect(() => {
     setTitleValue(title);

--- a/frontend/src/components/setting/InformationSettingSection.tsx
+++ b/frontend/src/components/setting/InformationSettingSection.tsx
@@ -64,7 +64,7 @@ const InformationSettingSection = ({
 
   return (
     <>
-      <div className="w-full mb-7">
+      <div className="w-full mb-2">
         <p className="font-bold text-m text-middle-green">프로젝트 설정</p>
       </div>
       <div className="flex flex-col w-full">

--- a/frontend/src/components/setting/MemberBlock.tsx
+++ b/frontend/src/components/setting/MemberBlock.tsx
@@ -1,0 +1,32 @@
+import useMemberStore from "../../stores/useMemberStore";
+import { LandingMemberDTO } from "../../types/DTO/landingDTO";
+
+interface MemberBlockProps extends LandingMemberDTO {}
+
+const MemberBlock = ({ username, imageUrl, role }: MemberBlockProps) => {
+  const myRole = useMemberStore((state) => state.myInfo.role);
+
+  return (
+    <div className="flex w-full gap-3">
+      <div className="w-[16.25rem] flex gap-3 items-center">
+        <img className="w-8 h-8 rounded-full" src={imageUrl} alt={username} />
+        <p className="">{username}</p>
+      </div>
+      <div className="w-[18.75rem]">
+        <p className="">{role}</p>
+      </div>
+      <div className="w-[30rem]">
+        {myRole === "LEADER" && (
+          <button
+            className="px-2 py-1 text-white rounded w-fit bg-error-red text-xxs"
+            type="button"
+          >
+            프로젝트에서 제거
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MemberBlock;

--- a/frontend/src/components/setting/MemberSettingSection.tsx
+++ b/frontend/src/components/setting/MemberSettingSection.tsx
@@ -16,7 +16,7 @@ const MemberSettingSection = ({ memberList }: MemberSettingSectionProps) => (
         <p className="w-[18.75rem]">역할</p>
         <p className="w-[30rem]">작업</p>
       </div>
-      <div className="overflow-y-auto scrollbar-thin">
+      <div className="flex flex-col gap-3 overflow-y-auto scrollbar-thin">
         {...memberList.map((member) => <MemberBlock {...member} />)}
       </div>
     </div>

--- a/frontend/src/components/setting/MemberSettingSection.tsx
+++ b/frontend/src/components/setting/MemberSettingSection.tsx
@@ -1,0 +1,26 @@
+import { LandingMemberDTO } from "../../types/DTO/landingDTO";
+import MemberBlock from "./MemberBlock";
+
+interface MemberSettingSectionProps {
+  memberList: LandingMemberDTO[];
+}
+
+const MemberSettingSection = ({ memberList }: MemberSettingSectionProps) => (
+  <div className="mb-5">
+    <div className="mb-2">
+      <p className="font-bold text-m text-middle-green">멤버 관리</p>
+    </div>
+    <div className="flex flex-col gap-2 h-[18.52rem]">
+      <div className="flex w-full gap-3 border-b-[2px] text-[1rem] text-dark-gray">
+        <p className="w-[16.25rem]">닉네임</p>
+        <p className="w-[18.75rem]">역할</p>
+        <p className="w-[30rem]">작업</p>
+      </div>
+      <div className="overflow-y-auto scrollbar-thin">
+        {...memberList.map((member) => <MemberBlock {...member} />)}
+      </div>
+    </div>
+  </div>
+);
+
+export default MemberSettingSection;

--- a/frontend/src/components/setting/ProjectDeleteModal.tsx
+++ b/frontend/src/components/setting/ProjectDeleteModal.tsx
@@ -60,7 +60,7 @@ const ProjectDeleteModal = ({
         </div>
         <p className="mb-10 text-lg">프로젝트 삭제 후 되돌릴 수 없습니다.</p>
         <div className="flex flex-col gap-2">
-          <p className="text-sm font-bold">
+          <p className="text-sm font-bold select-none">
             삭제하시려면 "{projectTitle}"을(를) 입력해주세요.
           </p>
           <input

--- a/frontend/src/components/setting/ProjectDeleteModal.tsx
+++ b/frontend/src/components/setting/ProjectDeleteModal.tsx
@@ -1,17 +1,23 @@
 import { ChangeEvent, MouseEventHandler, useState } from "react";
+import useSettingProjectSocket from "../../hooks/pages/setting/useSettingProjectSocket";
 import Closed from "../../assets/icons/closed.svg?react";
+import { Socket } from "socket.io-client";
 
 interface ProjectDeleteModalProps {
   projectTitle: string;
+  socket: Socket;
   close: () => void;
 }
 
 const ProjectDeleteModal = ({
   projectTitle,
+  socket,
   close,
 }: ProjectDeleteModalProps) => {
   const [inputValue, setInputValue] = useState("");
   const [confirmed, setConfirmed] = useState(false);
+
+  const { emitProjectDeleteEvent } = useSettingProjectSocket(socket);
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
@@ -32,6 +38,12 @@ const ProjectDeleteModal = ({
       return;
     }
     close();
+  };
+
+  const handleDeleteButtonClick = () => {
+    if (confirmed) {
+      emitProjectDeleteEvent();
+    }
   };
 
   return (
@@ -63,12 +75,15 @@ const ProjectDeleteModal = ({
             } h-7 relative`}
           >
             {!confirmed && (
-              <div className="absolute w-full h-full bg-black rounded opacity-20"></div>
+              <div className="absolute w-full h-full bg-black rounded opacity-40"></div>
             )}
             <button
-              className="w-full h-full text-sm text-center text-white rounded bg-error-red"
+              className={`w-full h-full text-sm text-center text-white rounded ${
+                !confirmed ? "bg-gray-300" : "bg-error-red"
+              }`}
               type="button"
               disabled={!confirmed}
+              onClick={handleDeleteButtonClick}
             >
               프로젝트 삭제
             </button>

--- a/frontend/src/components/setting/ProjectDeleteModal.tsx
+++ b/frontend/src/components/setting/ProjectDeleteModal.tsx
@@ -1,0 +1,82 @@
+import { ChangeEvent, MouseEventHandler, useState } from "react";
+import Closed from "../../assets/icons/closed.svg?react";
+
+interface ProjectDeleteModalProps {
+  projectTitle: string;
+  close: () => void;
+}
+
+const ProjectDeleteModal = ({
+  projectTitle,
+  close,
+}: ProjectDeleteModalProps) => {
+  const [inputValue, setInputValue] = useState("");
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+
+    setInputValue(value);
+
+    if (value === projectTitle) {
+      setConfirmed(true);
+    } else {
+      setConfirmed(false);
+    }
+  };
+
+  const handleCloseClick: MouseEventHandler<
+    HTMLButtonElement | HTMLDivElement
+  > = ({ target, currentTarget }: React.MouseEvent) => {
+    if (target !== currentTarget) {
+      return;
+    }
+    close();
+  };
+
+  return (
+    <div
+      className="fixed top-0 left-0 z-50 flex items-center justify-center w-full h-full bg-black bg-opacity-30"
+      onClick={handleCloseClick}
+    >
+      <div className="px-6 py-7 bg-white rounded-lg w-[23.75rem] h-fit">
+        <div className="flex justify-between w-full mb-2">
+          <p className="font-bold text-m">|프로젝트 삭제</p>
+          <button type="button" onClick={close}>
+            <Closed width={32} height={32} stroke="black" />
+          </button>
+        </div>
+        <p className="mb-10 text-lg">프로젝트 삭제 후 되돌릴 수 없습니다.</p>
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-bold">
+            삭제하시려면 "{projectTitle}"을(를) 입력해주세요.
+          </p>
+          <input
+            className="w-full px-1 text-sm border rounded border-error-red outline-error-red"
+            type="text"
+            value={inputValue}
+            onChange={handleInputChange}
+          />
+          <div
+            className={`${
+              !confirmed ? "hover:cursor-not-allowed" : ""
+            } h-7 relative`}
+          >
+            {!confirmed && (
+              <div className="absolute w-full h-full bg-black rounded opacity-20"></div>
+            )}
+            <button
+              className="w-full h-full text-sm text-center text-white rounded bg-error-red"
+              type="button"
+              disabled={!confirmed}
+            >
+              프로젝트 삭제
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectDeleteModal;

--- a/frontend/src/components/setting/ProjectDeleteSection.tsx
+++ b/frontend/src/components/setting/ProjectDeleteSection.tsx
@@ -1,0 +1,31 @@
+import { useModal } from "../../hooks/common/modal/useModal";
+import ProjectDeleteModal from "./ProjectDeleteModal";
+
+interface ProjectDeleteSectionProps {
+  projectTitle: string;
+}
+
+const ProjectDeleteSection = ({ projectTitle }: ProjectDeleteSectionProps) => {
+  const { open, close } = useModal(true);
+  const handleDeleteButtonClick = () => {
+    open(<ProjectDeleteModal {...{ projectTitle, close }} />);
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="">
+        <p className="text-xs">프로젝트 삭제</p>
+        <p className="text-xxs">프로젝트를 삭제한 후 되돌릴 수 없습니다.</p>
+      </div>
+      <button
+        className="h-10 px-2 font-light text-white rounded-lg w-fit bg-error-red text-xxs"
+        type="button"
+        onClick={handleDeleteButtonClick}
+      >
+        프로젝트 삭제
+      </button>
+    </div>
+  );
+};
+
+export default ProjectDeleteSection;

--- a/frontend/src/components/setting/ProjectDeleteSection.tsx
+++ b/frontend/src/components/setting/ProjectDeleteSection.tsx
@@ -1,3 +1,5 @@
+import { useOutletContext } from "react-router-dom";
+import { Socket } from "socket.io-client";
 import { useModal } from "../../hooks/common/modal/useModal";
 import ProjectDeleteModal from "./ProjectDeleteModal";
 
@@ -7,8 +9,9 @@ interface ProjectDeleteSectionProps {
 
 const ProjectDeleteSection = ({ projectTitle }: ProjectDeleteSectionProps) => {
   const { open, close } = useModal(true);
+  const { socket }: { socket: Socket } = useOutletContext();
   const handleDeleteButtonClick = () => {
-    open(<ProjectDeleteModal {...{ projectTitle, close }} />);
+    open(<ProjectDeleteModal {...{ projectTitle, close, socket }} />);
   };
 
   return (

--- a/frontend/src/hooks/common/landing/useLandingProjectSocket.ts
+++ b/frontend/src/hooks/common/landing/useLandingProjectSocket.ts
@@ -6,6 +6,11 @@ import {
   LandingSocketData,
   LandingSocketDomain,
 } from "../../../types/common/landing";
+import {
+  SettingSocketData,
+  SettingSocketDomain,
+} from "../../../types/common/setting";
+import { SettingProjectDTO } from "../../../types/DTO/settingDTO";
 
 const useLandingProjectSocket = (socket: Socket) => {
   const [project, setProject] = useState<LandingProjectDTO>(
@@ -17,11 +22,22 @@ const useLandingProjectSocket = (socket: Socket) => {
     setProject(project);
   };
 
-  const handleOnLanding = ({ domain, content }: LandingSocketData) => {
-    if (domain !== LandingSocketDomain.INIT) {
+  const handleProjectInfoEvent = (content: SettingProjectDTO) => {
+    setProject({ ...project, title: content.title, subject: content.subject });
+  };
+
+  const handleOnLanding = ({
+    domain,
+    content,
+  }: LandingSocketData | SettingSocketData) => {
+    if (domain === SettingSocketDomain.PROJECT_INFO) {
+      handleProjectInfoEvent(content);
+    }
+
+    if (domain === LandingSocketDomain.INIT) {
+      handleInitEvent(content);
       return;
     }
-    handleInitEvent(content);
   };
 
   useEffect(() => {

--- a/frontend/src/hooks/common/socket/useSocket.ts
+++ b/frontend/src/hooks/common/socket/useSocket.ts
@@ -1,7 +1,9 @@
-import { io } from "socket.io-client";
-import { BASE_URL } from "../../../constants/path";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { io } from "socket.io-client";
+import { BASE_URL, ROUTER_URL } from "../../../constants/path";
 import { getAccessToken } from "../../../apis/utils/authAPI";
+import { SettingSocketData } from "../../../types/common/setting";
 
 const useSocket = (projectId: string) => {
   const WS_URL = `${BASE_URL}/project-${projectId}`;
@@ -15,6 +17,16 @@ const useSocket = (projectId: string) => {
     })
   );
   const [connected, setConnected] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  const handleProjectDeleted = ({ domain, action }: SettingSocketData) => {
+    if (domain === "projectInfo" && action === "delete") {
+      alert("프로젝트가 삭제되었습니다.");
+      setTimeout(() => {
+        navigate(ROUTER_URL.PROJECTS);
+      }, 1000);
+    }
+  };
 
   useEffect(() => {
     const handleOnConnect = () => {
@@ -27,11 +39,13 @@ const useSocket = (projectId: string) => {
     socket.connect();
     socket.on("connect", handleOnConnect);
     socket.on("disconnect", handleOnDisconnect);
+    socket.on("main", handleProjectDeleted);
 
     return () => {
       socket.disconnect();
       socket.off("connect", handleOnConnect);
       socket.off("disconnect", handleOnDisconnect);
+      socket.off("main", handleProjectDeleted);
     };
   }, []);
 

--- a/frontend/src/hooks/pages/setting/useSettingProjectInfoSocket.ts
+++ b/frontend/src/hooks/pages/setting/useSettingProjectInfoSocket.ts
@@ -1,58 +1,14 @@
-import { useEffect, useState } from "react";
 import { Socket } from "socket.io-client";
-import { SettingDTO, SettingProjectDTO } from "../../../types/DTO/settingDTO";
-import {
-  SettingSocketData,
-  SettingSocketDomain,
-  SettingSocketProjectInfoAction,
-} from "../../../types/common/setting";
 
 const useSettingProjectInfoSocket = (socket: Socket) => {
-  const [projectInfo, setProjectInfo] = useState<SettingProjectDTO>({
-    title: "",
-    subject: "",
-  });
-
-  const handleInitEvent = (content: SettingDTO) => {
-    const { project } = content;
-    setProjectInfo(project);
+  const emitProjectInfoUpdateEvent = (content: {
+    title: string;
+    subject: string;
+  }) => {
+    socket.emit("projectInfo", { action: "update", content });
   };
 
-  const handleProjectInfoEvent = (
-    action: SettingSocketProjectInfoAction,
-    content: SettingProjectDTO
-  ) => {
-    switch (action) {
-      case SettingSocketProjectInfoAction.UPDATE:
-        setProjectInfo(content);
-        break;
-    }
-  };
-
-  const handleOnProjectInfoSetting = ({
-    domain,
-    action,
-    content,
-  }: SettingSocketData) => {
-    switch (domain) {
-      case SettingSocketDomain.INIT:
-        handleInitEvent(content);
-        break;
-      case SettingSocketDomain.PROJECT_INFO:
-        handleProjectInfoEvent(action, content);
-        break;
-    }
-  };
-
-  useEffect(() => {
-    socket.on("setting", handleOnProjectInfoSetting);
-
-    return () => {
-      socket.off("setting", handleOnProjectInfoSetting);
-    };
-  }, []);
-
-  return { projectInfo };
+  return { emitProjectInfoUpdateEvent };
 };
 
 export default useSettingProjectInfoSocket;

--- a/frontend/src/hooks/pages/setting/useSettingProjectInfoSocket.ts
+++ b/frontend/src/hooks/pages/setting/useSettingProjectInfoSocket.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Socket } from "socket.io-client";
+import { SettingDTO, SettingProjectDTO } from "../../../types/DTO/settingDTO";
+import {
+  SettingSocketData,
+  SettingSocketDomain,
+  SettingSocketProjectInfoAction,
+} from "../../../types/common/setting";
+
+const useSettingProjectInfoSocket = (socket: Socket) => {
+  const [projectInfo, setProjectInfo] = useState<SettingProjectDTO>({
+    title: "",
+    subject: "",
+  });
+
+  const handleInitEvent = (content: SettingDTO) => {
+    const { project } = content;
+    setProjectInfo(project);
+  };
+
+  const handleProjectInfoEvent = (
+    action: SettingSocketProjectInfoAction,
+    content: SettingProjectDTO
+  ) => {
+    switch (action) {
+      case SettingSocketProjectInfoAction.UPDATE:
+        setProjectInfo(content);
+        break;
+    }
+  };
+
+  const handleOnProjectInfoSetting = ({
+    domain,
+    action,
+    content,
+  }: SettingSocketData) => {
+    switch (domain) {
+      case SettingSocketDomain.INIT:
+        handleInitEvent(content);
+        break;
+      case SettingSocketDomain.PROJECT_INFO:
+        handleProjectInfoEvent(action, content);
+        break;
+    }
+  };
+
+  useEffect(() => {
+    socket.on("setting", handleOnProjectInfoSetting);
+
+    return () => {
+      socket.off("setting", handleOnProjectInfoSetting);
+    };
+  }, []);
+
+  return { projectInfo };
+};
+
+export default useSettingProjectInfoSocket;

--- a/frontend/src/hooks/pages/setting/useSettingProjectSocket.ts
+++ b/frontend/src/hooks/pages/setting/useSettingProjectSocket.ts
@@ -1,0 +1,11 @@
+import { Socket } from "socket.io-client";
+
+const useSettingProjectSocket = (socket: Socket) => {
+  const emitProjectDeleteEvent = () => {
+    socket.emit("projectInfo", { action: "delete", content: {} });
+  };
+
+  return { emitProjectDeleteEvent };
+};
+
+export default useSettingProjectSocket;

--- a/frontend/src/hooks/pages/setting/useSettingSocket.ts
+++ b/frontend/src/hooks/pages/setting/useSettingSocket.ts
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+import { Socket } from "socket.io-client";
+
+const useSettingSocket = (socket: Socket) => {
+  useEffect(() => {
+    socket.emit("joinLanding");
+  }, []);
+};
+
+export default useSettingSocket;

--- a/frontend/src/hooks/pages/setting/useSettingSocket.ts
+++ b/frontend/src/hooks/pages/setting/useSettingSocket.ts
@@ -1,10 +1,59 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Socket } from "socket.io-client";
+import {
+  SettingSocketData,
+  SettingSocketDomain,
+  SettingSocketProjectInfoAction,
+} from "../../../types/common/setting";
+import { SettingDTO, SettingProjectDTO } from "../../../types/DTO/settingDTO";
 
 const useSettingSocket = (socket: Socket) => {
+  const [projectInfo, setProjectInfo] = useState<SettingProjectDTO>({
+    title: "",
+    subject: "",
+  });
+
+  const handleInitEvent = (content: SettingDTO) => {
+    const { project } = content;
+    setProjectInfo(project);
+  };
+
+  const handleProjectInfoEvent = (
+    action: SettingSocketProjectInfoAction,
+    content: SettingProjectDTO
+  ) => {
+    switch (action) {
+      case SettingSocketProjectInfoAction.UPDATE:
+        setProjectInfo(content);
+        break;
+    }
+  };
+
+  const handleOnProjectInfoSetting = ({
+    domain,
+    action,
+    content,
+  }: SettingSocketData) => {
+    switch (domain) {
+      case SettingSocketDomain.INIT:
+        handleInitEvent(content);
+        break;
+      case SettingSocketDomain.PROJECT_INFO:
+        handleProjectInfoEvent(action, content);
+        break;
+    }
+  };
+
   useEffect(() => {
-    socket.emit("joinLanding");
+    socket.emit("joinSetting");
+    socket.on("setting", handleOnProjectInfoSetting);
+
+    return () => {
+      socket.off("setting", handleOnProjectInfoSetting);
+    };
   }, []);
+
+  return { projectInfo };
 };
 
 export default useSettingSocket;

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -34,7 +34,7 @@ const SettingPage = () => {
     <div className="w-full h-full">
       <InformationSettingSection {...{ title, subject }} />
       <MemberSettingSection memberList={memberList} />
-      <ProjectDeleteSection projectTitle="프로젝트 이름" />
+      <ProjectDeleteSection projectTitle={title} />
     </div>
   );
 };

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -1,54 +1,8 @@
+import InformationSettingSection from "../../components/setting/InformationSettingSection";
+
 const SettingPage = () => (
   <div className="w-full h-full">
-    <div className="w-full mb-7">
-      <p className="font-bold text-m text-middle-green">프로젝트 설정</p>
-    </div>
-    <div className="flex flex-col w-full">
-      <div className="flex w-full gap-6 mb-5">
-        <label
-          className="min-w-[6.125rem] text-xs font-semibold text-middle-green"
-          htmlFor="name"
-        >
-          프로젝트 이름
-        </label>
-        <div>
-          <input
-            className="w-[60.8rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
-            type="text"
-            id="name"
-            autoComplete="off"
-          />
-          <p className="text-xxxs text-error-red">
-            프로젝트 이름을 입력해주세요
-          </p>
-        </div>
-      </div>
-      <div className="flex gap-6 mb-5">
-        <label
-          className="min-w-[6.125rem] text-xs font-semibold text-middle-green"
-          htmlFor="name"
-        >
-          프로젝트 주제
-        </label>
-        <div>
-          <input
-            className="w-[60.8rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
-            type="text"
-            id="name"
-            autoComplete="off"
-          />
-          <p className="text-xxxs text-error-red">
-            프로젝트 주제를 입력해주세요
-          </p>
-        </div>
-      </div>
-      <button
-        className="w-[4.5rem] h-10 bg-middle-green text-white rounded-lg text-xs self-end"
-        type="button"
-      >
-        저장
-      </button>
-    </div>
+    <InformationSettingSection title="프로젝트 이름" subject="프로젝트 주제" />
     <div className="">
       <p className="font-bold text-m text-middle-green">멤버 관리</p>
     </div>

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -1,7 +1,10 @@
+import { Socket } from "socket.io-client";
 import InformationSettingSection from "../../components/setting/InformationSettingSection";
 import MemberSettingSection from "../../components/setting/MemberSettingSection";
 import ProjectDeleteSection from "../../components/setting/ProjectDeleteSection";
 import { LandingMemberDTO } from "../../types/DTO/landingDTO";
+import { useOutletContext } from "react-router-dom";
+import useSettingSocket from "../../hooks/pages/setting/useSettingSocket";
 
 const memberList: LandingMemberDTO[] = [
   { id: 1, username: "lesserTest", role: "LEADER", imageUrl: "", status: "on" },
@@ -21,12 +24,17 @@ const memberList: LandingMemberDTO[] = [
   },
 ];
 
-const SettingPage = () => (
-  <div className="w-full h-full">
-    <InformationSettingSection title="프로젝트 이름" subject="프로젝트 주제" />
-    <MemberSettingSection memberList={memberList} />
-    <ProjectDeleteSection projectTitle="프로젝트 이름" />
-  </div>
-);
+const SettingPage = () => {
+  const { socket }: { socket: Socket } = useOutletContext();
+  useSettingSocket(socket);
+
+  return (
+    <div className="w-full h-full">
+      <InformationSettingSection />
+      <MemberSettingSection memberList={memberList} />
+      <ProjectDeleteSection projectTitle="프로젝트 이름" />
+    </div>
+  );
+};
 
 export default SettingPage;

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -1,5 +1,6 @@
 import InformationSettingSection from "../../components/setting/InformationSettingSection";
 import MemberSettingSection from "../../components/setting/MemberSettingSection";
+import ProjectDeleteSection from "../../components/setting/ProjectDeleteSection";
 import { LandingMemberDTO } from "../../types/DTO/landingDTO";
 
 const memberList: LandingMemberDTO[] = [
@@ -24,18 +25,7 @@ const SettingPage = () => (
   <div className="w-full h-full">
     <InformationSettingSection title="프로젝트 이름" subject="프로젝트 주제" />
     <MemberSettingSection memberList={memberList} />
-    <div className="flex items-center justify-between">
-      <div className="">
-        <p className="text-xs">프로젝트 삭제</p>
-        <p className="text-xxs">프로젝트를 삭제한 후 되돌릴 수 없습니다.</p>
-      </div>
-      <button
-        className="h-10 px-2 font-light text-white rounded-lg w-fit bg-error-red text-xxs"
-        type="button"
-      >
-        프로젝트 삭제
-      </button>
-    </div>
+    <ProjectDeleteSection projectTitle="프로젝트 이름" />
   </div>
 );
 

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -26,11 +26,13 @@ const memberList: LandingMemberDTO[] = [
 
 const SettingPage = () => {
   const { socket }: { socket: Socket } = useOutletContext();
-  useSettingSocket(socket);
+  const {
+    projectInfo: { title, subject },
+  } = useSettingSocket(socket);
 
   return (
     <div className="w-full h-full">
-      <InformationSettingSection />
+      <InformationSettingSection {...{ title, subject }} />
       <MemberSettingSection memberList={memberList} />
       <ProjectDeleteSection projectTitle="프로젝트 이름" />
     </div>

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -1,0 +1,95 @@
+const SettingPage = () => (
+  <div className="w-full h-full">
+    <div className="w-full mb-7">
+      <p className="font-bold text-m text-middle-green">프로젝트 설정</p>
+    </div>
+    <div className="flex flex-col w-full">
+      <div className="flex w-full gap-6 mb-5">
+        <label
+          className="min-w-[6.125rem] text-xs font-semibold text-middle-green"
+          htmlFor="name"
+        >
+          프로젝트 이름
+        </label>
+        <div>
+          <input
+            className="w-[60.8rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
+            type="text"
+            id="name"
+            autoComplete="off"
+          />
+          <p className="text-xxxs text-error-red">
+            프로젝트 이름을 입력해주세요
+          </p>
+        </div>
+      </div>
+      <div className="flex gap-6 mb-5">
+        <label
+          className="min-w-[6.125rem] text-xs font-semibold text-middle-green"
+          htmlFor="name"
+        >
+          프로젝트 주제
+        </label>
+        <div>
+          <input
+            className="w-[60.8rem] mb-1 h-10 border-[2px] border-text-gray rounded-lg focus:outline-middle-green px-1 hover:cursor-pointer"
+            type="text"
+            id="name"
+            autoComplete="off"
+          />
+          <p className="text-xxxs text-error-red">
+            프로젝트 주제를 입력해주세요
+          </p>
+        </div>
+      </div>
+      <button
+        className="w-[4.5rem] h-10 bg-middle-green text-white rounded-lg text-xs self-end"
+        type="button"
+      >
+        저장
+      </button>
+    </div>
+    <div className="">
+      <p className="font-bold text-m text-middle-green">멤버 관리</p>
+    </div>
+    <div className="flex flex-col gap-2 h-[18.52rem]">
+      <div className="flex w-full gap-3 border-b-[2px] text-[1rem] text-dark-gray">
+        <p className="w-[16.25rem]">닉네임</p>
+        <p className="w-[18.75rem]">역할</p>
+        <p className="w-[30rem]">작업</p>
+      </div>
+      <div className="flex w-full gap-3 overflow-y-auto">
+        <div className="w-[16.25rem] flex gap-3 items-center">
+          {/* <img className="w-8 h-8 rounded-full" src="" alt="" /> */}
+          <div className="w-8 h-8 bg-blue-400 rounded-full"></div>
+          <p className="">lesserTest</p>
+        </div>
+        <div className="w-[18.75rem]">
+          <p className="">멤버</p>
+        </div>
+        <div className="w-[30rem]">
+          <button
+            className="px-2 py-1 text-white rounded w-fit bg-error-red text-xxs"
+            type="button"
+          >
+            프로젝트에서 제거
+          </button>
+        </div>
+      </div>
+    </div>
+    <div className="flex items-center justify-between">
+      <div className="">
+        <p className="text-xs">프로젝트 삭제</p>
+        <p className="text-xxs">프로젝트를 삭제한 후 되돌릴 수 없습니다.</p>
+      </div>
+      <button
+        className="h-10 px-2 font-light text-white rounded-lg w-fit bg-error-red text-xxs"
+        type="button"
+      >
+        프로젝트 삭제
+      </button>
+    </div>
+  </div>
+);
+
+export default SettingPage;

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -1,36 +1,29 @@
 import InformationSettingSection from "../../components/setting/InformationSettingSection";
+import MemberSettingSection from "../../components/setting/MemberSettingSection";
+import { LandingMemberDTO } from "../../types/DTO/landingDTO";
+
+const memberList: LandingMemberDTO[] = [
+  { id: 1, username: "lesserTest", role: "LEADER", imageUrl: "", status: "on" },
+  {
+    id: 2,
+    username: "lesserTest2",
+    role: "MEMBER",
+    imageUrl: "",
+    status: "on",
+  },
+  {
+    id: 3,
+    username: "lesserTest3",
+    role: "MEMBER",
+    imageUrl: "",
+    status: "on",
+  },
+];
 
 const SettingPage = () => (
   <div className="w-full h-full">
     <InformationSettingSection title="프로젝트 이름" subject="프로젝트 주제" />
-    <div className="">
-      <p className="font-bold text-m text-middle-green">멤버 관리</p>
-    </div>
-    <div className="flex flex-col gap-2 h-[18.52rem]">
-      <div className="flex w-full gap-3 border-b-[2px] text-[1rem] text-dark-gray">
-        <p className="w-[16.25rem]">닉네임</p>
-        <p className="w-[18.75rem]">역할</p>
-        <p className="w-[30rem]">작업</p>
-      </div>
-      <div className="flex w-full gap-3 overflow-y-auto">
-        <div className="w-[16.25rem] flex gap-3 items-center">
-          {/* <img className="w-8 h-8 rounded-full" src="" alt="" /> */}
-          <div className="w-8 h-8 bg-blue-400 rounded-full"></div>
-          <p className="">lesserTest</p>
-        </div>
-        <div className="w-[18.75rem]">
-          <p className="">멤버</p>
-        </div>
-        <div className="w-[30rem]">
-          <button
-            className="px-2 py-1 text-white rounded w-fit bg-error-red text-xxs"
-            type="button"
-          >
-            프로젝트에서 제거
-          </button>
-        </div>
-      </div>
-    </div>
+    <MemberSettingSection memberList={memberList} />
     <div className="flex items-center justify-between">
       <div className="">
         <p className="text-xs">프로젝트 삭제</p>

--- a/frontend/src/stores/useMemberStore.ts
+++ b/frontend/src/stores/useMemberStore.ts
@@ -15,7 +15,7 @@ interface MemberState extends InitialMemberState {
 }
 
 const initialState: InitialMemberState = {
-  myInfo: { id: -1, username: "", imageUrl: "", status: "on" },
+  myInfo: { id: -1, username: "", imageUrl: "", status: "on", role: "MEMBER" },
   memberList: [],
 };
 

--- a/frontend/src/test/sortMemberByStatus.test.ts
+++ b/frontend/src/test/sortMemberByStatus.test.ts
@@ -4,12 +4,12 @@ import sortMemberByStatus from "../utils/sortMemberByStatus";
 describe("sortMemberByStatus test", () => {
   it("on, away, off 순 정렬 테스트", () => {
     const memberList: LandingMemberDTO[] = [
-      { id: 1, username: "", imageUrl: "", status: "off" },
-      { id: 2, username: "", imageUrl: "", status: "on" },
-      { id: 3, username: "", imageUrl: "", status: "away" },
-      { id: 4, username: "", imageUrl: "", status: "on" },
-      { id: 5, username: "", imageUrl: "", status: "off" },
-      { id: 6, username: "", imageUrl: "", status: "away" },
+      { id: 1, username: "", imageUrl: "", status: "off", role: "LEADER" },
+      { id: 2, username: "", imageUrl: "", status: "on", role: "MEMBER" },
+      { id: 3, username: "", imageUrl: "", status: "away", role: "MEMBER" },
+      { id: 4, username: "", imageUrl: "", status: "on", role: "MEMBER" },
+      { id: 5, username: "", imageUrl: "", status: "off", role: "MEMBER" },
+      { id: 6, username: "", imageUrl: "", status: "away", role: "MEMBER" },
     ];
 
     const sortedMemberIdList = memberList

--- a/frontend/src/types/DTO/landingDTO.ts
+++ b/frontend/src/types/DTO/landingDTO.ts
@@ -2,6 +2,8 @@ import { MemoColorType } from "../common/landing";
 
 export type MemberStatus = "on" | "off" | "away";
 
+export type MemberRole = "LEADER" | "MEMBER";
+
 export interface LandingProjectDTO {
   title: string;
   subject: string;
@@ -13,6 +15,7 @@ export interface LandingMemberDTO {
   username: string;
   imageUrl: string;
   status: MemberStatus;
+  role: MemberRole;
 }
 
 export interface LandingSprintDTO {

--- a/frontend/src/types/DTO/settingDTO.ts
+++ b/frontend/src/types/DTO/settingDTO.ts
@@ -1,0 +1,18 @@
+import { MemberRole } from "./landingDTO";
+
+export interface SettingProjectDTO {
+  title: string;
+  subject: string;
+}
+
+export interface SettingMemberDTO {
+  id: number;
+  username: string;
+  imageUrl: string;
+  role: MemberRole;
+}
+
+export interface SettingDTO {
+  project: SettingProjectDTO;
+  member: SettingMemberDTO[];
+}

--- a/frontend/src/types/common/setting.ts
+++ b/frontend/src/types/common/setting.ts
@@ -1,0 +1,27 @@
+import { SettingDTO, SettingProjectDTO } from "../DTO/settingDTO";
+
+export enum SettingSocketDomain {
+  INIT = "setting",
+  PROJECT_INFO = "projectInfo",
+}
+
+export enum SettingSocketProjectInfoAction {
+  UPDATE = "update",
+  DELETE = "delete",
+}
+
+interface SettingSocketInitData {
+  domain: SettingSocketDomain.INIT;
+  action: "init";
+  content: SettingDTO;
+}
+
+interface SettingSocketProjectInfoData {
+  domain: SettingSocketDomain.PROJECT_INFO;
+  action: SettingSocketProjectInfoAction;
+  content: SettingProjectDTO;
+}
+
+export type SettingSocketData =
+  | SettingSocketInitData
+  | SettingSocketProjectInfoData;


### PR DESCRIPTION
## 🎟️ 태스크

[주제 수정 API 연결](https://plastic-toad-cb0.notion.site/API-b891274ee2a04397a0ca093fa906932a)
[이름 수정 API 연결](https://plastic-toad-cb0.notion.site/API-488a58416e054f79be74d8ddd1e7f79b)

## ✅ 작업 내용

- 세팅 페이지 구현
- 주제 수정, 이름 수정 API 연결


## 🖊️ 구체적인 작업

### 세팅 페이지 구현

- 피그마 디자인대로 세팅 페이지를 퍼블리싱 했습니다.

### 주제, 이름 수정 API 연결

- API 명세에 맞게 프로젝트 주제와 이름을 수정할 수 있도록 연결했습니다.
- 세팅 페이지에서 이름 및 주제를 변경하면 랜딩 페이지에도 반영되도록 했습니다.
