### PR TITLE
feat: 참여 요청 기능 구현, 초대 링크 변경 기능 구현

### DIFF
--- a/frontend/src/apis/api/inviteAPI.ts
+++ b/frontend/src/apis/api/inviteAPI.ts
@@ -1,0 +1,10 @@
+import { API_URL } from "../../constants/path";
+import { authAPI } from "../utils/authAPI";
+
+export const getInvitePreview = async (inviteLinkId: string) => {
+  const response = await authAPI.get(
+    `${API_URL.INVITE_PREVIEW}/${inviteLinkId}`
+  );
+
+  return response;
+};

--- a/frontend/src/components/landing/member/LandingMember.tsx
+++ b/frontend/src/components/landing/member/LandingMember.tsx
@@ -73,6 +73,12 @@ const LandingMember = ({ projectTitle }: LandingMemberProps) => {
     });
   }
 
+  const handleChangeInviteLinkClick = () => {
+    console.log("Asdfsdf");
+
+    socket.emit("inviteLink", { action: "update", content: {} });
+  };
+
   return (
     <div className="w-full px-6 py-6 overflow-y-scroll rounded-lg shadow-box bg-gradient-to-tr to-light-green-linear-from from-light-green scrollbar-thin scrollbar-thumb-light-green scrollbar-track-transparent scrollbar-thumb-rounded-full">
       <div className="flex flex-col gap-3">
@@ -103,7 +109,10 @@ const LandingMember = ({ projectTitle }: LandingMemberProps) => {
                 초대링크 복사
               </button>
               <span>|</span>
-              <button className="text-xxs hover:underline" onClick={() => {}}>
+              <button
+                className="text-xxs hover:underline"
+                onClick={handleChangeInviteLinkClick}
+              >
                 링크 변경
               </button>
             </div>

--- a/frontend/src/components/landing/project/LandingProject.tsx
+++ b/frontend/src/components/landing/project/LandingProject.tsx
@@ -4,6 +4,7 @@ import LandingProjectLink from "./LandingProjectLink";
 import { useOutletContext } from "react-router-dom";
 
 import useLandingProjectSocket from "../../../hooks/common/landing/useLandingProjectSocket";
+import useMemberStore from "../../../stores/useMemberStore";
 
 interface LandingProjectProps {
   projectId: string;
@@ -12,6 +13,7 @@ interface LandingProjectProps {
 const LandingProject = ({ projectId }: LandingProjectProps) => {
   const { socket }: { socket: Socket } = useOutletContext();
   const { project } = useLandingProjectSocket(socket);
+  const { role } = useMemberStore((state) => state.myInfo);
 
   return (
     <div className="flex flex-col justify-between w-full p-6 rounded-lg shadow-box">
@@ -22,10 +24,12 @@ const LandingProject = ({ projectId }: LandingProjectProps) => {
         </p>
       </div>
       <div className="text-xs">{project.subject}</div>
-      <div className="flex justify-between">
+      <div className="flex justify-between gap-4">
         <LandingProjectLink projectId={projectId} type="BACKLOG" />
         <LandingProjectLink projectId={projectId} type="SPRINT" />
-        <LandingProjectLink projectId={projectId} type="SETTINGS" />
+        {role === "LEADER" && (
+          <LandingProjectLink projectId={projectId} type="SETTINGS" />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/landing/project/LandingProjectLink.tsx
+++ b/frontend/src/components/landing/project/LandingProjectLink.tsx
@@ -12,7 +12,7 @@ const LandingProjectLink = ({ projectId, type }: LandingProjectLinkProps) => {
   return (
     <Link
       to={LINK_URL.BACKLOG(projectId)}
-      className={`w-[8.75rem] h-[5rem] rounded-lg flex justify-center gap-2 items-center ${color} hover:shadow-button`}
+      className={`w-full h-[5rem] rounded-lg flex justify-center gap-2 items-center ${color} hover:shadow-button`}
     >
       <Icon height={36} width={36} fill="#FFFFFF" />
       <div className="flex flex-col items-center gap-0 text-white text-[1rem] font-semibold">

--- a/frontend/src/components/main/PageLinkIcons.tsx
+++ b/frontend/src/components/main/PageLinkIcons.tsx
@@ -5,34 +5,41 @@ import SprintIcon from "../../assets/icons/sprint.svg?react";
 import SettingIcon from "../../assets/icons/settings.svg?react";
 import { LINK_URL } from "../../constants/path";
 import { ProjectSidebarProps } from "../../types/common/main";
+import useMemberStore from "../../stores/useMemberStore";
 
-const PageLinkIcons = ({ pathname, projectId }: ProjectSidebarProps) => (
-  <div className="flex flex-col pl-[0.9375rem] pt-[1.5625rem] w-[5.3125rem] gap-5">
-    <PageIcon
-      Icon={LandingIcon}
-      activated={pathname === LINK_URL.MAIN(projectId)}
-      to={LINK_URL.MAIN(projectId)}
-      pageName="메인페이지"
-    />
-    <PageIcon
-      Icon={BacklogIcon}
-      activated={pathname.split("/").includes("backlog")}
-      to={LINK_URL.BACKLOG(projectId)}
-      pageName="백로그"
-    />
-    <PageIcon
-      Icon={SprintIcon}
-      activated={pathname === LINK_URL.SPRINT(projectId)}
-      to={LINK_URL.SPRINT(projectId)}
-      pageName="스프린트"
-    />
-    <PageIcon
-      Icon={SettingIcon}
-      activated={pathname === LINK_URL.SETTINGS(projectId)}
-      to={LINK_URL.SETTINGS(projectId)}
-      pageName="프로젝트 설정"
-    />
-  </div>
-);
+const PageLinkIcons = ({ pathname, projectId }: ProjectSidebarProps) => {
+  const { role } = useMemberStore((state) => state.myInfo);
+
+  return (
+    <div className="flex flex-col pl-[0.9375rem] pt-[1.5625rem] w-[5.3125rem] gap-5">
+      <PageIcon
+        Icon={LandingIcon}
+        activated={pathname === LINK_URL.MAIN(projectId)}
+        to={LINK_URL.MAIN(projectId)}
+        pageName="메인페이지"
+      />
+      <PageIcon
+        Icon={BacklogIcon}
+        activated={pathname.split("/").includes("backlog")}
+        to={LINK_URL.BACKLOG(projectId)}
+        pageName="백로그"
+      />
+      <PageIcon
+        Icon={SprintIcon}
+        activated={pathname === LINK_URL.SPRINT(projectId)}
+        to={LINK_URL.SPRINT(projectId)}
+        pageName="스프린트"
+      />
+      {role === "LEADER" && (
+        <PageIcon
+          Icon={SettingIcon}
+          activated={pathname === LINK_URL.SETTINGS(projectId)}
+          to={LINK_URL.SETTINGS(projectId)}
+          pageName="프로젝트 설정"
+        />
+      )}
+    </div>
+  );
+};
 
 export default PageLinkIcons;

--- a/frontend/src/components/setting/JoinRequestBlock.tsx
+++ b/frontend/src/components/setting/JoinRequestBlock.tsx
@@ -15,12 +15,20 @@ const JoinRequestBlock = ({ username, imageUrl }: JoinRequestBlockProps) => {
       <div className="w-[18.75rem]"></div>
       <div className="w-[30rem]">
         {myRole === "LEADER" && (
-          <button
-            className="px-2 py-1 text-white rounded w-fit bg-error-red text-xxs"
-            type="button"
-          >
-            프로젝트에서 제거
-          </button>
+          <>
+            <button
+              className="px-2 py-1 text-white rounded w-fit text-xxs bg-middle-green"
+              type="button"
+            >
+              참여 수락
+            </button>
+            <button
+              className="px-2 py-1 text-white rounded w-fit bg-error-red text-xxs"
+              type="button"
+            >
+              참여 거절
+            </button>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/setting/JoinRequestBlock.tsx
+++ b/frontend/src/components/setting/JoinRequestBlock.tsx
@@ -1,9 +1,9 @@
 import useMemberStore from "../../stores/useMemberStore";
-import { SettingMemberDTO } from "../../types/DTO/settingDTO";
+import { SettingJoinRequestDTO } from "../../types/DTO/settingDTO";
 
-interface MemberBlockProps extends SettingMemberDTO {}
+interface JoinRequestBlockProps extends SettingJoinRequestDTO {}
 
-const MemberBlock = ({ username, imageUrl, role }: MemberBlockProps) => {
+const JoinRequestBlock = ({ username, imageUrl }: JoinRequestBlockProps) => {
   const myRole = useMemberStore((state) => state.myInfo.role);
 
   return (
@@ -12,9 +12,7 @@ const MemberBlock = ({ username, imageUrl, role }: MemberBlockProps) => {
         <img className="w-8 h-8 rounded-full" src={imageUrl} alt={username} />
         <p className="">{username}</p>
       </div>
-      <div className="w-[18.75rem]">
-        <p className="">{role}</p>
-      </div>
+      <div className="w-[18.75rem]"></div>
       <div className="w-[30rem]">
         {myRole === "LEADER" && (
           <button
@@ -29,4 +27,4 @@ const MemberBlock = ({ username, imageUrl, role }: MemberBlockProps) => {
   );
 };
 
-export default MemberBlock;
+export default JoinRequestBlock;

--- a/frontend/src/components/setting/JoinRequestBlock.tsx
+++ b/frontend/src/components/setting/JoinRequestBlock.tsx
@@ -17,7 +17,7 @@ const JoinRequestBlock = ({ username, imageUrl }: JoinRequestBlockProps) => {
         {myRole === "LEADER" && (
           <>
             <button
-              className="px-2 py-1 text-white rounded w-fit text-xxs bg-middle-green"
+              className="px-2 py-1 mr-3 text-white rounded w-fit text-xxs bg-middle-green"
               type="button"
             >
               참여 수락

--- a/frontend/src/components/setting/MemberBlock.tsx
+++ b/frontend/src/components/setting/MemberBlock.tsx
@@ -5,6 +5,7 @@ interface MemberBlockProps extends SettingMemberDTO {}
 
 const MemberBlock = ({ username, imageUrl, role }: MemberBlockProps) => {
   const myRole = useMemberStore((state) => state.myInfo.role);
+  const myUserName = useMemberStore((state) => state.myInfo.username);
 
   return (
     <div className="flex w-full gap-3">
@@ -16,7 +17,7 @@ const MemberBlock = ({ username, imageUrl, role }: MemberBlockProps) => {
         <p className="">{role}</p>
       </div>
       <div className="w-[30rem]">
-        {myRole === "LEADER" && (
+        {myRole === "LEADER" && myUserName !== username && (
           <button
             className="px-2 py-1 text-white rounded w-fit bg-error-red text-xxs"
             type="button"

--- a/frontend/src/components/setting/MemberSettingSection.tsx
+++ b/frontend/src/components/setting/MemberSettingSection.tsx
@@ -1,11 +1,19 @@
-import { LandingMemberDTO } from "../../types/DTO/landingDTO";
+import JoinRequestBlock from "./JoinRequestBlock";
 import MemberBlock from "./MemberBlock";
+import {
+  SettingJoinRequestDTO,
+  SettingMemberDTO,
+} from "../../types/DTO/settingDTO";
 
 interface MemberSettingSectionProps {
-  memberList: LandingMemberDTO[];
+  memberList: SettingMemberDTO[];
+  joinRequestList: SettingJoinRequestDTO[];
 }
 
-const MemberSettingSection = ({ memberList }: MemberSettingSectionProps) => (
+const MemberSettingSection = ({
+  memberList,
+  joinRequestList,
+}: MemberSettingSectionProps) => (
   <div className="mb-5">
     <div className="mb-2">
       <p className="font-bold text-m text-middle-green">멤버 관리</p>
@@ -18,6 +26,7 @@ const MemberSettingSection = ({ memberList }: MemberSettingSectionProps) => (
       </div>
       <div className="flex flex-col gap-3 overflow-y-auto scrollbar-thin">
         {...memberList.map((member) => <MemberBlock {...member} />)}
+        {...joinRequestList.map((request) => <JoinRequestBlock {...request} />)}
       </div>
     </div>
   </div>

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -9,7 +9,7 @@ export const API_URL = {
   NICKNAME_AVAILABLILITY: "/member/availability",
   GITHUB_USERNAME: "/auth/github/username",
   PROJECT: "/project",
-  PROJECT_JOIN: "/project/join",
+  PROJECT_JOIN: "/project/join-request",
 };
 
 export const ROUTER_URL = {

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -10,6 +10,7 @@ export const API_URL = {
   GITHUB_USERNAME: "/auth/github/username",
   PROJECT: "/project",
   PROJECT_JOIN: "/project/join-request",
+  INVITE_PREVIEW: "/project/invite-preview",
 };
 
 export const ROUTER_URL = {

--- a/frontend/src/hooks/common/member/useUpdateUserStatus.ts
+++ b/frontend/src/hooks/common/member/useUpdateUserStatus.ts
@@ -3,6 +3,7 @@ import { Socket } from "socket.io-client";
 import {
   LandingSocketData,
   LandingSocketDomain,
+  LandingSocketInviteLinkAction,
   LandingSocketMemberAction,
 } from "../../../types/common/landing";
 import { LandingDTO, LandingMemberDTO } from "../../../types/DTO/landingDTO";
@@ -76,6 +77,16 @@ const useUpdateUserStatus = (
     }
   };
 
+  const handleInviteLinkEvent = (
+    action: LandingSocketInviteLinkAction,
+    content: { inviteLinkId: string }
+  ) => {
+    if (action === "update") {
+      alert("초대링크가 변경되었습니다.");
+      inviteLinkIdRef.current = content.inviteLinkId;
+    }
+  };
+
   const handleOnLanding = ({ domain, action, content }: LandingSocketData) => {
     switch (domain) {
       case LandingSocketDomain.INIT:
@@ -83,6 +94,9 @@ const useUpdateUserStatus = (
         break;
       case LandingSocketDomain.MEMBER:
         handleMemberEvent(action, content);
+        break;
+      case LandingSocketDomain.INVITE_LINK:
+        handleInviteLinkEvent(action, content);
         break;
     }
   };

--- a/frontend/src/hooks/common/socket/useSocket.ts
+++ b/frontend/src/hooks/common/socket/useSocket.ts
@@ -24,7 +24,7 @@ const useSocket = (projectId: string) => {
       alert("프로젝트가 삭제되었습니다.");
       setTimeout(() => {
         navigate(ROUTER_URL.PROJECTS);
-      }, 1000);
+      }, 500);
     }
   };
 

--- a/frontend/src/hooks/pages/setting/useSettingSocket.ts
+++ b/frontend/src/hooks/pages/setting/useSettingSocket.ts
@@ -5,17 +5,28 @@ import {
   SettingSocketDomain,
   SettingSocketProjectInfoAction,
 } from "../../../types/common/setting";
-import { SettingDTO, SettingProjectDTO } from "../../../types/DTO/settingDTO";
+import {
+  SettingDTO,
+  SettingJoinRequestDTO,
+  SettingMemberDTO,
+  SettingProjectDTO,
+} from "../../../types/DTO/settingDTO";
 
 const useSettingSocket = (socket: Socket) => {
   const [projectInfo, setProjectInfo] = useState<SettingProjectDTO>({
     title: "",
     subject: "",
   });
+  const [memberList, setMemberList] = useState<SettingMemberDTO[]>([]);
+  const [joinRequestList, setJoinRequestList] = useState<
+    SettingJoinRequestDTO[]
+  >([]);
 
   const handleInitEvent = (content: SettingDTO) => {
-    const { project } = content;
+    const { project, member, joinRequestList } = content;
     setProjectInfo(project);
+    setMemberList(member);
+    setJoinRequestList(joinRequestList ? joinRequestList : []);
   };
 
   const handleProjectInfoEvent = (
@@ -53,7 +64,7 @@ const useSettingSocket = (socket: Socket) => {
     };
   }, []);
 
-  return { projectInfo };
+  return { projectInfo, memberList, joinRequestList };
 };
 
 export default useSettingSocket;

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -44,7 +44,7 @@ const InvitePage = () => {
 
   return (
     <div className="w-[100%] min-w-[720px] h-[720px] flex justify-center items-center">
-      <div className="w-[49.37rem] h-[31.87rem] bg-middle-green flex justify-center items-center shadow-box">
+      <div className="w-[47rem] h-[31rem] bg-middle-green flex justify-center items-center shadow-box">
         <main className="bg-white w-[42.5rem] h-[27.5rem] flex justify-center items-center">
           <div className="w-[40rem] h-[25rem] border-middle-green border px-10 py-8">
             <p className="self-start font-bold break-words text-xxl">

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -23,7 +23,7 @@ const InvitePage = () => {
 
     switch (response.status) {
       case 201:
-        alert("프로젝트에 참여되었습니다.");
+        alert("참여 요청을 보냈습니다.");
         navigate("/projects");
         break;
       case 200:
@@ -43,9 +43,16 @@ const InvitePage = () => {
       navigate(ROUTER_URL.LOGIN, { replace: true });
     }
 
-    getInvitePreview(projectUUID!).then((response) => {
-      setProjectInfo(response.data);
-    });
+    getInvitePreview(projectUUID!)
+      .then((response) => {
+        setProjectInfo(response.data);
+      })
+      .catch((error) => {
+        if (error.response.status === 404) {
+          alert("유효하지 않은 요청 링크입니다.");
+          navigate("/projects");
+        }
+      });
 
     return () => {
       if (checkAccessToken()) {

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -1,13 +1,21 @@
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { checkAccessToken } from "../../apis/utils/authAPI";
 import { ROUTER_URL } from "../../constants/path";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { STORAGE_KEY } from "../../constants/storageKey";
 import { postJoinProject } from "../../apis/api/projectAPI";
+import { InvitePreview } from "../../types/DTO/inviteDTO";
+import { getInvitePreview } from "../../apis/api/inviteAPI";
 
 const InvitePage = () => {
   const { projectTitle, projectId: projectUUID } = useParams();
   const { pathname } = useLocation();
+  const [projectInfo, setProjectInfo] = useState<InvitePreview>({
+    id: -1,
+    title: "",
+    subject: "",
+    leaderUsername: "",
+  });
   const navigate = useNavigate();
 
   const handleJoinButtonClick = async () => {
@@ -35,6 +43,10 @@ const InvitePage = () => {
       navigate(ROUTER_URL.LOGIN, { replace: true });
     }
 
+    getInvitePreview(projectUUID!).then((response) => {
+      setProjectInfo(response.data);
+    });
+
     return () => {
       if (checkAccessToken()) {
         sessionStorage.removeItem(STORAGE_KEY.REDIRECT);
@@ -48,16 +60,20 @@ const InvitePage = () => {
         <main className="bg-white w-[42.5rem] h-[27.5rem] flex justify-center items-center">
           <div className="w-[40rem] h-[25rem] border-middle-green border px-10 py-8">
             <p className="self-start font-bold break-words text-xxl">
-              Leader<span className="font-light">님의</span>
+              {projectInfo.leaderUsername}
+              <span className="font-light">님의</span>
             </p>
             <p className="self-start font-bold break-words text-xxl">
               {projectTitle}
             </p>
-            <p className="self-start mt-8">
-              leader님의 {projectTitle} 프로젝트에 참여하고 싶다면 요청을
-              보내세요.
+            <p className="mt-1">{projectInfo.subject}</p>
+            <p className="self-start mt-3 text-xs truncate">
+              {projectInfo.leaderUsername}님의 {projectInfo.title}
             </p>
-            <div className="flex flex-col w-[35rem] gap-5 mt-14">
+            <p className="text-xs">
+              프로젝트에 참여하고 싶다면 요청을 보내세요.
+            </p>
+            <div className="flex flex-col w-[35rem] gap-5 mt-8">
               <button
                 className="w-full h-[2.5rem] rounded-lg text-white bg-middle-green"
                 type="button"

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { checkAccessToken } from "../../apis/utils/authAPI";
 import { ROUTER_URL } from "../../constants/path";
 import { useEffect } from "react";
@@ -43,17 +43,37 @@ const InvitePage = () => {
   }, []);
 
   return (
-    <div className="w-[100%] min-w-[720px] h-[600px] flex justify-center items-center">
-      <main>
-        <p>프로젝트{projectTitle}에 초대되었습니다.</p>
-        <p>{projectUUID}</p>
-        <button
-          type="button"
-          className="w-[100px] h-[50px] bg-middle-green rounded text-white"
-          onClick={handleJoinButtonClick}
-        >
-          참여하기
-        </button>
+    <div className="w-[100%] min-w-[720px] h-[720px] flex justify-center items-center">
+      <main className="bg-white shadow-box w-[42.5rem] h-[27.5rem] flex justify-center items-center">
+        <div className="w-[40rem] h-[25rem] border-middle-green border px-10 py-8">
+          <p className="self-start font-bold break-words text-xxl">
+            Leader<span className="font-light">님의</span>
+          </p>
+          <p className="self-start font-bold break-words text-xxl">
+            {projectTitle}
+          </p>
+          <p className="self-start mt-8">
+            leader님의 {projectTitle} 프로젝트에 참여하고 싶다면 요청을
+            보내세요.
+          </p>
+          <div className="flex flex-col w-[35rem] gap-5 mt-14">
+            <button
+              className="w-full h-[2.5rem] rounded-lg text-white bg-middle-green"
+              type="button"
+              onClick={handleJoinButtonClick}
+            >
+              프로젝트 참여 요청
+            </button>
+            <Link to={ROUTER_URL.PROJECTS}>
+              <button
+                className="w-full h-[2.5rem] rounded-lg text-white bg-dark-gray"
+                type="button"
+              >
+                내 프로젝트
+              </button>
+            </Link>
+          </div>
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/pages/invite/InvitePage.tsx
+++ b/frontend/src/pages/invite/InvitePage.tsx
@@ -44,37 +44,39 @@ const InvitePage = () => {
 
   return (
     <div className="w-[100%] min-w-[720px] h-[720px] flex justify-center items-center">
-      <main className="bg-white shadow-box w-[42.5rem] h-[27.5rem] flex justify-center items-center">
-        <div className="w-[40rem] h-[25rem] border-middle-green border px-10 py-8">
-          <p className="self-start font-bold break-words text-xxl">
-            Leader<span className="font-light">님의</span>
-          </p>
-          <p className="self-start font-bold break-words text-xxl">
-            {projectTitle}
-          </p>
-          <p className="self-start mt-8">
-            leader님의 {projectTitle} 프로젝트에 참여하고 싶다면 요청을
-            보내세요.
-          </p>
-          <div className="flex flex-col w-[35rem] gap-5 mt-14">
-            <button
-              className="w-full h-[2.5rem] rounded-lg text-white bg-middle-green"
-              type="button"
-              onClick={handleJoinButtonClick}
-            >
-              프로젝트 참여 요청
-            </button>
-            <Link to={ROUTER_URL.PROJECTS}>
+      <div className="w-[49.37rem] h-[31.87rem] bg-middle-green flex justify-center items-center shadow-box">
+        <main className="bg-white w-[42.5rem] h-[27.5rem] flex justify-center items-center">
+          <div className="w-[40rem] h-[25rem] border-middle-green border px-10 py-8">
+            <p className="self-start font-bold break-words text-xxl">
+              Leader<span className="font-light">님의</span>
+            </p>
+            <p className="self-start font-bold break-words text-xxl">
+              {projectTitle}
+            </p>
+            <p className="self-start mt-8">
+              leader님의 {projectTitle} 프로젝트에 참여하고 싶다면 요청을
+              보내세요.
+            </p>
+            <div className="flex flex-col w-[35rem] gap-5 mt-14">
               <button
-                className="w-full h-[2.5rem] rounded-lg text-white bg-dark-gray"
+                className="w-full h-[2.5rem] rounded-lg text-white bg-middle-green"
                 type="button"
+                onClick={handleJoinButtonClick}
               >
-                내 프로젝트
+                프로젝트 참여 요청
               </button>
-            </Link>
+              <Link to={ROUTER_URL.PROJECTS}>
+                <button
+                  className="w-full h-[2.5rem] rounded-lg text-white bg-dark-gray"
+                  type="button"
+                >
+                  내 프로젝트
+                </button>
+              </Link>
+            </div>
           </div>
-        </div>
-      </main>
+        </main>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/setting/SettingPage.tsx
+++ b/frontend/src/pages/setting/SettingPage.tsx
@@ -2,38 +2,21 @@ import { Socket } from "socket.io-client";
 import InformationSettingSection from "../../components/setting/InformationSettingSection";
 import MemberSettingSection from "../../components/setting/MemberSettingSection";
 import ProjectDeleteSection from "../../components/setting/ProjectDeleteSection";
-import { LandingMemberDTO } from "../../types/DTO/landingDTO";
 import { useOutletContext } from "react-router-dom";
 import useSettingSocket from "../../hooks/pages/setting/useSettingSocket";
-
-const memberList: LandingMemberDTO[] = [
-  { id: 1, username: "lesserTest", role: "LEADER", imageUrl: "", status: "on" },
-  {
-    id: 2,
-    username: "lesserTest2",
-    role: "MEMBER",
-    imageUrl: "",
-    status: "on",
-  },
-  {
-    id: 3,
-    username: "lesserTest3",
-    role: "MEMBER",
-    imageUrl: "",
-    status: "on",
-  },
-];
 
 const SettingPage = () => {
   const { socket }: { socket: Socket } = useOutletContext();
   const {
     projectInfo: { title, subject },
+    memberList,
+    joinRequestList,
   } = useSettingSocket(socket);
 
   return (
     <div className="w-full h-full">
       <InformationSettingSection {...{ title, subject }} />
-      <MemberSettingSection memberList={memberList} />
+      <MemberSettingSection {...{ joinRequestList, memberList }} />
       <ProjectDeleteSection projectTitle={title} />
     </div>
   );

--- a/frontend/src/types/DTO/inviteDTO.ts
+++ b/frontend/src/types/DTO/inviteDTO.ts
@@ -1,0 +1,6 @@
+export interface InvitePreview {
+  id: number;
+  title: string;
+  subject: string;
+  leaderUsername: string;
+}

--- a/frontend/src/types/DTO/settingDTO.ts
+++ b/frontend/src/types/DTO/settingDTO.ts
@@ -12,7 +12,15 @@ export interface SettingMemberDTO {
   role: MemberRole;
 }
 
+export interface SettingJoinRequestDTO {
+  id: number;
+  memberId: number;
+  username: string;
+  imageUrl: string;
+}
+
 export interface SettingDTO {
   project: SettingProjectDTO;
   member: SettingMemberDTO[];
+  joinRequestList: SettingJoinRequestDTO[];
 }

--- a/frontend/src/types/common/landing.ts
+++ b/frontend/src/types/common/landing.ts
@@ -10,6 +10,7 @@ export enum LandingSocketDomain {
   MEMO = "memo",
   MEMBER = "member",
   LINK = "link",
+  INVITE_LINK = "inviteLink",
 }
 
 export enum LandingSocketMemoAction {
@@ -28,6 +29,10 @@ export enum LandingSocketLinkAction {
   CREATE = "create",
   UPDATE = "update",
   DELETE = "delete",
+}
+
+export enum LandingSocketInviteLinkAction {
+  UPDATE = "update",
 }
 
 interface LandingSocketInitData {
@@ -54,11 +59,18 @@ interface LandingSocketLinkData {
   content: LandingLinkDTO;
 }
 
+interface LandingSocketInviteLinkData {
+  domain: LandingSocketDomain.INVITE_LINK;
+  action: LandingSocketInviteLinkAction;
+  content: { inviteLinkId: string };
+}
+
 export type LandingSocketData =
   | LandingSocketInitData
   | LandingSocketMemoData
   | LandingSocketMemberData
-  | LandingSocketLinkData;
+  | LandingSocketLinkData
+  | LandingSocketInviteLinkData;
 
 export enum MemoColorStyle {
   yellow = "bg-[#FFD966]",


### PR DESCRIPTION
## 🎟️ 태스크

- [프로젝트 참여 요청 API 연결](https://plastic-toad-cb0.notion.site/API-b89b73a865564996acc78e9c1d0ba437)
- [초대 페이지 UI 구현](https://plastic-toad-cb0.notion.site/UI-6fd64ed637764623836217c9003b8c51)
- [초대링크 변경 API 연결](https://plastic-toad-cb0.notion.site/API-dd97ca20ea114377aa9ddeaf7939c582)

## ✅ 작업 내용

- 초대링크 변경 API 연결
- 초대 페이지 UI 구현
- 프로젝트 참여 요청 API 연결

## 🖊️ 구체적인 작업

### 프로젝트 참여 요청 API 연결

- 세팅 페이지 버튼은 리더에게만 보이도록 하였으며, 세팅페이지에 입장 시 프로젝트에 참여한 멤버와 초대 요청을 보낸 멤버를 볼 수 있도록 했습니다.
- 팀장에 대한 작업 버튼은 보이지 않도록 했습니다.