### PR TITLE
feat: 프로젝트 삭제 API 구현

### DIFF
--- a/backend/src/project/dto/project-info/ProjectDeleteNotify.dto.ts
+++ b/backend/src/project/dto/project-info/ProjectDeleteNotify.dto.ts
@@ -1,0 +1,13 @@
+export class ProjectDeleteNotifyDto {
+  domain: string;
+  action: string;
+  content: Record<string, string>;
+
+  static of() {
+    const dto = new ProjectDeleteNotifyDto();
+    dto.domain = 'projectInfo';
+    dto.action = 'delete';
+    dto.content = {};
+    return dto;
+  }
+}

--- a/backend/src/project/dto/project-info/ProjectDeleteRequest.dto.ts
+++ b/backend/src/project/dto/project-info/ProjectDeleteRequest.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, Matches } from 'class-validator';
+
+export class ProjectDeleteRequestDto {
+  @Matches(/^delete$/)
+  action: string;
+
+  @IsNotEmpty()
+  content: Record<string, string>;
+}

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -37,6 +37,11 @@ export class ProjectRepository {
     return this.projectRepository.save(project);
   }
 
+  async delete(projectId: number) {
+    const result = await this.projectRepository.delete({ id: projectId });
+    return result.affected ? result.affected : 0;
+  }
+
   async updateProjectInfo(
     project: Project,
     title: string,

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -39,6 +39,15 @@ export class ProjectService {
     return this.projectRepository.updateProjectInfo(project, title, subject);
   }
 
+  async deleteProject(projectId: number, member: Member): Promise<boolean> {
+    if (!(await this.isProjectLeader(projectId, member))) {
+      throw new Error('Member is not the project leader');
+    }
+    const affected = await this.projectRepository.delete(projectId);
+    if (affected === 0) return false;
+    return true;
+  }
+
   async getProjectList(member: Member): Promise<Project[]> {
     return await this.projectRepository.getProjectList(member);
   }

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -202,7 +202,14 @@ export class ProjectWebsocketGateway
   ) {
     if (data.action === 'update') {
       this.wsProjectInfoController.updateProjectInfo(client, data);
+    } else if (data.action === 'delete') {
+      this.wsProjectInfoController.deleteProject(client, data);
+      this.deleteProjectFromNamespaceMap(client.project.id);
     }
+  }
+
+  deleteProjectFromNamespaceMap(projectId: number) {
+    this.namespaceMap.delete(projectId);
   }
 
   notifyJoinToConnectedMembers(projectId: number, member: Member) {

--- a/backend/src/project/ws-controller/ws-project.controller.ts
+++ b/backend/src/project/ws-controller/ws-project.controller.ts
@@ -41,7 +41,7 @@ export class WsProjectController {
     );
     client.emit('landing', response);
 
-    client.leave('landing');
+    client.leave('backlog');
     client.leave('setting');
     client.join('landing');
 

--- a/backend/test/project/ws-setting-page/ws-delete-project.e2e-spec.ts
+++ b/backend/test/project/ws-setting-page/ws-delete-project.e2e-spec.ts
@@ -1,0 +1,109 @@
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  joinProject,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import { handleConnectErrorWithReject } from '../ws-common';
+import { Socket } from 'socket.io-client';
+
+describe('WS project', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+  describe('delete project', () => {
+    it('should return deleted project event when leader request', async () => {
+      let socket1: Socket;
+      let socket2: Socket;
+
+      await new Promise<void>(async (resolve, reject) => {
+        const accessToken1 = (await createMember(memberFixture, app))
+          .accessToken;
+        const project = await createProject(accessToken1, projectPayload, app);
+        const projectLinkId = await getProjectLinkId(accessToken1, project.id);
+
+        const accessToken2 = (await createMember(memberFixture2, app))
+          .accessToken;
+        await joinProject(accessToken2, projectLinkId);
+
+        socket1 = connectServer(project.id, accessToken1);
+        handleConnectErrorWithReject(socket1, reject);
+        await joinSettingPage(socket1);
+
+        socket2 = connectServer(project.id, accessToken2);
+        handleConnectErrorWithReject(socket2, reject);
+        await joinLandingPage(socket2);
+
+        socket1.emit('projectInfo', {
+          action: 'delete',
+          content: {},
+        });
+
+        await Promise.all([
+          expectDeleteProject(socket1, 'main'),
+          expectDeleteProject(socket2, 'main'),
+        ]);
+
+        await Promise.all([
+          expectCloseSocket(socket1),
+          expectCloseSocket(socket2),
+        ]);
+        resolve();
+      }).finally(() => {
+        socket1.close();
+        socket2.close();
+      });
+    });
+
+    const expectDeleteProject = (socket: Socket, eventPage: string) => {
+      return new Promise<void>((resolve) => {
+        socket.on(eventPage, (data) => {
+          const { action, domain } = data;
+          if (domain === 'projectInfo' && action === 'delete') {
+            resolve();
+          }
+        });
+      });
+    };
+    const expectCloseSocket = (socket: Socket) => {
+      return new Promise<void>((resolve) => {
+        socket.on('disconnect', () => {
+          resolve();
+        });
+      });
+    };
+  });
+});
+
+const joinSettingPage = (socket: Socket) => {
+  return new Promise<void>((resolve) => {
+    socket.emit('joinSetting');
+    socket.once('setting', (data) => {
+      const { action, domain } = data;
+      if (domain === 'setting' && action === 'init') {
+        resolve();
+      }
+    });
+  });
+};
+
+const joinLandingPage = (socket: Socket) => {
+  return new Promise<void>((resolve) => {
+    socket.emit('joinLanding');
+    socket.once('landing', (data) => {
+      const { action, domain } = data;
+      if (domain === 'landing' && action === 'init') {
+        resolve();
+      }
+    });
+  });
+};


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 삭제 API 구현](https://plastic-toad-cb0.notion.site/API-833fb4515de040b7bd9b568b51c04614?pvs=74)

## ✅ 작업 내용

- feat: 프로젝트 삭제 API 구현
- fix: 'joinLanding' 이벤트 처리 로직 중 잘못된 방을 나가는 로직 수정

## 🖊️ 구체적인 작업

### 프로젝트 삭제 API 구현
- 게이트웨이
  - 프로젝트 삭제관련 라우팅 로직 추가
  - 프로젝트 삭제시 해당 프로젝트의 네임스페이스 Map 삭제하도록 구현
- 컨트롤러
  - 프로젝트 삭제 메서드 추가
  - 삭제 알림 보내고 1초 후 프로젝트 삭제하는 로직 구현
- 서비스
  - 프로젝트 삭제 메서드 추가
- 레포지토리
  - 프로젝트 삭제 메서드 추가
- 프로젝트 삭제 E2E 테스트 추가