### PR TITLE
feat: 프로젝트 참여요청 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { Link } from './project/entity/link.entity.';
 import { Epic } from './project/entity/epic.entity';
 import { Story } from './project/entity/story.entity';
 import { Task } from './project/entity/task.entity';
+import { ProjectJoinRequest } from './project/entity/project-join-request.entity';
 
 @Module({
   imports: [
@@ -50,11 +51,12 @@ import { Task } from './project/entity/task.entity';
           LoginMember,
           Project,
           ProjectToMember,
+          ProjectJoinRequest,
           Memo,
           Link,
           Epic,
           Story,
-		  Task
+          Task,
         ],
         synchronize: ConfigService.get('NODE_ENV') == 'PROD' ? false : true,
       }),

--- a/backend/src/project/dto/ProjectJoinRequest-Request.dto.ts
+++ b/backend/src/project/dto/ProjectJoinRequest-Request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class ProjectJoinRequestRequestDto {
+  @IsNotEmpty()
+  @IsUUID(4, { message: 'not uuid' })
+  inviteLinkId: string;
+}

--- a/backend/src/project/entity/project-join-request.entity.ts
+++ b/backend/src/project/entity/project-join-request.entity.ts
@@ -1,0 +1,56 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+import { Member } from 'src/member/entity/member.entity';
+
+@Entity()
+@Unique('PROJECT_JOIN_REQUEST_UQ_PROJECT_ID_AND_MEMBER_ID', [
+  'projectId',
+  'memberId',
+])
+export class ProjectJoinRequest {
+  @PrimaryGeneratedColumn('increment', { type: 'int' })
+  id: number;
+
+  @ManyToOne(() => Project, (project) => project.joinRequestList, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @Column({ type: 'int', name: 'project_id' })
+  projectId: number;
+
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @ManyToOne(() => Member)
+  @Column({ type: 'int', name: 'member_id' })
+  memberId: number;
+
+  @ManyToOne(() => Member, (member) => member.id, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'member_id' })
+  member: Member;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  static of(projectId: number, memberId: number) {
+    const projectJoinRequest = new ProjectJoinRequest();
+    projectJoinRequest.projectId = projectId;
+    projectJoinRequest.memberId = memberId;
+    return projectJoinRequest;
+  }
+}

--- a/backend/src/project/entity/project.entity.ts
+++ b/backend/src/project/entity/project.entity.ts
@@ -6,12 +6,12 @@ import {
   UpdateDateColumn,
   OneToMany,
   Generated,
-  JoinColumn,
 } from 'typeorm';
 import { Epic } from './epic.entity';
 import { Link } from './link.entity.';
 import { Memo } from './memo.entity';
 import { ProjectToMember } from './project-member.entity';
+import { ProjectJoinRequest } from './project-join-request.entity';
 
 @Entity()
 export class Project {
@@ -51,6 +51,9 @@ export class Project {
 
   @OneToMany(() => Epic, (epic) => epic.project)
   epicList: Epic[];
+
+  @OneToMany(() => ProjectJoinRequest, (JoinRequest) => JoinRequest.project)
+  joinRequestList: ProjectJoinRequest[];
 
   static of(title: string, subject: string) {
     const newProject = new Project();

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -16,6 +16,7 @@ import { JoinProjectRequestDto } from './dto/JoinProjectRequest.dto';
 import { Response } from 'express';
 import { ProjectWebsocketGateway } from './websocket.gateway';
 import { ProjectInvitePreviewResponseDto } from './dto/ProjectInvitePreviewResponse.dto';
+import { ProjectJoinRequestRequestDto } from './dto/ProjectJoinRequest-Request.dto';
 
 @Controller('project')
 export class ProjectController {
@@ -82,6 +83,30 @@ export class ProjectController {
       project.id,
       request.member,
     );
+    return response.status(201).send();
+  }
+
+  @Post('/join-request')
+  async submitProjectJoinRequest(
+    @Req() request: MemberRequest,
+    @Body() body: ProjectJoinRequestRequestDto,
+    @Res() response: Response,
+  ) {
+    try {
+      await this.projectService.createProjectJoinRequest(
+        body.inviteLinkId,
+        request.member,
+      );
+    } catch (e) {
+      if (e.message === 'Join request already submitted') {
+        throw new ConflictException(e.message);
+      } else if (e.message === 'Already a project member') {
+        throw new ConflictException(e.message);
+      } else if (e.message === 'Project not found') {
+        throw new NotFoundException(e.message);
+      }
+    }
+
     return response.status(201).send();
   }
 

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -24,6 +24,7 @@ import { Task } from './entity/task.entity';
 import { WsProjectTaskController } from './ws-controller/ws-project-task.controller';
 import { WsProjectInfoController } from './ws-controller/ws-project-info.controller';
 import { WsProjectInviteLinkController } from './ws-controller/ws-project-invite-link.controller';
+import { ProjectJoinRequest } from './entity/project-join-request.entity';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { WsProjectInviteLinkController } from './ws-controller/ws-project-invite
       Epic,
       Story,
       Task,
+      ProjectJoinRequest,
     ]),
   ],
   controllers: [ProjectController],

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -10,6 +10,7 @@ import { Epic, EpicColor } from './entity/epic.entity';
 import { Story, StoryStatus } from './entity/story.entity';
 import { Task, TaskStatus } from './entity/task.entity';
 import { MemberRole } from './enum/MemberRole.enum';
+import { ProjectJoinRequest } from './entity/project-join-request.entity';
 
 @Injectable()
 export class ProjectRepository {
@@ -30,6 +31,8 @@ export class ProjectRepository {
     private readonly storyRepository: Repository<Story>,
     @InjectRepository(Task)
     private readonly taskRepository: Repository<Task>,
+    @InjectRepository(ProjectJoinRequest)
+    private readonly projectJoinRequestRepository: Repository<ProjectJoinRequest>,
     private readonly dataSource: DataSource,
   ) {}
 
@@ -101,6 +104,23 @@ export class ProjectRepository {
       { inviteLinkId: newInviteLinkId },
     );
     return !!result.affected;
+  }
+
+  async createProjectJoinRequest(
+    projectJoinRequest: ProjectJoinRequest,
+  ): Promise<ProjectJoinRequest> {
+    try {
+      return await this.projectJoinRequestRepository.save(projectJoinRequest);
+    } catch (e) {
+      if (
+        e.code === 'ER_DUP_ENTRY' &&
+        e.sqlMessage.includes(
+          'PROJECT_JOIN_REQUEST_UQ_PROJECT_ID_AND_MEMBER_ID',
+        )
+      )
+        throw new Error('DUPLICATED PROJECT ID AND MEMBER ID');
+      throw e;
+    }
   }
 
   getProject(projectId: number): Promise<Project | null> {

--- a/backend/test/project/post-join-request.e2e-spec.ts
+++ b/backend/test/project/post-join-request.e2e-spec.ts
@@ -1,0 +1,168 @@
+import * as request from 'supertest';
+import {
+  app,
+  appInit,
+  createMember,
+  createProject,
+  getProjectLinkId,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+
+describe('Join Request In Project', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+
+  it('should return 201 when join request is successfully submitted', async () => {
+    const { accessToken: accessToken1 } = await createMember(
+      memberFixture,
+      app,
+    );
+    const { accessToken: accessToken2 } = await createMember(
+      memberFixture2,
+      app,
+    );
+    const { id: projectId } = await createProject(
+      accessToken1,
+      projectPayload,
+      app,
+    );
+    const inviteLinkId = await getProjectLinkId(accessToken1, projectId);
+    const response = await postJoinRequest(accessToken2, inviteLinkId);
+    expectCreated(response);
+  });
+
+  it('should return 400 when given bad request', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const response = await postJoinRequestWithInvalidProperty(accessToken);
+    expectBadRequest(response);
+  });
+
+  it('should return 401 (Bearer Token is missing)', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const inviteLinkId = await getProjectLinkId(accessToken, projectId);
+    const response = await postJoinRequestWithoutAccessToken(inviteLinkId);
+    expectMissingBearerToken(response);
+  });
+
+  it('should return 401 (Expired:accessToken) when given invalid access token', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const inviteLinkId = await getProjectLinkId(accessToken, projectId);
+    const response = await postJoinRequest('invalidToken', inviteLinkId);
+    expectExpiredToken(response);
+  });
+
+  it('should return 404 when project link ID is not found', async () => {
+    const invalidUUID = 'c93a87e8-a0a4-4b55-bdf2-59bf691f5c37';
+    const { accessToken } = await createMember(memberFixture2, app);
+    const response = await postJoinRequest(accessToken, invalidUUID);
+    expectNotFound(response);
+  });
+
+  it('should return 409 when already joined member', async () => {
+    const { accessToken } = await createMember(memberFixture, app);
+    const { id: projectId } = await createProject(
+      accessToken,
+      projectPayload,
+      app,
+    );
+    const inviteLinkId = await getProjectLinkId(accessToken, projectId);
+    const response = await postJoinRequest(accessToken, inviteLinkId);
+    expectAlreadyMember(response);
+  });
+
+  it('should return 409 when already submit join request', async () => {
+    const { accessToken: accessToken1 } = await createMember(
+      memberFixture,
+      app,
+    );
+    const { accessToken: accessToken2 } = await createMember(
+      memberFixture2,
+      app,
+    );
+
+    const { id: projectId } = await createProject(
+      accessToken1,
+      projectPayload,
+      app,
+    );
+    const inviteLinkId = await getProjectLinkId(accessToken1, projectId);
+    await postJoinRequest(accessToken2, inviteLinkId);
+    const response = await postJoinRequest(accessToken2, inviteLinkId);
+    expectAlreadySubmit(response);
+  });
+});
+
+function postJoinRequest(
+  accessToken: string,
+  inviteLinkId: string,
+): Promise<request.Response> {
+  return request(app.getHttpServer())
+    .post('/api/project/join-request')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({ inviteLinkId });
+}
+
+function postJoinRequestWithInvalidProperty(
+  accessToken: string,
+): Promise<request.Response> {
+  return request(app.getHttpServer())
+    .post('/api/project/join-request')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({ invalidProperty: 'invalidProperty' });
+}
+
+function postJoinRequestWithoutAccessToken(
+  inviteLinkId: string,
+): Promise<request.Response> {
+  return request(app.getHttpServer())
+    .post('/api/project/join-request')
+    .send({ inviteLinkId });
+}
+
+function expectNotFound(response: request.Response) {
+  expect(response.status).toBe(404);
+}
+
+function expectCreated(response: request.Response) {
+  expect(response.status).toBe(201);
+}
+
+function expectBadRequest(response: request.Response) {
+  expect(response.status).toBe(400);
+}
+
+function expectMissingBearerToken(response: request.Response) {
+  expect(response.status).toBe(401);
+  expect(response.body.message).toBe('Bearer Token is missing');
+}
+
+function expectAlreadyMember(response: request.Response) {
+  expect(response.status).toBe(409);
+  expect(response.body.message).toBe('Already a project member');
+}
+
+function expectAlreadySubmit(response: request.Response) {
+  expect(response.status).toBe(409);
+  expect(response.body.message).toBe('Join request already submitted');
+}
+
+function expectExpiredToken(response: request.Response) {
+  expect(response.status).toBe(401);
+  expect(response.body.message).toBe('Expired:accessToken');
+}


### PR DESCRIPTION
## 🎟️ 태스크

[프로젝트 참여 요청 API 구현](https://plastic-toad-cb0.notion.site/API-106f5552133380b79c8de9737aa49c8a?pvs=74)

## ✅ 작업 내용

- 엔티티
  - 프로젝트 참여요청 엔티티 추가
  - 프로젝트 엔티티에 프로젝트 참여요청 프로퍼티 추가
- 레포지토리에서 DB에 프로젝트 참여요청 생성 메서드 추가
- 서비스에서 프로젝트 참여요청 생성 메서드 추가
- 컨트롤러에서 프로젝트 참여요청 제출 메서드 추가
- 프로젝트 참여요청 E2E 테스트 추가
  - 성공 상황
  - 인증실패 상황
  - 유효하지 않은 프로젝트 링크 상황
  - 이미 회원인 유저가 요청한 상황
  - 이미 참여요청한 유저가 다시 참여요청한 상황

## 🤔 고민 및 의논할 거리
- E2E 테스트를 보다 잘 읽히도록 함수내의 추상화 수준을 동일하게 작성하려고 시도해보았습니다. 확실히 소설처럼 쭉 읽으면 어떤 로직인지 파악할 수 있어 괜찮은것같습니당. 앞으로 테스트 뿐만 아니라 모든 코드를 추상화 수준을 신경써서 작성하면 가독성 측면에서 많은 향상이 있을것같아요. 감사합니다~