### PR TITLE
feat: 초대링크로 프로젝트의 프리뷰 조회하는 API 구현

### DIFF
--- a/backend/src/project/dto/ProjectInvitePreviewResponse.dto.ts
+++ b/backend/src/project/dto/ProjectInvitePreviewResponse.dto.ts
@@ -1,0 +1,20 @@
+export class ProjectInvitePreviewResponseDto {
+  id: number;
+  title: string;
+  subject: string;
+  leaderUsername: string;
+
+  static of(
+    id: number,
+    title: string,
+    subject: string,
+    leaderUsername: string,
+  ) {
+    const dto = new ProjectInvitePreviewResponseDto();
+    dto.id = id;
+    dto.title = title;
+    dto.subject = subject;
+    dto.leaderUsername = leaderUsername;
+    return dto;
+  }
+}

--- a/backend/src/project/dto/service/ProjectBriefInfo.dto.ts
+++ b/backend/src/project/dto/service/ProjectBriefInfo.dto.ts
@@ -1,0 +1,20 @@
+export class ProjectBriefInfoDto {
+  id: number;
+  title: string;
+  subject: string;
+  leaderUsername: string;
+
+  static of(
+    id: number,
+    title: string,
+    subject: string,
+    leaderUsername: string,
+  ) {
+    const dto = new ProjectBriefInfoDto();
+    dto.id = id;
+    dto.title = title;
+    dto.subject = subject;
+    dto.leaderUsername = leaderUsername;
+    return dto;
+  }
+}

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Get,
   NotFoundException,
+  Param,
   Post,
   Req,
   Res,
@@ -14,6 +15,7 @@ import { MemberRequest } from 'src/common/guard/authentication.guard';
 import { JoinProjectRequestDto } from './dto/JoinProjectRequest.dto';
 import { Response } from 'express';
 import { ProjectWebsocketGateway } from './websocket.gateway';
+import { ProjectInvitePreviewResponseDto } from './dto/ProjectInvitePreviewResponse.dto';
 
 @Controller('project')
 export class ProjectController {
@@ -81,5 +83,32 @@ export class ProjectController {
       request.member,
     );
     return response.status(201).send();
+  }
+
+  @Get('/invite-preview/:inviteLinkId')
+  async getProjectInvitePreview(
+    @Param('inviteLinkId') inviteLinkId: string,
+    @Res() response: Response,
+  ) {
+    let projectPublicInfo;
+    try {
+      projectPublicInfo =
+        await this.projectService.getProjectBriefInfoByInviteLinkId(
+          inviteLinkId,
+        );
+    } catch (err) {
+      if (err.message === 'Project Not Found') throw new NotFoundException();
+      throw err;
+    }
+    return response
+      .status(200)
+      .send(
+        ProjectInvitePreviewResponseDto.of(
+          projectPublicInfo.id,
+          projectPublicInfo.title,
+          projectPublicInfo.subject,
+          projectPublicInfo.leaderUsername,
+        ),
+      );
   }
 }

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -75,6 +75,17 @@ export class ProjectRepository {
     );
   }
 
+  async getProjectWithMemberListByLinkId(
+    inviteLinkId: string,
+  ): Promise<Project> {
+    const projectWithMemberList = await this.projectRepository.findOne({
+      where: { inviteLinkId },
+      relations: { projectToMember: { member: true } },
+    });
+    if (!projectWithMemberList) throw new Error('Project Not Found');
+    return projectWithMemberList;
+  }
+
   getProjectByLinkId(projectLinkId: string): Promise<Project | null> {
     return this.projectRepository.findOne({
       where: { inviteLinkId: projectLinkId },

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -11,6 +11,7 @@ import { Task, TaskStatus } from '../entity/task.entity';
 import { LexoRank } from 'lexorank';
 import { MemberRole } from '../enum/MemberRole.enum';
 import { v4 as uuidv4 } from 'uuid';
+import { ProjectBriefInfoDto } from '../dto/service/ProjectBriefInfo.dto';
 
 @Injectable()
 export class ProjectService {
@@ -122,6 +123,27 @@ export class ProjectService {
       member,
     );
     return projectToMember?.role === MemberRole.LEADER;
+  }
+
+  async getProjectBriefInfoByInviteLinkId(
+    inviteLinkId: string,
+  ): Promise<ProjectBriefInfoDto> {
+    const project =
+      await this.projectRepository.getProjectWithMemberListByLinkId(
+        inviteLinkId,
+      );
+    const leader = project.projectToMember.find(
+      (member) => member.role === MemberRole.LEADER,
+    );
+    if (!leader) {
+      throw new Error('Project does not have a leader');
+    }
+    return ProjectBriefInfoDto.of(
+      project.id,
+      project.title,
+      project.subject,
+      leader.member.username,
+    );
   }
 
   getProjectByLinkId(projectLinkId: string): Promise<Project | null> {

--- a/backend/test/project/get-project-preview.e2e-spec.ts
+++ b/backend/test/project/get-project-preview.e2e-spec.ts
@@ -1,0 +1,91 @@
+import * as request from 'supertest';
+import {
+  app,
+  appInit,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+
+describe('GET /project/invite-preview', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+
+  it('should return 200 when given valid invite link id', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const inviteLinkId = await getProjectLinkId(accessToken, projectId);
+    const { accessToken: newAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/project/invite-preview/${inviteLinkId}`)
+      .set('Authorization', `Bearer ${newAccessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(typeof response.body.id).toBe('number');
+    expect(response.body.title).toBe(projectPayload.title);
+    expect(response.body.subject).toBe(projectPayload.subject);
+    expect(response.body.leaderUsername).toBe(memberFixture.username);
+  });
+
+  it('should return 404 when project link ID is not found', async () => {
+    const invalidUUID = 'c93a87e8-a0a4-4b55-bdf2-59bf691f5c37';
+    const { accessToken: newAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/project/invite-preview/${invalidUUID}`)
+      .set('Authorization', `Bearer ${newAccessToken}`);
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 401 (Bearer Token is missing)', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(accessToken, projectId);
+
+    const response = await request(app.getHttpServer()).get(
+      `/api/project/invite-preview/${projectLinkId}`,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 401 (Expired:accessToken) when given invalid access token', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const projectLinkId = await getProjectLinkId(accessToken, projectId);
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/project/invite-preview/${projectLinkId}`)
+      .set('Authorization', `Bearer invalidToken`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Expired:accessToken');
+  });
+});


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 정보 반환 API 개발(UUID로 조회)](https://plastic-toad-cb0.notion.site/API-UUID-106f5552133380a783d5e33531eeb6f0)

## ✅ 작업 내용

- 컨트롤러
  - 프로젝트 초대 브리뷰 반환하는 메서드 구현
- 서비스
  - 초대링크로 프로젝트의 일부 정보를 반환하는 메서드 구현
- 레포지토리
  - 프로젝트, 프로젝트 회원을 조인해서 반환하는 메서드 구현
- 프로젝트 프리뷰 조회 E2E 테스트 추가

## 🤔 고민 및 의논할 거리
- 서비스에서 프로젝트의 전체 정보를 조회해 컨트롤러에서 필요한 정보를 선별해서 반환하는게 아니라 서비스에서 일부분의 정보만을 반환하는 서비스 메서드를 만들었습니다.
- 왜냐하면 프로젝트의 멤버가 아닌 일반 회원이 컨트롤러에서 서비스의 전체정보 메서드를 사용했을때 추후 컨트롤러의 구현이 바뀌는 이유로 프로젝트의 원치않은 정보가 노출되는것이 우려되었기 때문입니다.
- 따라서 서비스는 Project 엔티티 전체를 반환하지 않고, DTO 클래스로 `ProjectBriefInfoDto`를 정의해 초대를 요청하는 회원이 볼수있는 수준의 정보만을 제공하게 구현했습니다.