### PR TITLE
feat: 설정 페이지 API에 프로젝트 참여요청 정보 추가

### DIFF
--- a/backend/src/project/dto/setting-page/CreateJoinRequestNotify.dto.ts
+++ b/backend/src/project/dto/setting-page/CreateJoinRequestNotify.dto.ts
@@ -1,0 +1,48 @@
+import { Member } from 'src/member/entity/member.entity';
+import { ProjectJoinRequest } from 'src/project/entity/project-join-request.entity';
+
+class JoinRequestDto {
+  id: number;
+  memberId: number;
+  username: string;
+  imageUrl: string;
+
+  static of(
+    projectJoinRequest: ProjectJoinRequest,
+    member: Member,
+  ): JoinRequestDto {
+    const dto = new JoinRequestDto();
+    dto.id = projectJoinRequest.id;
+    dto.memberId = member.id;
+    dto.username = member.username;
+    dto.imageUrl = member.github_image_url;
+    return dto;
+  }
+}
+
+class ContentDto {
+  joinRequest: JoinRequestDto;
+
+  static of(joinRequest: ProjectJoinRequest, member: Member): ContentDto {
+    const dto = new ContentDto();
+    dto.joinRequest = JoinRequestDto.of(joinRequest, member);
+    return dto;
+  }
+}
+
+export class CreateJoinRequestNotifyDto {
+  domain: string;
+  action: string;
+  content: ContentDto;
+
+  static of(
+    joinRequest: ProjectJoinRequest,
+    member: Member,
+  ): CreateJoinRequestNotifyDto {
+    const dto = new CreateJoinRequestNotifyDto();
+    dto.domain = 'joinRequest';
+    dto.action = 'create';
+    dto.content = ContentDto.of(joinRequest, member);
+    return dto;
+  }
+}

--- a/backend/src/project/dto/setting-page/InitSettingResponse.dto.ts
+++ b/backend/src/project/dto/setting-page/InitSettingResponse.dto.ts
@@ -1,4 +1,5 @@
 import { Member } from 'src/member/entity/member.entity';
+import { ProjectJoinRequest } from 'src/project/entity/project-join-request.entity';
 import { Project } from 'src/project/entity/project.entity';
 import { MemberRole } from 'src/project/enum/MemberRole.enum';
 
@@ -30,14 +31,38 @@ class ProjectDto {
   }
 }
 
+class JoinRequestListDto {
+  id: number;
+  memberId: number;
+  username: string;
+  imageUrl: string;
+
+  static of(projectJoinRequest: ProjectJoinRequest): JoinRequestListDto {
+    const dto = new JoinRequestListDto();
+    dto.id = projectJoinRequest.id;
+    dto.memberId = projectJoinRequest.memberId;
+    dto.username = projectJoinRequest.member.username;
+    dto.imageUrl = projectJoinRequest.member.github_image_url;
+    return dto;
+  }
+}
+
 class ProjectInfoDto {
   project: ProjectDto;
   member: ProjectMemberDto[];
+  joinRequestList: JoinRequestListDto[];
 
-  static of(project: Project, memberList: Member[]): ProjectInfoDto {
+  static of(
+    project: Project,
+    memberList: Member[],
+    joinRequestList: ProjectJoinRequest[],
+  ): ProjectInfoDto {
     const dto = new ProjectInfoDto();
     dto.project = ProjectDto.of(project);
     dto.member = memberList.map((member) => ProjectMemberDto.of(member));
+    dto.joinRequestList = joinRequestList.map((joinRequest) =>
+      JoinRequestListDto.of(joinRequest),
+    );
     return dto;
   }
 }
@@ -47,11 +72,15 @@ export class InitSettingResponseDto {
   action: string;
   content: ProjectInfoDto;
 
-  static of(project: Project, memberList: Member[]): InitSettingResponseDto {
+  static of(
+    project: Project,
+    memberList: Member[],
+    joinRequestList: ProjectJoinRequest[],
+  ): InitSettingResponseDto {
     const dto = new InitSettingResponseDto();
     dto.domain = 'setting';
     dto.action = 'init';
-    dto.content = ProjectInfoDto.of(project, memberList);
+    dto.content = ProjectInfoDto.of(project, memberList, joinRequestList);
     return dto;
   }
 }

--- a/backend/src/project/project.controller.ts
+++ b/backend/src/project/project.controller.ts
@@ -93,8 +93,13 @@ export class ProjectController {
     @Res() response: Response,
   ) {
     try {
-      await this.projectService.createProjectJoinRequest(
-        body.inviteLinkId,
+      const projectJoinRequest =
+        await this.projectService.createProjectJoinRequest(
+          body.inviteLinkId,
+          request.member,
+        );
+      this.projectWebsocketGateway.notifyCreateJoinRequestToSettingPage(
+        projectJoinRequest,
         request.member,
       );
     } catch (e) {

--- a/backend/src/project/project.repository.ts
+++ b/backend/src/project/project.repository.ts
@@ -123,6 +123,15 @@ export class ProjectRepository {
     }
   }
 
+  async getProjectJoinRequestListWithMember(
+    projectId: number,
+  ): Promise<ProjectJoinRequest[]> {
+    return this.projectJoinRequestRepository.find({
+      where: { projectId },
+      relations: { member: true },
+    });
+  }
+
   getProject(projectId: number): Promise<Project | null> {
     return this.projectRepository.findOne({ where: { id: projectId } });
   }

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -154,7 +154,7 @@ export class ProjectService {
   async createProjectJoinRequest(
     inviteLinkId: string,
     member: Member,
-  ): Promise<void> {
+  ): Promise<ProjectJoinRequest> {
     const project = await this.getProjectByLinkId(inviteLinkId);
     if (!project) throw new Error('Project not found');
     const isProjectMember = await this.isProjectMember(project.id, member);
@@ -164,9 +164,11 @@ export class ProjectService {
         project.id,
         member.id,
       );
-      await this.projectRepository.createProjectJoinRequest(
-        newProjectJoinRequest,
-      );
+      const projectJoinRequest =
+        await this.projectRepository.createProjectJoinRequest(
+          newProjectJoinRequest,
+        );
+      return projectJoinRequest;
     } catch (e) {
       if (e.message === 'DUPLICATED PROJECT ID AND MEMBER ID') {
         throw new Error('Join request already submitted');

--- a/backend/src/project/service/project.service.ts
+++ b/backend/src/project/service/project.service.ts
@@ -174,6 +174,21 @@ export class ProjectService {
     }
   }
 
+  async getProjectJoinRequestList(
+    projectId: number,
+    member: Member,
+  ): Promise<ProjectJoinRequest[]> {
+    if (!(await this.isExistProject(projectId))) {
+      throw new Error('Project not found');
+    }
+    if (!(await this.isProjectLeader(projectId, member))) {
+      throw new Error('Member is not the project leader');
+    }
+    return this.projectRepository.getProjectJoinRequestListWithMember(
+      projectId,
+    );
+  }
+
   async createMemo(project: Project, member: Member, color: memoColor) {
     const newMemo = Memo.of(project, member, '', '', color);
     return this.projectRepository.createMemo(newMemo);

--- a/backend/src/project/websocket.gateway.ts
+++ b/backend/src/project/websocket.gateway.ts
@@ -23,6 +23,8 @@ import { WsProjectStoryController } from './ws-controller/ws-project-story.contr
 import { WsProjectTaskController } from './ws-controller/ws-project-task.controller';
 import { WsProjectInfoController } from './ws-controller/ws-project-info.controller';
 import { WsProjectInviteLinkController } from './ws-controller/ws-project-invite-link.controller';
+import { ProjectJoinRequest } from './entity/project-join-request.entity';
+import { CreateJoinRequestNotifyDto } from './dto/setting-page/CreateJoinRequestNotify.dto';
 
 @WebSocketGateway({
   namespace: /project-\d+/,
@@ -210,6 +212,22 @@ export class ProjectWebsocketGateway
 
   deleteProjectFromNamespaceMap(projectId: number) {
     this.namespaceMap.delete(projectId);
+  }
+
+  notifyCreateJoinRequestToSettingPage(
+    projectJoinRequest: ProjectJoinRequest,
+    member: Member,
+  ) {
+    const projectNamespace = this.namespaceMap.get(
+      projectJoinRequest.projectId,
+    );
+    if (!projectNamespace) return;
+    projectNamespace
+      .to('setting')
+      .emit(
+        'setting',
+        CreateJoinRequestNotifyDto.of(projectJoinRequest, member),
+      );
   }
 
   notifyJoinToConnectedMembers(projectId: number, member: Member) {

--- a/backend/src/project/ws-controller/ws-project.controller.ts
+++ b/backend/src/project/ws-controller/ws-project.controller.ts
@@ -79,14 +79,18 @@ export class WsProjectController {
     client.leave('backlog');
     client.join('setting');
 
-    const [project, projectMemberList] = await Promise.all([
+    const [project, projectMemberList, joinRequestList] = await Promise.all([
       this.projectService.getProject(client.projectId, client.member),
       this.projectService.getProjectMemberList(client.project),
+      this.projectService.getProjectJoinRequestList(
+        client.projectId,
+        client.member,
+      ),
     ]);
 
     client.emit(
       'setting',
-      InitSettingResponseDto.of(project, projectMemberList),
+      InitSettingResponseDto.of(project, projectMemberList, joinRequestList),
     );
   }
 }

--- a/backend/test/project/ws-setting-page/ws-join-request-setting-page.e2e-spec.ts
+++ b/backend/test/project/ws-setting-page/ws-join-request-setting-page.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { Socket } from 'socket.io-client';
+import * as request from 'supertest';
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getMemberByAccessToken,
+  getProjectLinkId,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import { Member } from 'src/member/entity/member.entity';
+
+describe('WS Setting', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+
+  it('should return join request data when leader enters setting page', async () => {
+    const { accessToken: leaderAccessToken } = await createMember(
+      memberFixture,
+      app,
+    );
+
+    const { id: projectId } = await createProject(
+      leaderAccessToken,
+      projectPayload,
+      app,
+    );
+
+    const { accessToken: requestingAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+
+    await submitJoinRequest(
+      leaderAccessToken,
+      projectId,
+      requestingAccessToken,
+    );
+    const requestingMember = await getMemberByAccessToken(
+      requestingAccessToken,
+    );
+
+    const leaderSocket = await enterSettingPage(projectId, leaderAccessToken);
+    await expectJoinRequestList(leaderSocket, requestingMember);
+    closePage(leaderSocket);
+  });
+
+  async function enterSettingPage(projectId: number, accessToken: string) {
+    const socket = connectServer(projectId, accessToken);
+    socket.emit('joinSetting');
+    return socket;
+  }
+
+  async function expectJoinRequestList(
+    socket: Socket,
+    requestingMember: Member,
+  ) {
+    return new Promise<void>((resolve) => {
+      socket.on('setting', (data) => {
+        const { action, domain, content } = data;
+        expect(domain).toBe('setting');
+        expect(action).toBe('init');
+        expect(content.joinRequestList).toBeDefined();
+        expect(content.joinRequestList.length).toBe(1);
+        expect(content.joinRequestList[0].id).toBeDefined();
+        expect(content.joinRequestList[0].memberId).toBe(requestingMember.id);
+        expect(content.joinRequestList[0].username).toBe(
+          requestingMember.username,
+        );
+        expect(content.joinRequestList[0].imageUrl).toBe(
+          requestingMember.github_image_url,
+        );
+        resolve();
+      });
+    });
+  }
+
+  function closePage(socket: Socket) {
+    socket.close();
+  }
+});
+
+async function submitJoinRequest(
+  leaderAccessToken: string,
+  projectId: number,
+  requestingAccessToken: string,
+): Promise<request.Response> {
+  const inviteLinkId = await getProjectLinkId(leaderAccessToken, projectId);
+  return request(app.getHttpServer())
+    .post('/api/project/join-request')
+    .set('Authorization', `Bearer ${requestingAccessToken}`)
+    .send({ inviteLinkId });
+}

--- a/backend/test/project/ws-setting-page/ws-notify-project-join-request.e2e-spec.ts
+++ b/backend/test/project/ws-setting-page/ws-notify-project-join-request.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { Socket } from 'socket.io-client';
+import * as request from 'supertest';
+import {
+  app,
+  appInit,
+  connectServer,
+  createMember,
+  createProject,
+  getMemberByAccessToken,
+  getProjectLinkId,
+  listenAppAndSetPortEnv,
+  memberFixture,
+  memberFixture2,
+  projectPayload,
+} from 'test/setup';
+import { Member } from 'src/member/entity/member.entity';
+
+describe('WS Setting', () => {
+  beforeEach(async () => {
+    await app.close();
+    await appInit();
+    await listenAppAndSetPortEnv(app);
+  });
+
+  it('should notify join request in setting page when project join request is submitted', async () => {
+    const { accessToken: leaderAccessToken } = await createMember(
+      memberFixture,
+      app,
+    );
+
+    const { id: projectId } = await createProject(
+      leaderAccessToken,
+      projectPayload,
+      app,
+    );
+    const leaderSocket = await enterSettingPage(projectId, leaderAccessToken);
+
+    const { accessToken: requestingAccessToken } = await createMember(
+      memberFixture2,
+      app,
+    );
+
+    const requestingMember = await getMemberByAccessToken(
+      requestingAccessToken,
+    );
+
+    const expectPromise = expectNotifyJoinRequest(
+      leaderSocket,
+      requestingMember,
+    );
+    const submitPromise = submitJoinRequest(
+      leaderAccessToken,
+      projectId,
+      requestingAccessToken,
+    );
+    await Promise.all([expectPromise, submitPromise]);
+    closePage(leaderSocket);
+  });
+
+  async function enterSettingPage(projectId: number, accessToken: string) {
+    const socket = connectServer(projectId, accessToken);
+    socket.emit('joinSetting');
+
+    await new Promise<void>((resolve) => {
+      socket.once('setting', (data) => {
+        const { action, domain } = data;
+        expect(domain).toBe('setting');
+        expect(action).toBe('init');
+        resolve();
+      });
+    });
+
+    return socket;
+  }
+
+  function closePage(socket: Socket) {
+    socket.close();
+  }
+});
+
+async function submitJoinRequest(
+  leaderAccessToken: string,
+  projectId: number,
+  requestingAccessToken: string,
+): Promise<request.Response> {
+  const inviteLinkId = await getProjectLinkId(leaderAccessToken, projectId);
+  return request(app.getHttpServer())
+    .post('/api/project/join-request')
+    .set('Authorization', `Bearer ${requestingAccessToken}`)
+    .send({ inviteLinkId });
+}
+
+async function expectNotifyJoinRequest(
+  socket: Socket,
+  requestingMember: Member,
+) {
+  return new Promise<void>((resolve) => {
+    socket.on('setting', (data) => {
+      const { action, domain, content } = data;
+      expect(domain).toBe('joinRequest');
+      expect(action).toBe('create');
+      expect(content.joinRequest).toBeDefined();
+      expect(content.joinRequest.id).toBeDefined();
+      expect(content.joinRequest.memberId).toBe(requestingMember.id);
+      expect(content.joinRequest.username).toBe(requestingMember.username);
+      expect(content.joinRequest.imageUrl).toBe(
+        requestingMember.github_image_url,
+      );
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## 🎟️ 태스크

[설정 페이지 API 변경(프로젝트 참여요청한 사람 목록을 설정 페이지 init API에 추가)](https://plastic-toad-cb0.notion.site/API-init-API-24af9b242c8540b4a5841d860633f77e?pvs=74)

## ✅ 작업 내용

- 프로젝트 설정페이지 init API에 프로젝트 참여요청 정보 추가
- 프로젝트 참여요청시 해당 프로젝트의 설정 페이지에 접속한 회원에게 프로젝트 참여요청 알림 구현

## 🖊️ 구체적인 작업

### 프로젝트 설정페이지 init API에 프로젝트 참여요청 정보 추가

- 레포지토리
  - 프로젝트 참여요청 목록 조회 메서드 추가
- 서비스
  - 프로젝트 참여요청 목록 조회 메서드 추가
- 컨트롤러
  - setting page join 메서드의 반환으로 참여요청 목록 데이터 추가
- DTO
  - 설정 페이지 init DTO에 프로젝트 참여요청 정보 추가
- E2E 테스트
  - 프로젝트 참여요청 조회 E2E 테스트 추가

### 프로젝트 참여요청시 해당 프로젝트의 설정 페이지에 접속한 회원에게 프로젝트 참여요청 알림 구현

- 서비스
  - 프로젝트 참여 요청 메서드가 참여요청 엔티티를 반환하도록 수정
- 컨트롤러
  - 프로젝트 참여요청 후 참여알림 메서드를 호출하도록 수정
- 게이트웨이
  - 프로젝트 참여 알림 메서드 구현
- E2E 테스트
  - 프로젝트 참여 요청 시 설정 페이지에 접속한 회원에게 알림이 가는지 확인하는 E2E 테스트 추가